### PR TITLE
test(skills): keep the shipped catalog in sync

### DIFF
--- a/plugins/codexclaw/skills/README.md
+++ b/plugins/codexclaw/skills/README.md
@@ -25,15 +25,21 @@ This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin
   class-scaled depth. Folds in the structured-development discipline.
 - `interview/` — discoverable `cxc-interview` surface for persistent I-phase
   contradiction discovery, question/answer recording, and readiness gating.
-- `orchestrate/` — discoverable `cxc-orchestrate (DEPRECATED -> cxc-pabcd)` surface for explicit IPABCD
-  phase control from chat plus the live agent-gated `cxc orchestrate` terminal path.
+- `orchestrate/` — deprecated compatibility redirect from `cxc-orchestrate` to
+  `cxc-pabcd`; it has no `agents/openai.yaml` registration of its own.
 - `loop/` — discoverable `cxc-loop` surface for HOTL work-phase continuation.
-- `goalplan/` — discoverable `cxc-goalplan (DEPRECATED -> cxc-loop)` surface for durable criteria,
-  checkpoints, steering, and quality gates.
+- `goalplan/` — deprecated compatibility redirect from `cxc-goalplan` to
+  `cxc-loop`; the `cxc goalplan` CLI remains an alias during migration.
 - `search/` — discoverable `cxc-search` surface for external/current/public lookup
-  discipline; not memory or chat search.
+  discipline; not memory or chat search. Its opt-in Tier 3 protocol owns the former
+  ultraresearch multi-wave journal and claim-ledger discipline.
 - `recall/` — discoverable `cxc-recall` surface for read-only past-session chat and
   memory search over `~/.codex` before asking the user to repeat context.
+- `qa/` — discoverable `cxc-qa` manual surface-driving QA gate for web, GUI, TUI,
+  CLI, and HTTP API changes. It records scenario artifacts and teardown receipts;
+  automated suites remain owned by `dev-testing`.
+- `repo-map/` — on-demand `cxc-repo-map` structure overview using tree-sitter tags
+  and PageRank. It orients unfamiliar codebases before exact `rg` or ast-grep work.
 - `kwrite/` — discoverable `cxc-kwrite` surface for Korean prose polishing (윤문):
   AI-tell removal, register consistency, rhythm, meaning-exact revision of existing
   Korean text. On-demand: `agents/openai.yaml` sets `allow_implicit_invocation: false`;
@@ -45,8 +51,8 @@ This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin
   description match or explicit `$cxc-remote`.
 - `ast-grep/` — discoverable `cxc-ast-grep` surface for optional AST-aware structural
   search/codemods, with `rg` first for ordinary text search.
-- `skill-hub/` — discoverable `cxc-skill-hub (DEPRECATED -> cxc-dev)` catalog for choosing the right
-  on-demand skill.
+- `skill-hub/` — deprecated compatibility redirect from `cxc-skill-hub` to
+  `cxc-dev`; capability routing is canonical in `dev/SKILL.md`.
 - `lunasearch/` — discoverable `cxc-lunasearch` lane for cheap parallel public-web
   discovery that hands proof back to `cxc-search`.
 - `worktree-guardian/` — discoverable `cxc-worktree-guardian` surface for Codex-app
@@ -55,8 +61,6 @@ This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin
   On-demand (`allow_implicit_invocation: false`; the pinned implicit set in
   `test/manifest-policy.test.mjs` S3 stays untouched) — the WORKTREE-GUARD hooks
   reference it explicitly.
-- `ultraresearch/` — discoverable `cxc-ultraresearch (DEPRECATED -> cxc-search)` protocol for multi-wave
-  research with journal and claim-ledger proof discipline.
 
 ## Conventions
 

--- a/plugins/codexclaw/skills/README.md
+++ b/plugins/codexclaw/skills/README.md
@@ -2,6 +2,43 @@
 
 This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin.
 
