### PR TITLE
test(worktree): canonicalize fixture paths natively

### DIFF
--- a/plugins/codexclaw/components/pabcd-state/test/worktree-guard.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/worktree-guard.test.ts
@@ -34,7 +34,7 @@ interface Rig {
 /** tmp HOME + CODEX_HOME with worktrees/<slot>/<repo>/.git (gitfile, like a real worktree). */
 function makeRig(): Rig {
   // realpath: macOS tmpdir is a /var → /private/var symlink; detection canonicalizes.
-  const home = realpathSync(mkdtempSync(join(tmpdir(), "cxc-wg-home-")));
+  const home = realpathSync.native(mkdtempSync(join(tmpdir(), "cxc-wg-home-")));
   const codexHome = join(home, ".codex");
   const worktreesDir = join(codexHome, "worktrees");
   const slotRoot = join(worktreesDir, "7627");


### PR DESCRIPTION
Closes #2.

## Summary

- align the worktree-guardian fixture with production `canonicalize()` by using `realpathSync.native()`
- preserve the strict path-identity assertions instead of weakening comparisons
- leave runtime behavior and all frontend/UI/UX skills untouched

## Why

The failing Windows CI values were the same directories rendered through two aliases: `RUNNER~1` from the fixture and `runneradmin` from the native canonicalizer. Using the same canonicalization contract on both sides removes the false negative.

## Verification

- branch is one commit ahead of `dev`
- diff is exactly one replacement line (`+1/-1`)
- GitHub Actions CI run 54 completed successfully across the repository's Ubuntu/Windows matrix

Local GitHub checkout was unavailable in the execution sandbox because `github.com` DNS was not resolvable; the repository Actions matrix is the cross-platform proof for this patch.
