### PR TITLE
docs(roadmap): codify the MLB 1.0 native-thin harness contract

### DIFF
--- a/docs/native-thin-harness.md
+++ b/docs/native-thin-harness.md
@@ -1,0 +1,114 @@
+# Native-thin harness contract
+
+## Position
+
+codexclaw is a discipline and evidence layer attached directly to OpenAI Codex. It is not an alternative coding-agent runtime.
+
+Codex remains responsible for model execution, reasoning, session/context transport, shell and sandbox behavior, permissions, base editing, browser/computer-use capabilities, and native subagent scheduling. codexclaw is responsible for risk-scaled development method, surface-specific knowledge routing, PABCD state and evidence, dispatch eligibility, completion judgment, and thin adaptation to the capabilities exposed by the active Codex version.
+
+This boundary is a product constraint. A feature is not automatically desirable because another harness ships it.
+
+## Ownership matrix
+
+| codexclaw owns | Codex owns |
+| --- | --- |
+| C0–C5 work/risk classification | model execution and reasoning |
+| surface router/reference selection | shell, sandbox, permissions |
+| PABCD FSM, attestation, goalplan | base edits/apply-patch behavior |
+| HITL/HOTL and completion gates | browser/computer-use runtime |
+| dispatch eligibility and evidence packet | native subagent scheduler/processes |
+| capability/version adaptation | provider/model runtime |
+| doctor, migration, recovery receipts | session/context transport |
+
+## Progressive-disclosure contract
+
+Four layers must remain distinct:
+
+1. installed skill directories
+2. implicit-visible metadata and trigger surface
+3. router `SKILL.md` bodies actually selected for a task
+4. references and subagent skill attachments actually selected
+
+Installed skill count is not a context-cost proxy. References are never bulk-preloaded. A subagent receives only the skills needed for its bounded task. C0/C1 tasks should usually read no specialist reference; high-risk work must not miss the relevant router merely to minimize tokens.
+
+`dev-frontend` and `dev-uiux-design` are maintainer-owned personal harnesses with established users. Their design grammar, implicit visibility, and lazy-loaded references are not normalization targets. They may be measured for activation economy, but their semantic direction remains maintainer-owned.
+
+## PABCD boundary
+
+`pabcd_initiative` is the methodology/provenance source of truth. codexclaw is the live Codex-specific adapter.
+
+The methodology is capability-responsive:
+
+- model judgment chooses work class, architecture, test strategy, and whether a task packet is dispatchable
+- mechanics enforce only invariants that must not depend on probabilistic obedience, such as state transitions, attestation, Stop continuation, source identity, and evidence-backed completion
+- C0/C1 retain fast paths; higher-risk work earns deeper process
+
+## Dispatch boundary
+
+Dispatch is decided by:
+
+- **specifiability:** inputs, outputs, and decision boundary can be stated completely
+- **verifiability:** the main agent can inspect anchors, metrics, receipts, or reproduction commands
+- **judgment ownership:** collapse/crux judgment remains with the main agent
+
+Complex work may be dispatched when the packet is specifiable and verifiable. Simple-looking work stays with the main agent when its decision boundary is unclear. Two distinct agents failing the same unchanged packet retires the packet; the main agent reclaims the slice.
+
+Use native Codex spawn surfaces. Permanent roles remain explorer, reviewer, and executor; surface specialization is attached as skills rather than multiplied into a role catalog.
+
+## Extension admission contract
+
+A new component, hook, role, MCP, daemon, or always-on context block must declare:
+
+```yaml
+native_gap: why current Codex capabilities are insufficient
+activation: when the feature is actually selected
+hot_path: whether it runs per session, turn, tool, stop, or only on demand
+cost_budget: token, process, filesystem, and p50/p95 budget
+failure_mode: fail-open or fail-closed, with rationale
+disable: exact one-command disable/remove path
+sunset_when: native capability that causes adapter removal
+evidence: eval or regression proving outcome improvement
+```
+
+Review rules:
+
+- a new hook is for a machine-enforced invariant, not probabilistic judgment
+- a new agent role is rejected unless the three stable roles plus attached skills cannot express the packet
+- a new MCP must close a real native capability gap and remain dormant when unused
+- a required daemon or proxy is presumed out of scope
+- hidden provider/tool/model fallback is prohibited
+- disabled or irrelevant optional features should have effectively zero context cost
+
+## Hot-path and failure requirements
+
+Hook count alone is not a performance metric. Measure session-once and hot-path hooks separately, including invocation frequency, no-op rate, process creation, filesystem IO, and platform-specific p50/p95. Security and PABCD invariants may intentionally cost more, but they still require an explicit budget and regression fixture.
+
+Failure behavior must be explainable. Unsupported capability, stale state, or malformed payloads must not silently invent a provider, tool, model, or success result.
+
+## Deliberate non-goals
+
+codexclaw does not seek to own:
+
+- a general edit protocol or hash-anchored editor
+- an LSP/DAP runtime
+- a tmux/team scheduler
+- a default active MCP fleet
+- a required daemon, proxy, or provider router
+- a broad model-provider fallback engine
+- a large permanent agent-role catalog
+- default opt-out telemetry
+
+Operational discipline from broader systems is welcome: packed-install smoke tests, doctor/recovery evidence, typed subagent receipts, exact-candidate release proof, and controlled benchmarks. Their replacement-runtime machinery is not.
+
+## Change-review checklist
+
+Before merging an architectural feature:
+
+- [ ] native gap and sunset condition are documented
+- [ ] installed, visible, activated, and reference-loaded costs are not conflated
+- [ ] ordinary irrelevant sessions remain dormant
+- [ ] failure mode is explicit and tested
+- [ ] platform-specific timing/regression budget exists for hot paths
+- [ ] no frontend/UIUX semantic normalization is hidden in the change
+- [ ] no PABCD methodology is copied blindly without recording the Codex adapter delta
+- [ ] exact-head verification and rollback/disable path are recorded

