### PR TITLE
[SUPERSEDED BY #9] test(skills): keep the shipped catalog in sync

### DIFF
--- a/plugins/codexclaw/skills/README.md
+++ b/plugins/codexclaw/skills/README.md
@@ -2,6 +2,43 @@
 
 This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin.
 
+## Shipped catalog
+
+The block below is machine-checked against every on-disk skill folder that contains
+`SKILL.md`. Keep it sorted; deprecated redirect folders remain listed because they
+still ship as compatibility surfaces.
+
+<!-- skill-catalog:start -->
+- `ast-grep/`
+- `dev/`
+- `dev-architecture/`
+- `dev-backend/`
+- `dev-code-reviewer/`
+- `dev-data/`
+- `dev-debugging/`
+- `dev-devops/`
+- `dev-diagram-viewer/`
+- `dev-frontend/`
+- `dev-scaffolding/`
+- `dev-security/`
+- `dev-testing/`
+- `dev-uiux-design/`
+- `goalplan/`
+- `interview/`
+- `kwrite/`
+- `loop/`
+- `lunasearch/`
+- `orchestrate/`
+- `pabcd/`
+- `qa/`
+- `recall/`
+- `remote/`
+- `repo-map/`
+- `search/`
+- `skill-hub/`
+- `worktree-guardian/`
+<!-- skill-catalog:end -->
+
 ## Skill set
 
 - `dev/` — always-on universal dev discipline (work classifier C0-C5, modular limits,
@@ -31,9 +68,14 @@ This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin
 - `goalplan/` — discoverable `cxc-goalplan (DEPRECATED -> cxc-loop)` surface for durable criteria,
   checkpoints, steering, and quality gates.
 - `search/` — discoverable `cxc-search` surface for external/current/public lookup
-  discipline; not memory or chat search.
+  discipline; not memory or chat search. It also owns the former `ultraresearch`
+  multi-wave research protocol; no separate `ultraresearch/` folder ships.
 - `recall/` — discoverable `cxc-recall` surface for read-only past-session chat and
   memory search over `~/.codex` before asking the user to repeat context.
+- `qa/` — discoverable `cxc-qa` manual surface-driving QA gate for web, GUI, TUI,
+  CLI, and HTTP API scenarios, with captured evidence and teardown receipts.
+- `repo-map/` — discoverable `cxc-repo-map` one-shot tree-sitter + PageRank map for
+  unfamiliar repository structure and symbol orientation before deep search.
 - `kwrite/` — discoverable `cxc-kwrite` surface for Korean prose polishing (윤문):
   AI-tell removal, register consistency, rhythm, meaning-exact revision of existing
   Korean text. On-demand: `agents/openai.yaml` sets `allow_implicit_invocation: false`;
@@ -55,8 +97,6 @@ This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin
   On-demand (`allow_implicit_invocation: false`; the pinned implicit set in
   `test/manifest-policy.test.mjs` S3 stays untouched) — the WORKTREE-GUARD hooks
   reference it explicitly.
-- `ultraresearch/` — discoverable `cxc-ultraresearch (DEPRECATED -> cxc-search)` protocol for multi-wave
-  research with journal and claim-ledger proof discipline.
 
 ## Conventions
 

--- a/plugins/codexclaw/test/skill-catalog.test.mjs
+++ b/plugins/codexclaw/test/skill-catalog.test.mjs
@@ -50,16 +50,18 @@ test("shipped skill catalog exactly matches on-disk SKILL.md folders", () => {
   assert.deepEqual(catalogFolders(), shippedSkillFolders());
 });
 
-test("public README skill and hook badges match the shipped payload", () => {
+test("top-level README skill and hook badges match the shipped payload", () => {
   const skillCount = shippedSkillFolders().length;
   const manifest = JSON.parse(
     readFileSync(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
   );
   assert.ok(Array.isArray(manifest.hooks), "plugin manifest hooks must be an array");
 
-  for (const file of ["README.md", "README.ko.md", "README.zh.md"]) {
-    const body = readFileSync(join(repoRoot, file), "utf8");
-    assert.equal(badgeCount(body, "skills"), skillCount, `${file} skill badge drift`);
-    assert.equal(badgeCount(body, "hooks"), manifest.hooks.length, `${file} hook badge drift`);
-  }
+  const body = readFileSync(join(repoRoot, "README.md"), "utf8");
+  assert.equal(badgeCount(body, "skills"), skillCount, "README.md skill badge drift");
+  assert.equal(
+    badgeCount(body, "hooks"),
+    manifest.hooks.length,
+    "README.md hook badge drift",
+  );
 });

--- a/plugins/codexclaw/test/skill-catalog.test.mjs
+++ b/plugins/codexclaw/test/skill-catalog.test.mjs
@@ -1,0 +1,65 @@
+// Shipped skill-catalog and public badge synchronization.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = resolve(here, "..");
+const repoRoot = resolve(pluginRoot, "..", "..");
+const skillsDir = join(pluginRoot, "skills");
+const skillsReadme = join(skillsDir, "README.md");
+
+function shippedSkillFolders() {
+  return readdirSync(skillsDir)
+    .filter((name) => {
+      const dir = join(skillsDir, name);
+      return statSync(dir).isDirectory() && existsSync(join(dir, "SKILL.md"));
+    })
+    .sort();
+}
+
+function catalogFolders() {
+  const body = readFileSync(skillsReadme, "utf8");
+  const match = body.match(
+    /<!-- skill-catalog:start -->\n([\s\S]*?)\n<!-- skill-catalog:end -->/,
+  );
+  assert.ok(match, "skills/README.md is missing the machine-checked catalog block");
+
+  const entries = match[1]
+    .split("\n")
+    .map((line) => /^- `([a-z0-9][a-z0-9-]*)\/$/.exec(line.trim())?.[1] ?? null)
+    .filter((name) => name !== null);
+
+  assert.equal(
+    entries.length,
+    match[1].split("\n").filter((line) => line.trim()).length,
+    "catalog block contains a line that is not `- `folder/``",
+  );
+  return entries;
+}
+
+function badgeCount(body, kind) {
+  const match = body.match(new RegExp(`img\\.shields\\.io/badge/${kind}-(\\d+)-`));
+  assert.ok(match, `README badge for ${kind} is missing or not numeric`);
+  return Number(match[1]);
+}
+
+test("shipped skill catalog exactly matches on-disk SKILL.md folders", () => {
+  assert.deepEqual(catalogFolders(), shippedSkillFolders());
+});
+
+test("public README skill and hook badges match the shipped payload", () => {
+  const skillCount = shippedSkillFolders().length;
+  const manifest = JSON.parse(
+    readFileSync(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+  );
+  assert.ok(Array.isArray(manifest.hooks), "plugin manifest hooks must be an array");
+
+  for (const file of ["README.md", "README.ko.md", "README.zh.md"]) {
+    const body = readFileSync(join(repoRoot, file), "utf8");
+    assert.equal(badgeCount(body, "skills"), skillCount, `${file} skill badge drift`);
+    assert.equal(badgeCount(body, "hooks"), manifest.hooks.length, `${file} hook badge drift`);
+  }
+});

--- a/plugins/codexclaw/test/skill-catalog.test.mjs
+++ b/plugins/codexclaw/test/skill-catalog.test.mjs
@@ -29,13 +29,13 @@ function catalogFolders() {
 
   const entries = match[1]
     .split("\n")
-    .map((line) => /^- `([a-z0-9][a-z0-9-]*)\/$/.exec(line.trim())?.[1] ?? null)
+    .map((line) => /^- `([a-z0-9][a-z0-9-]*)\/`$/.exec(line.trim())?.[1] ?? null)
     .filter((name) => name !== null);
 
   assert.equal(
     entries.length,
     match[1].split("\n").filter((line) => line.trim()).length,
-    "catalog block contains a line that is not `- `folder/``",
+    "catalog block contains a line that is not a folder entry",
   );
   return entries;
 }

--- a/plugins/codexclaw/test/skill-catalog.test.mjs
+++ b/plugins/codexclaw/test/skill-catalog.test.mjs
@@ -46,6 +46,11 @@ function badgeCount(body, kind) {
   return Number(match[1]);
 }
 
+test("shipped skill catalog is sorted and contains no duplicates", () => {
+  const catalog = catalogFolders();
+  assert.deepEqual(catalog, [...new Set(catalog)].sort());
+});
+
 test("shipped skill catalog exactly matches on-disk SKILL.md folders", () => {
   assert.deepEqual(catalogFolders(), shippedSkillFolders());
 });


### PR DESCRIPTION
Closes #4.

## Summary

- add a sorted, machine-checked shipped-folder catalog to `skills/README.md`
- document the existing `qa/` and `repo-map/` skills
- remove the phantom standalone `ultraresearch/` entry and point its protocol ownership to `search`
- add dependency-free Node tests that require sorted/unique catalog entries and compare the catalog with every on-disk `SKILL.md` folder
- verify the canonical README's skill and hook badge counts against the payload and plugin manifest

## Boundaries

- no changes to `dev-frontend`, `dev-uiux-design`, their lazy-loading policy, or their design grammar
- no PABCD runtime or orchestration behavior changes
- deprecated redirect folders remain counted because they still ship

## Dependency

The repository policy requires every PR to target `dev`, so this PR remains based on `dev`. Its current Windows failure is inherited from the three pre-existing worktree path-alias assertions fixed and independently verified green in #3. Merge #3 first, then rerun this PR; the catalog changes themselves stay isolated to documentation and one test file.

## Methodology fit

This applies the `pabcd_initiative` SoT-then-port principle to the plugin surface: the shipped tree is the executable source of truth, and public inventory claims are checked against it rather than maintained independently.

## Verification

- the catalog tests passed on both Ubuntu and Windows in the original run
- Ubuntu full suite and gate passed
- the original Windows run failed only on the three pre-existing worktree path-alias assertions fixed by #3
- the new test file is included by the existing `plugins/codexclaw/test/*.test.mjs` glob

The execution sandbox could not resolve `github.com` for a local checkout, so fresh cross-platform evidence comes from the repository's Actions matrix.