+## Shipped catalog
+
+The block below is machine-checked against every on-disk skill folder that contains
+`SKILL.md`. Keep it sorted; deprecated redirect folders remain listed because they
+still ship as compatibility surfaces.
+
+<!-- skill-catalog:start -->
+- `ast-grep/`
+- `dev/`
+- `dev-architecture/`
+- `dev-backend/`
+- `dev-code-reviewer/`
+- `dev-data/`
+- `dev-debugging/`
+- `dev-devops/`
+- `dev-diagram-viewer/`
+- `dev-frontend/`
+- `dev-scaffolding/`
+- `dev-security/`
+- `dev-testing/`
+- `dev-uiux-design/`
+- `goalplan/`
+- `interview/`
+- `kwrite/`
+- `loop/`
+- `lunasearch/`
+- `orchestrate/`
+- `pabcd/`
+- `qa/`
+- `recall/`
+- `remote/`
+- `repo-map/`
+- `search/`
+- `skill-hub/`
+- `worktree-guardian/`
+<!-- skill-catalog:end -->
+
 ## Skill set
 
 - `dev/` — always-on universal dev discipline (work classifier C0-C5, modular limits,
@@ -25,21 +62,20 @@ This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin
   class-scaled depth. Folds in the structured-development discipline.
 - `interview/` — discoverable `cxc-interview` surface for persistent I-phase
   contradiction discovery, question/answer recording, and readiness gating.
-- `orchestrate/` — deprecated compatibility redirect from `cxc-orchestrate` to
-  `cxc-pabcd`; it has no `agents/openai.yaml` registration of its own.
+- `orchestrate/` — discoverable `cxc-orchestrate (DEPRECATED -> cxc-pabcd)` surface for explicit IPABCD
+  phase control from chat plus the live agent-gated `cxc orchestrate` terminal path.
 - `loop/` — discoverable `cxc-loop` surface for HOTL work-phase continuation.
-- `goalplan/` — deprecated compatibility redirect from `cxc-goalplan` to
-  `cxc-loop`; the `cxc goalplan` CLI remains an alias during migration.
+- `goalplan/` — discoverable `cxc-goalplan (DEPRECATED -> cxc-loop)` surface for durable criteria,
+  checkpoints, steering, and quality gates.
 - `search/` — discoverable `cxc-search` surface for external/current/public lookup
-  discipline; not memory or chat search. Its opt-in Tier 3 protocol owns the former
-  ultraresearch multi-wave journal and claim-ledger discipline.
+  discipline; not memory or chat search. It also owns the former `ultraresearch`
+  multi-wave research protocol; no separate `ultraresearch/` folder ships.
 - `recall/` — discoverable `cxc-recall` surface for read-only past-session chat and
   memory search over `~/.codex` before asking the user to repeat context.
 - `qa/` — discoverable `cxc-qa` manual surface-driving QA gate for web, GUI, TUI,
-  CLI, and HTTP API changes. It records scenario artifacts and teardown receipts;
-  automated suites remain owned by `dev-testing`.
-- `repo-map/` — on-demand `cxc-repo-map` structure overview using tree-sitter tags
-  and PageRank. It orients unfamiliar codebases before exact `rg` or ast-grep work.
+  CLI, and HTTP API scenarios, with captured evidence and teardown receipts.
+- `repo-map/` — discoverable `cxc-repo-map` one-shot tree-sitter + PageRank map for
+  unfamiliar repository structure and symbol orientation before deep search.
 - `kwrite/` — discoverable `cxc-kwrite` surface for Korean prose polishing (윤문):
   AI-tell removal, register consistency, rhythm, meaning-exact revision of existing
   Korean text. On-demand: `agents/openai.yaml` sets `allow_implicit_invocation: false`;
@@ -51,8 +87,8 @@ This directory holds the Codex `SKILL.md` skills bundled by the codexclaw plugin
   description match or explicit `$cxc-remote`.
 - `ast-grep/` — discoverable `cxc-ast-grep` surface for optional AST-aware structural
   search/codemods, with `rg` first for ordinary text search.
-- `skill-hub/` — deprecated compatibility redirect from `cxc-skill-hub` to
-  `cxc-dev`; capability routing is canonical in `dev/SKILL.md`.
+- `skill-hub/` — discoverable `cxc-skill-hub (DEPRECATED -> cxc-dev)` catalog for choosing the right
+  on-demand skill.
 - `lunasearch/` — discoverable `cxc-lunasearch` lane for cheap parallel public-web
   discovery that hands proof back to `cxc-search`.
 - `worktree-guardian/` — discoverable `cxc-worktree-guardian` surface for Codex-app

--- a/plugins/codexclaw/test/skill-catalog.test.mjs
+++ b/plugins/codexclaw/test/skill-catalog.test.mjs
@@ -1,0 +1,50 @@
+// Keep the human-facing skill catalog aligned with the lazy-loaded on-disk tree.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = resolve(here, "..");
+const skillsDir = join(pluginRoot, "skills");
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function skillDirectories() {
+  return readdirSync(skillsDir)
+    .filter((name) => {
+      const dir = join(skillsDir, name);
+      return statSync(dir).isDirectory() && existsSync(join(dir, "SKILL.md"));
+    })
+    .sort();
+}
+
+test("skill README names every on-disk SKILL.md directory", () => {
+  const readme = readFileSync(join(skillsDir, "README.md"), "utf8");
+  const missing = skillDirectories().filter((name) => {
+    const token = new RegExp(`\\\`${escapeRegex(name)}(?:/)?\\\``);
+    return !token.test(readme);
+  });
+
+  assert.deepEqual(
+    missing,
+    [],
+    `skills/README.md omits skill directories: ${missing.join(", ")}`,
+  );
+});
+
+test("skill README has no bullet for a missing skill directory", () => {
+  const readme = readFileSync(join(skillsDir, "README.md"), "utf8");
+  const actual = new Set(skillDirectories());
+  const listed = [...readme.matchAll(/^- `([a-z0-9-]+)\/`/gm)].map((match) => match[1]);
+  const phantom = listed.filter((name) => !actual.has(name));
+
+  assert.deepEqual(
+    phantom,
+    [],
+    `skills/README.md names missing skill directories: ${phantom.join(", ")}`,
+  );
+});

--- a/plugins/codexclaw/test/skill-catalog.test.mjs
+++ b/plugins/codexclaw/test/skill-catalog.test.mjs
@@ -1,4 +1,4 @@
-// Keep the human-facing skill catalog aligned with the lazy-loaded on-disk tree.
+// Shipped skill-catalog and public badge synchronization.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
@@ -7,13 +7,11 @@ import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pluginRoot = resolve(here, "..");
+const repoRoot = resolve(pluginRoot, "..", "..");
 const skillsDir = join(pluginRoot, "skills");
+const skillsReadme = join(skillsDir, "README.md");
 
-function escapeRegex(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function skillDirectories() {
+function shippedSkillFolders() {
   return readdirSync(skillsDir)
     .filter((name) => {
       const dir = join(skillsDir, name);
@@ -22,29 +20,53 @@ function skillDirectories() {
     .sort();
 }
 
-test("skill README names every on-disk SKILL.md directory", () => {
-  const readme = readFileSync(join(skillsDir, "README.md"), "utf8");
-  const missing = skillDirectories().filter((name) => {
-    const token = new RegExp(`\\\`${escapeRegex(name)}(?:/)?\\\``);
-    return !token.test(readme);
-  });
-
-  assert.deepEqual(
-    missing,
-    [],
-    `skills/README.md omits skill directories: ${missing.join(", ")}`,
+function catalogFolders() {
+  const body = readFileSync(skillsReadme, "utf8");
+  const match = body.match(
+    /<!-- skill-catalog:start -->\n([\s\S]*?)\n<!-- skill-catalog:end -->/,
   );
+  assert.ok(match, "skills/README.md is missing the machine-checked catalog block");
+
+  const entries = match[1]
+    .split("\n")
+    .map((line) => /^- `([a-z0-9][a-z0-9-]*)\/`$/.exec(line.trim())?.[1] ?? null)
+    .filter((name) => name !== null);
+
+  assert.equal(
+    entries.length,
+    match[1].split("\n").filter((line) => line.trim()).length,
+    "catalog block contains a line that is not a folder entry",
+  );
+  return entries;
+}
+
+function badgeCount(body, kind) {
+  const match = body.match(new RegExp(`img\\.shields\\.io/badge/${kind}-(\\d+)-`));
+  assert.ok(match, `README badge for ${kind} is missing or not numeric`);
+  return Number(match[1]);
+}
+
+test("shipped skill catalog is sorted and contains no duplicates", () => {
+  const catalog = catalogFolders();
+  assert.deepEqual(catalog, [...new Set(catalog)].sort());
 });
 
-test("skill README has no bullet for a missing skill directory", () => {
-  const readme = readFileSync(join(skillsDir, "README.md"), "utf8");
-  const actual = new Set(skillDirectories());
-  const listed = [...readme.matchAll(/^- `([a-z0-9-]+)\/`/gm)].map((match) => match[1]);
-  const phantom = listed.filter((name) => !actual.has(name));
+test("shipped skill catalog exactly matches on-disk SKILL.md folders", () => {
+  assert.deepEqual(catalogFolders(), shippedSkillFolders());
+});
 
-  assert.deepEqual(
-    phantom,
-    [],
-    `skills/README.md names missing skill directories: ${phantom.join(", ")}`,
+test("top-level README skill and hook badges match the shipped payload", () => {
+  const skillCount = shippedSkillFolders().length;
+  const manifest = JSON.parse(
+    readFileSync(join(pluginRoot, ".codex-plugin", "plugin.json"), "utf8"),
+  );
+  assert.ok(Array.isArray(manifest.hooks), "plugin manifest hooks must be an array");
+
+  const body = readFileSync(join(repoRoot, "README.md"), "utf8");
+  assert.equal(badgeCount(body, "skills"), skillCount, "README.md skill badge drift");
+  assert.equal(
+    badgeCount(body, "hooks"),
+    manifest.hooks.length,
+    "README.md hook badge drift",
   );
 });


### PR DESCRIPTION
Closes #4.

## Summary

- add a sorted, machine-checked shipped-folder catalog to `skills/README.md`
- document the existing `qa/` and `repo-map/` skills
- remove the phantom standalone `ultraresearch/` entry and point its protocol ownership to `search`
- add a dependency-free Node test that compares the catalog with every on-disk `SKILL.md` folder
- verify the canonical README's skill and hook badge counts against the payload and plugin manifest

## Architecture decision

This does **not** reduce the skill family or change loading policy. The 13-skill dev architecture, progressive disclosure, on-demand references, pinned implicit set, and the existing frontend/UIUX personal-harness behavior remain unchanged. The contract is inventory accuracy, not skill-count minimization.

## Supersession

This is the clean `dev`-based replacement for #5, whose head was accidentally stacked on the Windows fixture branch. The catalog implementation and stronger badge checks have been folded here without including the independent #3 diff.

## Verification

GitHub Actions run 59 provides the current evidence:

- Ubuntu full `npm test` and `gate.mjs`: **PASS**
- Windows: all three new catalog tests **PASS**
  - sorted/unique shipped catalog
  - exact catalog ↔ on-disk `SKILL.md` equality
  - canonical README skill/hook badge agreement
- Windows overall job: **FAIL only on the three pre-existing worktree path-alias assertions** fixed by #3

Merge #3 first, then update/re-run this PR against the new `dev` head. Keep this PR draft until the resulting Ubuntu/Windows matrix is green.

No runtime, hook, `agents/openai.yaml`, UI/UX, or frontend skill file changes are included. Local checkout was unavailable because the execution sandbox cannot resolve `github.com`; repository Actions are the authoritative cross-platform proof.