--- a/docs/roadmap-mlb-1.0.md
+++ b/docs/roadmap-mlb-1.0.md
@@ -1,0 +1,105 @@
+# MLB 1.0 roadmap: 80-grade Codex-native thin harness
+
+Parent roadmap: #22
+
+## Scorecard
+
+The 20–80 scale treats 50 as a major-league average, 60 as a clear plus tool, 70 as elite, and 80 as category-defining. The resolved baseline is an architectural projection, not a claim that every benchmark has already been run.
+
+| Tool | Resolved baseline | MLB 1.0 target |
+| --- | ---: | ---: |
+| Codex-native fit | 80 | **80** |
+| Context/runtime economy | 75 | **80** |
+| Risk-scaled methodology | 75 | **80** |
+| Evidence completion | 75 | **80** |
+| Delegation contract | 70 | **75** |
+| Tool/code intelligence | 50 | **55** |
+| Install/update/release | 65 | **75** |
+| Cross-platform/trust | 65 | **70** |
+| Eval/observability | 65 | **80** |
+| Field maturity | 35 | **55–60** |
+
+Tool/code intelligence is deliberately not targeted at 80. Codex should own and improve the editor, shell, browser, computer-use, and scheduler. codexclaw should improve automatically as those native capabilities improve.
+
+## Existing tracks
+
+- #7 — capability resolver
+- #8 — PABCD port provenance
+- #10 — release metadata synchronization
+- #11 — activation traces
+- #12 — secret-safe token ingress
+- #13 — hook lifecycle benchmark
+- lidge-jun/pabcd_initiative#1 — host-neutral activation-economy schema
+
+## Execution issues
+
+- #14 — architecture contract
+- #15 — operations and lifecycle evidence
+- #16 — stable/canary capability lock
+- #17 — typed native dispatch contract
+- #18 — Rule Impact Ledger
+- #19 — reference league and comparative benchmark
+- #20 — sanitized scouting bundle
+- #21 — exact-head MLB 1.0 release gate
+
+## Phase 0 — Spring Training: freeze and measure
+
+Land the opt-in activation and hook baselines before changing router sizes, implicit policy, or hook topology.
+
+Measure:
+
+- expected/observed C0–C5 class
+- visible skills, activated router bodies, selected references
+- subagent skill attachments and duplication
+- hook invocation/no-op/process/IO/p50/p95
+- verifier result, rework, tokens, and wall time where exposed
+- rule violations caught because knowledge was activated
+
+Ordinary tracing-disabled sessions must gain no context or artifact.
+
+## Phase 1 — Triple-A defense: operations without a second runtime
+
+Make `cxc doctor` the single typed source for plugin/capability/state health. Add fresh install, N-1 upgrade, hook reapproval, schema migration, interrupted recovery, uninstall, re-install, offline, and corrupt-state receipts across supported surfaces.
+
+Do not require a global CLI, daemon, proxy, tmux runtime, or default MCP fleet.
+
+## Phase 2 — Rookie season: small capability lock
+
+After #7 centralizes runtime identities, pin only the Codex surfaces codexclaw actually consumes: plugin/hook payload versions, native spawn fields, goals, discovery/source-open capabilities, and relevant model-catalog capabilities. Stable and canary fixtures are separate. Unsupported states fail explicitly; no hidden fallback.
+
+## Phase 3 — Pitch calling: typed dispatch over native spawn
+
+Add a bounded DispatchPacket and DispatchReceipt that express specifiability, verifiability, skill attachments, worktree policy, source identity, and verifier evidence. Keep explorer/reviewer/executor. Keep final judgment with the main agent. Retire a packet after two independent failures on the unchanged contract.
+
+## Phase 4 — Batting average: measure rule value
+
+Join activation cost to verifier outcome. Keep frequently useful rules in router cores, preserve rare high-risk rules as targeted references, move frequently neutral rules deeper, and consolidate duplicate ownership. File size alone is not a deletion criterion.
+
+## Phase 5 — 162-game season: field maturity
+
+Pin representative repository snapshots and run controlled tasks across bare Codex, codexclaw, LazyCodex, and OMX with the same model, effort, sandbox, budget, and verifier where possible. Run stochastic cases at least three times. Add an explicitly generated sanitized support bundle; do not add default telemetry.
+
+## Phase 6 — All-Star gate: exact candidate release
+
+Promote MLB 1.0 only when one candidate manifest links:
+
+- activation and rule-impact reports
+- platform-specific hook performance baseline
+- install/upgrade/recovery receipts
+- capability-lock report
+- typed dispatch verification
+- reference-league results
+- secret-safe/scouting-bundle tests
+- exact supported-platform CI for the candidate SHA
+
+## Feature admission
+
+Every new feature must document a native gap, activation point, hot-path cost, failure mode, disable path, sunset condition, and outcome evidence. New hooks are for invariants, not judgment. New roles, default MCPs, daemons, or duplicated native tools require exceptional evidence.
+
+## Protected boundaries
+
+- preserve the 13-skill dev family and on-demand references
+- preserve C0/C1 fast paths and C4/C5 escalation
+- preserve maintainer ownership of frontend/UIUX design grammar and loading policy
+- preserve `pabcd_initiative` as methodology/provenance SoT and codexclaw as the Codex adapter SoT
+- preserve the principle: **own judgment and evidence, not replacement runtime machinery**


### PR DESCRIPTION
Closes #14.

## Summary

- document codexclaw's permanent native-thin ownership boundary
- add the MLB 1.0 20–80 target scorecard and phased execution roadmap
- define the admission/sunset contract for hooks, roles, MCPs, daemons, and always-on context
- link the existing activation, hook, capability, provenance, security, and release-metadata tracks

## Architecture decision

Codex remains the runtime. codexclaw owns risk-scaled development discipline, PABCD state/evidence, surface knowledge routing, dispatch eligibility, completion judgment, and thin capability adaptation.

This PR deliberately does **not** add a custom editor, LSP/DAP runtime, scheduler, default MCP fleet, daemon, provider fallback, or new permanent agent role.

## Protected boundaries

- no `dev-frontend` or `dev-uiux-design` content, reference, implicit-policy, or design-grammar changes
- no PABCD FSM, hook, goalplan, attestation, or Stop behavior change
- no runtime, manifest, CLI, GUI, state, or packaging behavior change
- progressive disclosure and the 13-skill dev family remain unchanged

## Verification

Docs-only change. Verify links and Markdown rendering; normal test behavior should be byte-for-byte unaffected.
