### PR TITLE
[WRONG BRANCH] release(0.2.7): win/linux campaign version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,3 +356,31 @@ First public release. 25 skills, 12 hooks, 801 tests.
 [0.2.0]: https://github.com/lidge-jun/codexclaw/compare/v0.2.0-beta.1...v0.2.0
 [0.2.0-beta.1]: https://github.com/lidge-jun/codexclaw/compare/v0.1.0...v0.2.0-beta.1
 [0.1.0]: https://github.com/lidge-jun/codexclaw/releases/tag/v0.1.0
+# Changelog
+
+## 0.2.7 (2026-08-22)
+
+Windows/Linux cross-platform optimization campaign (11 PABCD cycles,
+devlog/_plan/260821_win-linux-optimization). Closes #29, #30, #31.
+
+- attest gates batch every missing field into one rejection; new --attest-file
+  for PowerShell (BOM-tolerant); reviewer agent_type wording corrected (#31)
+- plan init no longer doubles a supplied YYMMDD prefix and preserves underscores;
+  decade docs use 3-digit numbering (#30)
+- loop criteria are registrable: init --criteria persists, add-criterion and
+  add-work-phase verbs steer additively; goalplan loader names the exact failing
+  field instead of "no plan found" (#29)
+- scouting bundle: homedir-safe redaction, case- and 8.3-aware path matching
+  (P0 security fixes); doctor version regex repaired
+- win-exec command ladder across bin, cxc-ops, skill-search, messenger-bridge:
+  PATHEXT x PATH resolution, ComSpec route for .cmd/.bat, Store-stub 9009
+  handling, venv Scripts\python.exe on win32, taskkill tree kill
+- filesystem-based WSL residency detection (no wsl.exe subprocess) surfaced in
+  doctor check 9 and the steering lock tier note
+- CRLF-tolerant parsing via splitLines copies in six packages; hook-bench runs
+  from a real tmpdir; .gitattributes eol policy
+- worktree guard covers Remove-Item/ri/del/erase/rd with rmdir semantics
+  preserved; UNC errors normalize to one signature
+- hooks: lazy-load terminal-only verb modules (-22% win32 overhead, measured)
+- CI: platform-smoke real-subprocess verifier, WSL lane (drvfs + ext4),
+  autocrlf=true matrix cell, receipts upload

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C727_passing-brightgreen" alt="1,727 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C900_passing-brightgreen" alt="1,900 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C727_passing-brightgreen" alt="1,727 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C900_passing-brightgreen" alt="1,900 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C727_passing-brightgreen" alt="1,727 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C900_passing-brightgreen" alt="1,900 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.6+codex.20260818121334",
+  "version": "0.2.7+codex.20260818121334",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI — doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge — cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.6+codex.20260818121334",
-    "packageVersion": "0.2.6"
+    "manifestVersion": "0.2.7+codex.20260818121334",
+    "packageVersion": "0.2.7"
   },
   "skills": [
     {
@@ -257,43 +257,43 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasTests": true
     },
     {

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -299,7 +299,7 @@
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasTests": true
     }
   ]


### PR DESCRIPTION
Version surface bump to 0.2.7 + regenerated inventory/badges. Follows #34.