### PR TITLE
[WRONG BRANCH] test(telegram): widen photo settle race to 15s

### DIFF
--- a/plugins/codexclaw/components/messenger-bridge/test/telegram-adapter.test.ts
+++ b/plugins/codexclaw/components/messenger-bridge/test/telegram-adapter.test.ts
@@ -153,8 +153,9 @@ test("allowlisted message drives the agent and sends a reply", async () => {
     });
     await adapter.start();
     // The download + agent round-trip races the fixed 30ms settle on loaded
-    // runners; poll for the observable outcome instead of sleeping.
-    const deadline = Date.now() + 5000;
+    // runners; poll for the observable outcome instead of sleeping. 15s covers
+    // the slowest observed CI cell (windows CRLF under load).
+    const deadline = Date.now() + 15000;
     while (seen.length === 0 && Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 25));
     }


### PR DESCRIPTION
CI flake fix observed on loaded windows cells.