### PR TITLE
[WRONG BRANCH] release(0.2.7): promote dev to main - Windows closeout

### DIFF
--- a/.github/workflows/enforce-pr-target.yml
+++ b/.github/workflows/enforce-pr-target.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           script: |
             const EXPECTED_BASE = "dev";
+            // dev -> main is the release promotion path and is exempt.
+            const PROMOTION_BASE = "main";
+            const PROMOTION_HEAD = "dev";
             const TITLE_PREFIX = "[WRONG BRANCH] ";
             const COMMENT_MARKER = "<!-- wrong-branch-enforcer -->";
             const STATE_PATTERN =
@@ -52,7 +55,7 @@ jobs:
               }
             );
 
-            const botComment = comments.find(
+            let botComment = comments.find(
               comment =>
                 comment.user?.login === "github-actions[bot]" &&
                 comment.body?.includes(COMMENT_MARKER)
@@ -100,60 +103,99 @@ jobs:
                 return;
               }
 
-              await github.rest.issues.createComment({
+              // A created comment becomes the handle for every later write in this
+              // run. Without the reassignment a second upsert would post a duplicate,
+              // and the NEXT run would find the stale first comment.
+              const { data: created } = await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number: pull_number,
                 body
               });
+
+              botComment = created;
             }
 
             async function convertToDraft() {
-              await github.graphql(
-                `
-                  mutation($pullRequestId: ID!) {
-                    convertPullRequestToDraft(
-                      input: {
-                        pullRequestId: $pullRequestId
-                      }
-                    ) {
-                      pullRequest {
-                        id
-                        isDraft
+              // The default GITHUB_TOKEN cannot draft a PR in every repo
+              // configuration. The title prefix and the comment are the
+              // enforcement that matters, so a FORBIDDEN draft attempt must not
+              // fail the whole check.
+              try {
+                await github.graphql(
+                  `
+                    mutation($pullRequestId: ID!) {
+                      convertPullRequestToDraft(
+                        input: {
+                          pullRequestId: $pullRequestId
+                        }
+                      ) {
+                        pullRequest {
+                          id
+                          isDraft
+                        }
                       }
                     }
+                  `,
+                  {
+                    pullRequestId: pr.node_id
                   }
-                `,
-                {
-                  pullRequestId: pr.node_id
-                }
-              );
+                );
+
+                return true;
+              } catch (error) {
+                core.warning(
+                  `Could not convert the pull request to a draft: ${error.message}`
+                );
+
+                return false;
+              }
             }
 
             async function markReadyForReview() {
-              await github.graphql(
-                `
-                  mutation($pullRequestId: ID!) {
-                    markPullRequestReadyForReview(
-                      input: {
-                        pullRequestId: $pullRequestId
-                      }
-                    ) {
-                      pullRequest {
-                        id
-                        isDraft
+              try {
+                await github.graphql(
+                  `
+                    mutation($pullRequestId: ID!) {
+                      markPullRequestReadyForReview(
+                        input: {
+                          pullRequestId: $pullRequestId
+                        }
+                      ) {
+                        pullRequest {
+                          id
+                          isDraft
+                        }
                       }
                     }
+                  `,
+                  {
+                    pullRequestId: pr.node_id
                   }
-                `,
-                {
-                  pullRequestId: pr.node_id
-                }
-              );
+                );
+
+                return true;
+              } catch (error) {
+                core.warning(
+                  `Could not mark the pull request ready for review: ${error.message}`
+                );
+
+                return false;
+              }
             }
 
             const storedState = parseState(botComment?.body);
-            const wrongBase = pr.base.ref !== EXPECTED_BASE;
+            const isPromotion =
+              pr.base.ref === PROMOTION_BASE &&
+              pr.head.ref === PROMOTION_HEAD &&
+              pr.head.repo?.full_name === `${owner}/${repo}`;
+            const wrongBase = pr.base.ref !== EXPECTED_BASE && !isPromotion;
+
+            if (isPromotion) {
+              core.info(
+                `${PROMOTION_HEAD} -> ${PROMOTION_BASE} is the release promotion path; skipping enforcement.`
+              );
+            }
 
             // Wrong branch:
             // - add the title prefix
@@ -178,14 +220,8 @@ jobs:
                 state.titlePrefixedByBot = true;
               }
 
-              const draftExplanation = state.autoDraftedByBot
-                ? "This pull request is being kept as a draft automatically. Once the target branch is corrected, it will be marked ready for review again."
-                : "This pull request was already a draft. Its draft status will be preserved after the target branch is corrected.";
-
-              // Store the restoration state before changing the PR, allowing
-              // a rerun to recover if an API request fails partway through.
-              await upsertComment(
-                [
+              function wrongBaseComment(draftExplanation) {
+                return [
                   COMMENT_MARKER,
                   stateMarker(state),
                   "",
@@ -198,8 +234,16 @@ jobs:
                   `@${pr.user.login} Please retarget this PR to the \`dev\` branch. All contributions go to \`dev\` first, and \`main\` receives only release promotions. See the [Contributing section](https://github.com/lidge-jun/codexclaw#contributing) for details. Thanks! 🙏`,
                   "",
                   draftExplanation
-                ].join("\n")
-              );
+                ].join("\n");
+              }
+
+              const draftExplanation = state.autoDraftedByBot
+                ? "This pull request is being kept as a draft automatically. Once the target branch is corrected, it will be marked ready for review again."
+                : "This pull request was already a draft. Its draft status will be preserved after the target branch is corrected.";
+
+              // Store the restoration state before changing the PR, allowing
+              // a rerun to recover if an API request fails partway through.
+              await upsertComment(wrongBaseComment(draftExplanation));
 
               if (!pr.title.startsWith(TITLE_PREFIX)) {
                 await github.rest.pulls.update({
@@ -211,7 +255,22 @@ jobs:
               }
 
               if (!pr.draft) {
-                await convertToDraft();
+                const drafted = await convertToDraft();
+
+                // The stored state is written before the mutation so a rerun can
+                // recover. If drafting was refused, correct it so a later run does
+                // not try to "restore" a draft status this workflow never set.
+                // upsertComment now holds the handle of the comment it just created,
+                // so this rewrites that comment instead of posting a duplicate.
+                if (!drafted) {
+                  state.autoDraftedByBot = false;
+
+                  await upsertComment(
+                    wrongBaseComment(
+                      "Drafting was not permitted for this token, so the draft status was left unchanged."
+                    )
+                  );
+                }
               }
 
               return;
@@ -242,17 +301,21 @@ jobs:
 
             // Mark the PR ready only if this workflow originally converted it
             // to draft. Intentionally drafted PRs remain drafts.
+            let restoredDraft = null;
+
             if (
               storedState.autoDraftedByBot &&
               pr.draft
             ) {
-              await markReadyForReview();
+              restoredDraft = await markReadyForReview();
             }
 
+            // A refused restoration must not be reported as done, and the state
+            // must stay active so a later rerun can retry it.
             const completedState = {
               version: 1,
-              active: false,
-              autoDraftedByBot: false,
+              active: restoredDraft === false,
+              autoDraftedByBot: restoredDraft === false,
               titlePrefixedByBot: false
             };
 
@@ -260,9 +323,12 @@ jobs:
               ? `The ${inlineCode(TITLE_PREFIX.trim())} title prefix has been removed.`
               : "The title was left unchanged.";
 
-            const draftResult = storedState.autoDraftedByBot
-              ? "The pull request has been marked ready for review again."
-              : "Its existing draft status has been preserved.";
+            const draftResult =
+              restoredDraft === true
+                ? "The pull request has been marked ready for review again."
+                : restoredDraft === false
+                  ? "This workflow could not mark the pull request ready for review; please undraft it manually."
+                  : "Its existing draft status has been preserved.";
 
             await upsertComment(
               [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ All notable changes to codexclaw are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **`cxc hooks retrust` could not verify its own write on Windows (#33).** The
+  post-write `codex features list` check spawned a bare `codex` with no shell,
+  which fails two different ways on a Codex-desktop host: the first PATH match is
+  the Store-packaged `WindowsApps\...\codex.EXE`, which is readable, is not a
+  reparse point, and still fails `CreateProcess` with `EPERM`; and the npm shim
+  beside it is `codex.CMD`, which Node refuses to spawn shell-less after the
+  CVE-2024-27980 hardening (`EINVAL`). Verification failed for reasons that had
+  nothing to do with the config, so a correct write was rolled back every time.
+
+  The command is now resolved before it is spawned: an explicit `CODEX_BIN` wins,
+  then a PATH/PATHEXT walk that skips `WindowsApps` entries, then a `cmd.exe`
+  hop with caret-escaped arguments (the only route that starts a Store-aliased
+  `codex`). The injected runner seam is unchanged.
+
+- **`cxc doctor` now names the recovery command for untrusted hooks (#33).** On a
+  fresh Windows install no `[hooks.state.*]` entry exists yet, so every hook read
+  `actual=(none)` with no next step printed. Writing those entries is the host
+  Codex binary's job, performed when the user approves the plugin's hooks;
+  codexclaw does not forge them, because that would silently bypass the trust
+  prompt. Doctor now distinguishes never-trusted from drifted and prints the exact
+  `cxc hooks retrust` invocation for each case, including `--bootstrap-ok` only
+  when the entries genuinely do not exist yet.
+
+- **The GUI dashboard could resolve your entire home directory as the project
+  root.** `resolveProjectRoot` accepted any ancestor holding a `.codexclaw/`
+  directory, and `~/.codexclaw` is codexclaw's own global store (recall index,
+  skill cache). Any start directory outside a repository therefore walked to the
+  filesystem root and answered with `~`, so dashboard reads and writes landed in
+  the global store. The home directory is now excluded from that marker, compared
+  case-insensitively on Windows where `c:\users\me` and `C:\Users\me` are the
+  same directory.
+
+- **Symlink-refusal tests could not run on a stock Windows checkout (#32).**
+  Creating a symlink needs Developer Mode or elevation, so the tests died on the
+  `symlinkSync` that BUILT their hostile input, never reaching the guard under
+  test. Several sibling suites hid the same problem behind a bare
+  `if (process.platform === "win32") return`, which passes the whole case while
+  asserting nothing. A shared capability probe now gates only the link-creating
+  half, and directory cases use junctions - which need no elevation and still
+  report `isSymbolicLink()` - so most of these guards are genuinely exercised on
+  Windows now. Only the three cases that require a link to a FILE report a skip,
+  with the reason stated.
+
+- **The `enforce-target` check blocked the release path it documents.** Every PR
+  had to target `dev`, with no exemption for the `dev` -> `main` promotion, so the
+  release PR was prefixed `[WRONG BRANCH]` and told to retarget itself to the
+  branch it was being promoted from. Same-repository promotions are now exempt;
+  a fork branch merely named `dev` is not. The check also failed outright when
+  `convertPullRequestToDraft` came back `FORBIDDEN`, which the default token is
+  not always granted - a refused draft is now a warning, and a refused
+  ready-for-review restoration is reported instead of being announced as success.
+
+- **A photo-only Telegram turn raced a fixed sleep in CI.** The test waited 30ms
+  for a getFile + download + agent round-trip, which is enough on an idle machine
+  and not on a loaded Windows runner, so the `windows-latest` cell failed
+  intermittently on an assertion about work that simply had not finished. It now
+  polls for the observable outcome and fails with a named cause on timeout.
+
 ## [0.2.6] — 2026-08-18
 
 ### Changed

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C900_passing-brightgreen" alt="1,901 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C901_passing-brightgreen" alt="1,901 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C900_passing-brightgreen" alt="1,901 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C901_passing-brightgreen" alt="1,901 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C900_passing-brightgreen" alt="1,901 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C901_passing-brightgreen" alt="1,901 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260822_win_closeout/000_plan.md
+++ b/devlog/_plan/260822_win_closeout/000_plan.md
@@ -1,0 +1,32 @@
+# 260822 win closeout - campaign closeout roadmap
+
+The 11-cycle win/linux campaign (devlog/_plan/260821_win-linux-optimization) closed its
+goalplan, but it left the repository in a state that cannot ship:
+
+- The `test (windows-latest, false)` CI cell is RED on the newest dev commit.
+- The `enforce-target` check fails on every PR and blocks the release promotion path.
+- GitHub issues #32 and #33 are open, both Windows-only defects filed during the campaign.
+- No v0.2.7 release exists. `origin/main` and `origin/dev` both carry version 0.2.7 in
+  the tree, but the newest tagged release is v0.2.6, so nothing shipped.
+
+This unit closes all four before cutting the release.
+
+## Work phases
+
+| id | doc | scope |
+|----|-----|-------|
+| wp01-win-ci-red | 010 | telegram photo-download test race on windows runners |
+| wp02-symlink-tests | 020 | issue #32: goalplan symlink guards vs unprivileged Windows |
+| wp03-hook-trust | 030 | issue #33: hook trust registration + retrust spawn on win32 |
+| wp04-enforce-target | 040 | enforce-pr-target workflow: promotion exemption + 403 tolerance |
+| wp05-dual-verify | 050 | native Windows + WSL Ubuntu full suites |
+| wp06-release | 060 | push dev, promote to main, publish v0.2.7 |
+
+## Success criteria
+
+1. CI is green on windows-latest, ubuntu-latest and macos-latest for the head of dev.
+2. The goalplan symlink tests run on a stock non-admin Windows checkout.
+3. `cxc hooks retrust` runs on Windows without spawnSync EPERM.
+4. A dev -> main promotion PR passes the enforce-target check.
+5. The component suite passes natively on Windows and under WSL Ubuntu.
+6. `main` carries 0.2.7 and a v0.2.7 GitHub release exists.

--- a/devlog/_plan/260822_win_closeout/010_win_ci_red.md
+++ b/devlog/_plan/260822_win_closeout/010_win_ci_red.md
@@ -1,0 +1,55 @@
+# 010 - wp01: the red windows-latest CI cell
+
+## Symptom
+
+`test (windows-latest, false)` in run 32556937213 fails with exactly one assertion:
+
+```
+test at plugins\codexclaw\components\messenger-bridge\test\telegram-adapter.test.ts:427:1
+photo-only private message is downloaded and prefixed into the prompt
+  AssertionError: 0 !== 1   (actual: 0, expected: 1)
+```
+
+Line 474 is `assert.equal(seen.length, 1)`. The agent callback never ran.
+
+## Root cause
+
+The test drives the adapter and then waits with the shared 30ms `settle()` helper:
+
+```ts
+await adapter.start();
+await settle();          // 30ms, unconditional
+adapter.stop();
+assert.equal(seen.length, 1);
+```
+
+A photo turn is not one tick of work. It is `getFile` -> file download -> temp dir
+creation -> agent dispatch, and every step is a real promise chain behind
+`withMediaDownloadSlot`. On an idle developer machine 30ms happens to be enough; on a
+loaded windows-latest runner it is not, so `adapter.stop()` lands before the agent
+callback and `seen` is still empty.
+
+Commit 0954b8d already hit the same race in the sibling text test at :153 and fixed it
+by polling, and af8d8dd widened that poll to 15s. The photo test was never converted -
+it is the last fixed-sleep media assertion in the file.
+
+## Fix
+
+Promote the ad-hoc poll into a named helper next to `settle()` and use it for both
+observable outcomes the photo test cares about:
+
+```ts
+async function waitUntil(predicate, what, timeoutMs = 15000) { ... }
+```
+
+1. `waitUntil(() => seen.length > 0, ...)` replaces the fixed sleep before `stop()`.
+2. The temp-dir cleanup assertions become `waitUntil` too: cleanup runs after the
+   agent callback resolves, so it inherits the same race.
+3. The inline poll at :153 collapses into the helper.
+
+A timeout is an assertion failure with a named cause, not a silent pass.
+
+## Verification
+
+`node --test --experimental-strip-types plugins/codexclaw/components/messenger-bridge/test/telegram-adapter.test.ts`
+-> 28 tests, 28 pass, 0 fail (native Windows).

--- a/devlog/_plan/260822_win_closeout/020_symlink_tests.md
+++ b/devlog/_plan/260822_win_closeout/020_symlink_tests.md
@@ -1,0 +1,52 @@
+# 020 - wp02: issue #32, symlink guards vs an unprivileged Windows host
+
+## Symptom
+
+`plugins/codexclaw/components/pabcd-state/test/goalplan.test.ts` tests 4 and 5 fail on a
+stock Windows checkout:
+
+```
+not ok 4 - goalplan slug is an identifier ... EPERM: operation not permitted, symlink
+not ok 5 - goalplan reads and ledger appends refuse symlink leaf files ... EPERM
+```
+
+Creating a symbolic link on Windows requires Developer Mode or elevation. The tests call
+`symlinkSync` to BUILD the hostile input, so they die on the setup line and never reach
+the guard they exist to verify.
+
+## What the fix must not do
+
+Two tempting shortcuts are both wrong:
+
+- `if (process.platform === "win32") return;` passes the whole case silently. A test
+  that reports "ok" while asserting nothing is worse than a red one.
+- Dropping the symlink assertions entirely removes the coverage on the platforms where
+  the guard actually matters.
+
+## Fix
+
+A memoized `supportsSymlinks()` probe creates a throwaway file link and directory link
+in its own temp dir, removes it, and reports `{ file, dir }`. Any failure counts as
+unsupported, so the probe can never itself fail the suite.
+
+`symlinkDirSync` routes directory links through `"junction"` on win32 and `"dir"`
+elsewhere. Junctions do not need elevation, which means test 4's linked-root case
+genuinely RUNS on Windows now - `lstatSync().isSymbolicLink()` is true for a junction,
+so the production refusal is exercised rather than skipped.
+
+Test 5 needs a link whose target is a FILE, which a junction cannot express. It probes
+`file` support and calls `t.skip()` with a precise reason when unavailable.
+
+## Verification
+
+`node --test --experimental-strip-types .../pabcd-state/test/goalplan.test.ts`
+-> 24 tests, 23 pass, 0 fail, 1 skipped (native Windows, non-admin).
+
+Test 4 passes for real. Test 5 reports:
+`# SKIP file symlinks unavailable on this host: leaf-symlink refusal not exercised`
+
+## Follow-on
+
+The same bare-`return` pattern hides in `worktree-guard.test.ts`,
+`source-receipt.test.ts`, `subagent-evidence.test.ts` and the `cxc-ops` symlink tests.
+Swept in the same work-phase using the same probe.

--- a/devlog/_plan/260822_win_closeout/030_hook_trust.md
+++ b/devlog/_plan/260822_win_closeout/030_hook_trust.md
@@ -1,0 +1,67 @@
+# 030 - wp03: issue #33, Windows hook trust
+
+Two independent defects were filed as one issue.
+
+## Bug A - `cxc hooks retrust` dies before it can help
+
+```
+cxc-ops hooks retrust: codex features list verification failed: spawnSync codex EPERM
+```
+
+`verifyCodexConfig` (cxc-ops/src/hook-trust.ts) spawns a bare `codex` with no shell.
+On this host the failure is TWO stacked problems, not one:
+
+1. PATH offers `WindowsApps\...\codex.EXE` first. That file is readable and passes
+   `X_OK`, and it is NOT a reparse point - yet `CreateProcess` still refuses it with
+   `EPERM` ("Access is denied" from cmd.exe). So the obvious "skip unreadable reparse
+   points" heuristic does not catch it. The only reliable discriminator is the
+   `WindowsApps` path SEGMENT, matched whole so `MyWindowsAppsBackup` is not swept up.
+2. The npm shim next to it is `codex.CMD`, which Node refuses to spawn shell-less
+   after the CVE-2024-27980 hardening (`EINVAL`).
+
+Because verification failed for reasons unrelated to the config, the rollback path
+discarded a CORRECT write on every run.
+
+Fix: a new `cxc-ops/src/codex-bin.ts` resolves the binary through a ladder -
+`CODEX_BIN` override, then a PATH/PATHEXT walk that skips WindowsApps, then a
+caret-escaped `cmd.exe` hop. The injected `runner` seam is untouched; `retrustHooks`
+takes a trailing `platform` parameter so win32 behavior is testable from any OS.
+
+It lives in a new module rather than in `win-exec.ts`, which is byte-identical across
+three components under SHARED-HELPER-01 and must stay that way.
+
+## Bug B - no [hooks.state.*] entries after a fresh install
+
+Investigated and DISMISSED as a codexclaw defect: nothing in this repository writes
+`[hooks.state.*]`. Only the host Codex binary does, on hook approval. Adding a silent
+bootstrap would forge a trust decision the user never made, so it was not done.
+
+What did change: `runHookTrustCheck` now distinguishes never-trusted
+(`actual=null`) from drifted, and emits a repair line naming the owner of the write
+plus the exact command. `--bootstrap-ok` is suggested only when no entry exists at all.
+
+## Verification
+
+`cxc doctor` on the live host: `[PASS] hook-trust: 22 hook hash(es) trusted`.
+A real `cxc hooks retrust` run: `updated=22 appended=0` with a timestamped backup -
+the exact command that previously died on EPERM.
+
+## Note on the reporter's workaround
+
+The issue's confirmed workaround (prepend the vendored binary dir to PATH) is now
+unnecessary; the resolver finds that binary itself.
+
+# 031 - a defect found while verifying, not filed
+
+`resolveProjectRoot` in `gui/src/server/middleware.ts` treats any ancestor with a
+`.codexclaw/` directory as the project root. `~/.codexclaw` is codexclaw's own GLOBAL
+store (recall index, skill cache), so on any real installation a start dir outside a
+repository walks up and resolves the user's ENTIRE HOME DIRECTORY as the project root.
+The dashboard would then read and write `~/.codexclaw/subagents.json`.
+
+The test "no marker anywhere -> falls back to the start dir" catches it, but only on a
+machine that actually has `~/.codexclaw` - which CI runners do not. It was green in CI
+and red locally.
+
+Fix: exclude `homedir()` from the `.codexclaw` marker check, plus a regression test
+that asserts the resolution is not the home directory.

--- a/devlog/_plan/260822_win_closeout/040_enforce_target.md
+++ b/devlog/_plan/260822_win_closeout/040_enforce_target.md
@@ -1,0 +1,83 @@
+# 040 - wp04: the enforce-target check blocks its own release path
+
+## Two defects in one workflow
+
+`.github/workflows/enforce-pr-target.yml` requires every PR to target `dev`. It has
+been failing on every PR, including PR #38.
+
+### Defect 1 - the release promotion path is not exempt
+
+`main` exists precisely to receive `dev` promotions, and the workflow's own comment
+text says so: "main receives only release promotions". But the check is a flat
+`pr.base.ref !== "dev"`, so the promotion PR gets prefixed `[WRONG BRANCH]`, converted
+to draft, and told to retarget itself to the branch it is being promoted FROM. The
+release path cannot pass its own gate.
+
+Fix: treat `dev -> main` from the same repository as exempt.
+
+```js
+const isPromotion =
+  pr.base.ref === PROMOTION_BASE &&
+  pr.head.ref === PROMOTION_HEAD &&
+  pr.head.repo?.full_name === `${owner}/${repo}`;
+const wrongBase = pr.base.ref !== EXPECTED_BASE && !isPromotion;
+```
+
+The same-repo condition matters: a fork whose branch happens to be named `dev` must
+not inherit the exemption.
+
+### Defect 2 - an unavailable mutation fails the whole check
+
+```
+GraphqlResponseError: Resource not accessible by integration
+  data: { convertPullRequestToDraft: null }
+##[error]Unhandled error
+```
+
+`permissions: pull-requests: write` is declared, but `convertPullRequestToDraft` is
+not granted to the default `GITHUB_TOKEN` in every repository configuration. The
+mutation throws, nothing catches it, and the step exits non-zero - so the check is red
+even when the enforcement it exists to perform (title prefix + explanatory comment)
+already succeeded.
+
+Fix: wrap both mutations, return a boolean, and downgrade a refusal to
+`core.warning`. When drafting was refused, rewrite the stored state with
+`autoDraftedByBot: false` so a later corrective run does not try to "restore" a draft
+status this workflow never set, and say so in the comment.
+
+## Verification
+
+### Two more defects the audit found in the first draft of this fix
+
+**`botComment` was captured once and never refreshed.** `upsertComment` closes over a
+handle resolved before any write. On a FRESH wrong-base PR no bot comment exists, so
+the first upsert CREATES comment #1 and the corrective upsert created a SECOND comment
+instead of updating it. The next run's `comments.find` then returned the first comment,
+whose state still said `autoDraftedByBot: true` - so the correction never applied, and
+on retarget the workflow undrafted a PR it never drafted. Fix: `createComment` returns
+the created comment and `botComment` is reassigned to it. The two nearly identical
+comment bodies also collapsed into one `wrongBaseComment(draftExplanation)` builder.
+
+**`markReadyForReview()` returned a boolean nobody read.** `convertToDraft` got both
+the try/catch AND the call-site handling; its sibling only got the try/catch. So a
+FORBIDDEN restoration cleared the state to `active: false` and posted "The pull request
+has been marked ready for review again" while the PR sat there still drafted, with no
+record. Fix: capture the result. On refusal the state stays `active` so a rerun can
+retry, and the comment says restoration failed.
+
+### How it was verified
+
+`.codexclaw/wf-sim.mjs` extracts the embedded script body, wraps it in an async
+function, and runs it against mocked GitHub REST/GraphQL APIs. Six scenarios, 18
+assertions, all passing:
+
+1. `dev -> main` promotion: no prefix, no mutation, no comment.
+2. A FORK branch named `dev` targeting `main`: enforcement still fires.
+3. Fresh wrong-base PR with drafting refused: exactly ONE comment, updated in place,
+   `autoDraftedByBot` corrected to false, check does not throw.
+4. Retarget after a refused draft: no `markReadyForReview`, prefix removed.
+5. Normal cycle: drafted, then undrafted on retarget, one comment, state closed.
+6. Retarget with restoration refused: no success claim, state stays active, warning
+   recorded.
+
+The promotion PR opened in wp06 is the live confirmation.

--- a/docs-site/src/content/docs/guides/native-tools.md
+++ b/docs-site/src/content/docs/guides/native-tools.md
@@ -33,6 +33,23 @@ commit, or merge touching `plugins/codexclaw/hooks/*.json`, run `cxc doctor`. If
 a drifted or untrusted hook, run `cxc hooks retrust` to back up the config and atomically
 record safely recomputed hashes, then rerun `cxc doctor`.
 
+Those entries are written by the host Codex binary when you approve a plugin's hooks, not
+by codexclaw. A fresh install therefore starts with no `[hooks.state.*]` sections at all,
+and `cxc doctor` reports every hook as `untrusted ... actual=(none)` until the approval
+happens. codexclaw will not write them on your behalf as a side effect of installation:
+that would bypass the trust prompt the mechanism exists to enforce. To record them
+deliberately, run the command `cxc doctor` prints, which needs `--bootstrap-ok` only when
+no entry exists yet:
+
+```bash
+cxc hooks retrust --key codexclaw@codexclaw --bootstrap-ok
+```
+
+On Windows, `retrust` verifies its own write by running `codex features list`. It resolves
+that executable before spawning it, because a bare `codex` hits either the Store-packaged
+`WindowsApps` binary (`EPERM`) or the npm `.cmd` shim (`EINVAL`). Set `CODEX_BIN` to an
+explicit path if you keep `codex` somewhere the PATH walk cannot see.
+
 ## Browse-use ladder (owned by `cxc-search`)
 
 Proof-of-source escalates through named tools, stopping at the first rung that yields

--- a/plugins/codexclaw/components/cxc-ops/dist/codex-bin.js
+++ b/plugins/codexclaw/components/cxc-ops/dist/codex-bin.js
@@ -1,0 +1,125 @@
+/**
+ * codex-bin.ts - resolving the `codex` executable before spawning it.
+ *
+ * `spawnSync("codex", ...)` with no shell fails on Windows in two different ways,
+ * and both were measured on a stock Codex-desktop host (issue #33):
+ *
+ *  1. When the Codex desktop app is installed, a PATH entry points at the
+ *     packaged `WindowsApps\...\codex.EXE`. That file is readable and is not a
+ *     reparse point, so no stat-based probe rejects it, yet CreateProcess still
+ *     refuses it: spawnSync reports EPERM (not ENOENT), and cmd.exe reports
+ *     "Access is denied." Only the Store app-execution alias may launch it, so
+ *     the discriminator is the `WindowsApps` path segment itself, not file mode.
+ *  2. The npm shim next to it is `codex.CMD`, and Node refuses shell-less
+ *     `.cmd` spawns after the CVE-2024-27980 hardening: EINVAL.
+ *
+ * So the ladder is: explicit CODEX_BIN override, then a PATH/PATHEXT walk that
+ * skips WindowsApps, then a cmd.exe hop that lets the shell resolve the alias
+ * itself (measured working where every direct spawn failed).
+ *
+ * Everything is platform- and env-parameterized so the whole contract is
+ * testable from any OS.
+ */
+import { existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { commandInvocation, envValue,                 } from "./win-exec.js";
+
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/**
+ * True when `candidate` sits under a WindowsApps directory.
+ *
+ * Matched as a whole path segment on either separator so a legitimately named
+ * directory like `C:\tools\MyWindowsAppsBackup` is not swept up with it.
+ */
+export function isWindowsAppsAlias(candidate        )          {
+  return /(^|[\\/])WindowsApps([\\/]|$)/i.test(candidate);
+}
+
+/**
+ * Walk PATH x PATHEXT and return every spawnable match, nearest first.
+ *
+ * WindowsApps hits are dropped: they resolve but cannot be launched directly,
+ * and returning one would turn a working cmd.exe fallback into a hard EPERM.
+ */
+export function spawnableWindowsCandidates(command        , env                   )           {
+  if (command.includes("/") || command.includes("\\") || isAbsolute(command)) {
+    return isWindowsAppsAlias(command) ? [] : [command];
+  }
+  const exts = (envValue(env, "PATHEXT") ?? DEFAULT_PATHEXT).split(";").filter((e) => e.length > 0);
+  // A WINDOWS PATH is always ";"-separated. node:path's `delimiter` follows the
+  // HOST, so on a Linux CI runner exercising this win32-only walk it would be ":"
+  // and the whole PATH would collapse into one bogus directory entry.
+  const dirs = (envValue(env, "PATH") ?? "").split(";").filter((d) => d.length > 0);
+  const found           = [];
+  // Case-insensitive dedupe: on NTFS "codex.CMD" and "codex.cmd" are one file,
+  // and CreateProcess cannot tell them apart either.
+  const seen = new Set        ();
+  for (const dir of dirs) {
+    if (isWindowsAppsAlias(dir)) continue;
+    for (const ext of exts) {
+      // Case-sensitive filesystems spell the shim "codex.cmd" while PATHEXT
+      // spells ".CMD", so try both spellings (win-exec.ts carries the same rule).
+      for (const spelling of [ext, ext.toLowerCase()]) {
+        const candidate = join(dir, command + spelling);
+        const key = candidate.toLowerCase();
+        if (seen.has(key) || !existsSync(candidate)) continue;
+        seen.add(key);
+        found.push(candidate);
+      }
+    }
+  }
+  return found;
+}
+
+/** cross-spawn's escaping: double backslashes before quotes, quote, then caret. */
+function escapeCmdArg(arg        )         {
+  let out = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1");
+  out = `"${out}"`;
+  return out.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+function escapeCmdCommand(command        )         {
+  return command.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+/**
+ * Hand the bare command to cmd.exe and let the shell resolve it.
+ *
+ * This is the only route that starts a Store-aliased codex, because the alias
+ * is resolvable by the shell but not by a direct CreateProcess.
+ */
+function cmdShellInvocation(command        , args          , env                   )             {
+  const line = [escapeCmdCommand(command), ...args.map(escapeCmdArg)].join(" ");
+  return {
+    file: envValue(env, "ComSpec") ?? "cmd.exe",
+    args: ["/d", "/s", "/c", `"${line}"`],
+    options: { windowsVerbatimArguments: true },
+  };
+}
+
+/**
+ * Build the spawn shape for the `codex` CLI.
+ *
+ * POSIX is a passthrough; `CODEX_BIN` wins on every platform when it is set.
+ */
+export function resolveCodexInvocation(
+  command        ,
+  args          ,
+  platform                  = process.platform,
+  env                    = process.env,
+)             {
+  const override = envValue(env, "CODEX_BIN")?.trim();
+  const target = override && override.length > 0 ? override : command;
+  if (platform !== "win32") return { file: target, args: [...args], options: {} };
+
+  // An explicit override is honored as written; only PATH discovery filters.
+  const resolved = override && override.length > 0
+    ? (spawnableWindowsCandidates(override, env)[0] ?? null)
+    : (spawnableWindowsCandidates(command, env)[0] ?? null);
+  if (resolved === null) return cmdShellInvocation(target, args, env);
+  // commandInvocation already routes .cmd/.bat through ComSpec and spawns a
+  // resolved .exe directly; the path it gets here is absolute, so it re-resolves
+  // nothing.
+  return commandInvocation(resolved, args, platform, env);
+}

--- a/plugins/codexclaw/components/cxc-ops/dist/doctor.js
+++ b/plugins/codexclaw/components/cxc-ops/dist/doctor.js
@@ -369,12 +369,25 @@ export function runHookTrustCheck(pluginRoot        , options                = {
     }
     const results = diagnoseHookTrust(codexHome, pluginRoot, pluginKey);
     const failed = results.filter((result) => result.status !== "trusted");
+    // A fresh install has NO [hooks.state.*] sections at all: the host Codex
+    // binary writes them when the user approves the plugin's hooks, and nothing
+    // in codexclaw may forge them (that would silently bypass the trust prompt).
+    // Distinguish "never trusted" from "drifted" so the repair line is the one
+    // the operator actually needs (issue #33).
+    const neverTrusted = failed.filter((result) => result.actual === null);
+    const repair =
+      failed.length === 0
+        ? undefined
+        : neverTrusted.length === failed.length
+        ? `${failed.length} hook(s) have no trust entry in ${join(codexHome, "config.toml")}; only Codex itself writes those on hook approval. Approve this plugin's hooks in Codex, or record them explicitly with: cxc hooks retrust --key ${pluginKey} --codex-home ${codexHome} --bootstrap-ok`
+        : `cxc hooks retrust --key ${pluginKey} --codex-home ${codexHome}`;
     return {
       name: "hook-trust",
       // An EMPTY result set is not a pass. `diagnoseHookTrust` skips a handler it
       // cannot hash (invalid matcher, empty command, async), so "0 failed" can also
       // mean "0 examined" — a green check over hooks nobody verified.
       severity: results.length === 0 ? "WARN" : failed.length === 0 ? "PASS" : "FAIL",
+      repair,
       evidence:
         results.length === 0
           ? `no hook handler could be hashed for ${pluginKey}; nothing was verified`

--- a/plugins/codexclaw/components/cxc-ops/dist/hook-trust.js
+++ b/plugins/codexclaw/components/cxc-ops/dist/hook-trust.js
@@ -13,6 +13,7 @@ import {
 import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { renameWithRetry } from "./atomic-write.js";
+import { resolveCodexInvocation } from "./codex-bin.js";
 
 const EVENT_LABELS = {
   PreToolUse: "pre_tool_use",
@@ -368,10 +369,26 @@ function resolvedConfigPath(configPath        )         {
   return lstatSync(configPath).isSymbolicLink() ? realpathSync(configPath) : configPath;
 }
 
-function verifyCodexConfig(codexHome        , runner                 )       {
-  const result = runner("codex", ["features", "list"], {
+/**
+ * Prove the rewritten config still parses, by running `codex features list`
+ * against it.
+ *
+ * The invocation is resolved rather than spawned bare: on Windows a bare
+ * `codex` hits either the Store-packaged WindowsApps binary (EPERM) or the npm
+ * `.cmd` shim (EINVAL), and both surfaced as a bogus "verification failed" that
+ * rolled back a perfectly good write (issue #33).
+ */
+function verifyCodexConfig(
+  codexHome        ,
+  runner                 ,
+  platform                  = process.platform,
+)       {
+  const env = { ...process.env, CODEX_HOME: codexHome };
+  const invocation = resolveCodexInvocation("codex", ["features", "list"], platform, env);
+  const result = runner(invocation.file, invocation.args, {
     encoding: "utf8",
-    env: { ...process.env, CODEX_HOME: codexHome },
+    env,
+    ...invocation.options,
   });
   if (result.status !== 0) {
     const detail = result.error?.message ?? result.stderr?.trim() ?? `exit ${String(result.status)}`;
@@ -385,6 +402,7 @@ export function retrustHooks(
   pluginKey        ,
   bootstrapOk = false,
   runner                  = spawnSync,
+  platform                  = process.platform,
 )                {
   assertSupportedPlatform();
   const configPath = join(codexHome, "config.toml");
@@ -437,7 +455,7 @@ export function retrustHooks(
   copyFileSync(targetPath, backupPath, fsConstants.COPYFILE_EXCL);
   try {
     writeAtomic(targetPath, next);
-    verifyCodexConfig(codexHome, runner);
+    verifyCodexConfig(codexHome, runner, platform);
     const verification = diagnoseHookTrust(codexHome, pluginRoot, pluginKey);
     const failed = verification.filter((result) => result.status !== "trusted");
     if (failed.length > 0) throw new Error(`post-write verification failed for ${failed.map((item) => item.key).join(", ")}`);

--- a/plugins/codexclaw/components/cxc-ops/src/codex-bin.ts
+++ b/plugins/codexclaw/components/cxc-ops/src/codex-bin.ts
@@ -1,0 +1,125 @@
+/**
+ * codex-bin.ts - resolving the `codex` executable before spawning it.
+ *
+ * `spawnSync("codex", ...)` with no shell fails on Windows in two different ways,
+ * and both were measured on a stock Codex-desktop host (issue #33):
+ *
+ *  1. When the Codex desktop app is installed, a PATH entry points at the
+ *     packaged `WindowsApps\...\codex.EXE`. That file is readable and is not a
+ *     reparse point, so no stat-based probe rejects it, yet CreateProcess still
+ *     refuses it: spawnSync reports EPERM (not ENOENT), and cmd.exe reports
+ *     "Access is denied." Only the Store app-execution alias may launch it, so
+ *     the discriminator is the `WindowsApps` path segment itself, not file mode.
+ *  2. The npm shim next to it is `codex.CMD`, and Node refuses shell-less
+ *     `.cmd` spawns after the CVE-2024-27980 hardening: EINVAL.
+ *
+ * So the ladder is: explicit CODEX_BIN override, then a PATH/PATHEXT walk that
+ * skips WindowsApps, then a cmd.exe hop that lets the shell resolve the alias
+ * itself (measured working where every direct spawn failed).
+ *
+ * Everything is platform- and env-parameterized so the whole contract is
+ * testable from any OS.
+ */
+import { existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { commandInvocation, envValue, type Invocation } from "./win-exec.ts";
+
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/**
+ * True when `candidate` sits under a WindowsApps directory.
+ *
+ * Matched as a whole path segment on either separator so a legitimately named
+ * directory like `C:\tools\MyWindowsAppsBackup` is not swept up with it.
+ */
+export function isWindowsAppsAlias(candidate: string): boolean {
+  return /(^|[\\/])WindowsApps([\\/]|$)/i.test(candidate);
+}
+
+/**
+ * Walk PATH x PATHEXT and return every spawnable match, nearest first.
+ *
+ * WindowsApps hits are dropped: they resolve but cannot be launched directly,
+ * and returning one would turn a working cmd.exe fallback into a hard EPERM.
+ */
+export function spawnableWindowsCandidates(command: string, env: NodeJS.ProcessEnv): string[] {
+  if (command.includes("/") || command.includes("\\") || isAbsolute(command)) {
+    return isWindowsAppsAlias(command) ? [] : [command];
+  }
+  const exts = (envValue(env, "PATHEXT") ?? DEFAULT_PATHEXT).split(";").filter((e) => e.length > 0);
+  // A WINDOWS PATH is always ";"-separated. node:path's `delimiter` follows the
+  // HOST, so on a Linux CI runner exercising this win32-only walk it would be ":"
+  // and the whole PATH would collapse into one bogus directory entry.
+  const dirs = (envValue(env, "PATH") ?? "").split(";").filter((d) => d.length > 0);
+  const found: string[] = [];
+  // Case-insensitive dedupe: on NTFS "codex.CMD" and "codex.cmd" are one file,
+  // and CreateProcess cannot tell them apart either.
+  const seen = new Set<string>();
+  for (const dir of dirs) {
+    if (isWindowsAppsAlias(dir)) continue;
+    for (const ext of exts) {
+      // Case-sensitive filesystems spell the shim "codex.cmd" while PATHEXT
+      // spells ".CMD", so try both spellings (win-exec.ts carries the same rule).
+      for (const spelling of [ext, ext.toLowerCase()]) {
+        const candidate = join(dir, command + spelling);
+        const key = candidate.toLowerCase();
+        if (seen.has(key) || !existsSync(candidate)) continue;
+        seen.add(key);
+        found.push(candidate);
+      }
+    }
+  }
+  return found;
+}
+
+/** cross-spawn's escaping: double backslashes before quotes, quote, then caret. */
+function escapeCmdArg(arg: string): string {
+  let out = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1");
+  out = `"${out}"`;
+  return out.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+function escapeCmdCommand(command: string): string {
+  return command.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+/**
+ * Hand the bare command to cmd.exe and let the shell resolve it.
+ *
+ * This is the only route that starts a Store-aliased codex, because the alias
+ * is resolvable by the shell but not by a direct CreateProcess.
+ */
+function cmdShellInvocation(command: string, args: string[], env: NodeJS.ProcessEnv): Invocation {
+  const line = [escapeCmdCommand(command), ...args.map(escapeCmdArg)].join(" ");
+  return {
+    file: envValue(env, "ComSpec") ?? "cmd.exe",
+    args: ["/d", "/s", "/c", `"${line}"`],
+    options: { windowsVerbatimArguments: true },
+  };
+}
+
+/**
+ * Build the spawn shape for the `codex` CLI.
+ *
+ * POSIX is a passthrough; `CODEX_BIN` wins on every platform when it is set.
+ */
+export function resolveCodexInvocation(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): Invocation {
+  const override = envValue(env, "CODEX_BIN")?.trim();
+  const target = override && override.length > 0 ? override : command;
+  if (platform !== "win32") return { file: target, args: [...args], options: {} };
+
+  // An explicit override is honored as written; only PATH discovery filters.
+  const resolved = override && override.length > 0
+    ? (spawnableWindowsCandidates(override, env)[0] ?? null)
+    : (spawnableWindowsCandidates(command, env)[0] ?? null);
+  if (resolved === null) return cmdShellInvocation(target, args, env);
+  // commandInvocation already routes .cmd/.bat through ComSpec and spawns a
+  // resolved .exe directly; the path it gets here is absolute, so it re-resolves
+  // nothing.
+  return commandInvocation(resolved, args, platform, env);
+}

--- a/plugins/codexclaw/components/cxc-ops/src/doctor.ts
+++ b/plugins/codexclaw/components/cxc-ops/src/doctor.ts
@@ -369,12 +369,25 @@ export function runHookTrustCheck(pluginRoot: string, options: DoctorOptions = {
     }
     const results = diagnoseHookTrust(codexHome, pluginRoot, pluginKey);
     const failed = results.filter((result) => result.status !== "trusted");
+    // A fresh install has NO [hooks.state.*] sections at all: the host Codex
+    // binary writes them when the user approves the plugin's hooks, and nothing
+    // in codexclaw may forge them (that would silently bypass the trust prompt).
+    // Distinguish "never trusted" from "drifted" so the repair line is the one
+    // the operator actually needs (issue #33).
+    const neverTrusted = failed.filter((result) => result.actual === null);
+    const repair =
+      failed.length === 0
+        ? undefined
+        : neverTrusted.length === failed.length
+        ? `${failed.length} hook(s) have no trust entry in ${join(codexHome, "config.toml")}; only Codex itself writes those on hook approval. Approve this plugin's hooks in Codex, or record them explicitly with: cxc hooks retrust --key ${pluginKey} --codex-home ${codexHome} --bootstrap-ok`
+        : `cxc hooks retrust --key ${pluginKey} --codex-home ${codexHome}`;
     return {
       name: "hook-trust",
       // An EMPTY result set is not a pass. `diagnoseHookTrust` skips a handler it
       // cannot hash (invalid matcher, empty command, async), so "0 failed" can also
       // mean "0 examined" — a green check over hooks nobody verified.
       severity: results.length === 0 ? "WARN" : failed.length === 0 ? "PASS" : "FAIL",
+      repair,
       evidence:
         results.length === 0
           ? `no hook handler could be hashed for ${pluginKey}; nothing was verified`

--- a/plugins/codexclaw/components/cxc-ops/src/hook-trust.ts
+++ b/plugins/codexclaw/components/cxc-ops/src/hook-trust.ts
@@ -13,6 +13,7 @@ import {
 import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { renameWithRetry } from "./atomic-write.ts";
+import { resolveCodexInvocation } from "./codex-bin.ts";
 
 const EVENT_LABELS = {
   PreToolUse: "pre_tool_use",
@@ -83,7 +84,7 @@ interface TrustedHashLine {
 type HookTrustRunner = (
   command: string,
   args: string[],
-  options: { encoding: "utf8"; env: NodeJS.ProcessEnv },
+  options: { encoding: "utf8"; env: NodeJS.ProcessEnv; windowsVerbatimArguments?: boolean },
 ) => { status: number | null; stderr?: string; error?: Error };
 
 function assertSupportedPlatform(): void {}
@@ -368,10 +369,26 @@ function resolvedConfigPath(configPath: string): string {
   return lstatSync(configPath).isSymbolicLink() ? realpathSync(configPath) : configPath;
 }
 
-function verifyCodexConfig(codexHome: string, runner: HookTrustRunner): void {
-  const result = runner("codex", ["features", "list"], {
+/**
+ * Prove the rewritten config still parses, by running `codex features list`
+ * against it.
+ *
+ * The invocation is resolved rather than spawned bare: on Windows a bare
+ * `codex` hits either the Store-packaged WindowsApps binary (EPERM) or the npm
+ * `.cmd` shim (EINVAL), and both surfaced as a bogus "verification failed" that
+ * rolled back a perfectly good write (issue #33).
+ */
+function verifyCodexConfig(
+  codexHome: string,
+  runner: HookTrustRunner,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  const env = { ...process.env, CODEX_HOME: codexHome };
+  const invocation = resolveCodexInvocation("codex", ["features", "list"], platform, env);
+  const result = runner(invocation.file, invocation.args, {
     encoding: "utf8",
-    env: { ...process.env, CODEX_HOME: codexHome },
+    env,
+    ...invocation.options,
   });
   if (result.status !== 0) {
     const detail = result.error?.message ?? result.stderr?.trim() ?? `exit ${String(result.status)}`;
@@ -385,6 +402,7 @@ export function retrustHooks(
   pluginKey: string,
   bootstrapOk = false,
   runner: HookTrustRunner = spawnSync,
+  platform: NodeJS.Platform = process.platform,
 ): RetrustResult {
   assertSupportedPlatform();
   const configPath = join(codexHome, "config.toml");
@@ -437,7 +455,7 @@ export function retrustHooks(
   copyFileSync(targetPath, backupPath, fsConstants.COPYFILE_EXCL);
   try {
     writeAtomic(targetPath, next);
-    verifyCodexConfig(codexHome, runner);
+    verifyCodexConfig(codexHome, runner, platform);
     const verification = diagnoseHookTrust(codexHome, pluginRoot, pluginKey);
     const failed = verification.filter((result) => result.status !== "trusted");
     if (failed.length > 0) throw new Error(`post-write verification failed for ${failed.map((item) => item.key).join(", ")}`);

--- a/plugins/codexclaw/components/cxc-ops/test-support/symlink-support.ts
+++ b/plugins/codexclaw/components/cxc-ops/test-support/symlink-support.ts
@@ -1,0 +1,65 @@
+/**
+ * symlink-support.ts - shared host capability probe for the symlink guard tests.
+ *
+ * Issue #32: a stock non-admin Windows checkout cannot create symlinks, so
+ * symlinkSync threw EPERM before the guards under test ever ran. Probe the host
+ * once and gate only the symlink-creating half of each case.
+ *
+ * This lives beside test/ rather than inside it: node --test treats every file
+ * under a test directory as a test file, and a helper module with no cases
+ * would report as an empty passing "test".
+ */
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface SymlinkSupport {
+  /** file -> file symlinks (needs Developer Mode or elevation on Windows) */
+  file: boolean;
+  /** directory links; junctions cover this on Windows without elevation */
+  dir: boolean;
+}
+
+/** Directory link that does not need elevation on Windows. */
+export function symlinkDirSync(target: string, path: string): void {
+  symlinkSync(target, path, process.platform === "win32" ? "junction" : "dir");
+}
+
+let symlinkProbe: SymlinkSupport | null = null;
+
+/**
+ * A denied link answers EPERM/EACCES (and UNKNOWN on some Windows filesystems).
+ * Any other failure is still treated as "unsupported" so a probe can never fail
+ * the suite on its own; the gated assertions report a skip instead.
+ */
+export function supportsSymlinks(): SymlinkSupport {
+  if (symlinkProbe) return symlinkProbe;
+  const probeDir = mkdtempSync(join(tmpdir(), "cxc-symlink-probe-"));
+  const support: SymlinkSupport = { file: false, dir: false };
+  try {
+    const target = join(probeDir, "target.txt");
+    writeFileSync(target, "probe");
+    try {
+      symlinkSync(target, join(probeDir, "file-link"), "file");
+      support.file = true;
+    } catch {
+      support.file = false;
+    }
+    const dirTarget = join(probeDir, "target-dir");
+    mkdirSync(dirTarget, { recursive: true });
+    try {
+      symlinkDirSync(dirTarget, join(probeDir, "dir-link"));
+      support.dir = true;
+    } catch {
+      support.dir = false;
+    }
+  } finally {
+    try {
+      rmSync(probeDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup of the probe dir; ignore
+    }
+  }
+  symlinkProbe = support;
+  return support;
+}

--- a/plugins/codexclaw/components/cxc-ops/test/codex-bin.test.ts
+++ b/plugins/codexclaw/components/cxc-ops/test/codex-bin.test.ts
@@ -1,0 +1,178 @@
+/**
+ * codex-bin.test.ts - the win32 `codex` resolution contract (issue #33, bug A).
+ *
+ * Every case drives platform and env as parameters, so the whole file runs
+ * identically on Windows and on Linux CI. The two failure modes reproduced on a
+ * stock Codex-desktop host are pinned here:
+ *   - WindowsApps\codex.EXE spawns EPERM even though it is readable
+ *   - the npm codex.CMD shim spawns EINVAL without a cmd.exe hop
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isWindowsAppsAlias,
+  resolveCodexInvocation,
+  spawnableWindowsCandidates,
+} from "../src/codex-bin.ts";
+
+/** A throwaway PATH dir holding the given command files. */
+function fakePathDir(names: string[], prefix = "cxc-codexbin-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(dir, { recursive: true });
+  for (const name of names) writeFileSync(join(dir, name), "");
+  return dir;
+}
+
+/** A dir whose path contains a WindowsApps segment, like the Store install. */
+function fakeWindowsAppsDir(names: string[]): string {
+  const base = mkdtempSync(join(tmpdir(), "cxc-store-"));
+  const dir = join(base, "WindowsApps", "OpenAI.Codex_1.0.0_x64__abc", "app", "resources");
+  mkdirSync(dir, { recursive: true });
+  for (const name of names) writeFileSync(join(dir, name), "");
+  return dir;
+}
+
+test("POSIX is a passthrough", () => {
+  const inv = resolveCodexInvocation("codex", ["features", "list"], "linux", {});
+  assert.equal(inv.file, "codex");
+  assert.deepEqual(inv.args, ["features", "list"]);
+  assert.deepEqual(inv.options, {});
+});
+
+test("CODEX_BIN overrides discovery on POSIX", () => {
+  const inv = resolveCodexInvocation("codex", ["features", "list"], "linux", {
+    CODEX_BIN: "/opt/codex/bin/codex",
+  });
+  assert.equal(inv.file, "/opt/codex/bin/codex");
+  assert.deepEqual(inv.args, ["features", "list"]);
+});
+
+test("CODEX_BIN pointing at a real .exe wins over PATH on win32", () => {
+  const pathDir = fakePathDir(["codex.cmd"]);
+  const overrideDir = fakePathDir(["codex.exe"], "cxc-override-");
+  const override = join(overrideDir, "codex.exe");
+  const inv = resolveCodexInvocation("codex", ["features", "list"], "win32", {
+    CODEX_BIN: override,
+    PATH: pathDir,
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+    ComSpec: "C:\\Windows\\system32\\cmd.exe",
+  });
+  assert.equal(inv.file, override);
+  assert.deepEqual(inv.args, ["features", "list"]);
+  assert.equal(inv.options.windowsVerbatimArguments, undefined);
+});
+
+test("a WindowsApps segment is recognized, and a lookalike directory is not", () => {
+  assert.equal(isWindowsAppsAlias("C:\\Program Files\\WindowsApps\\x\\codex.exe"), true);
+  assert.equal(isWindowsAppsAlias("C:/Program Files/WindowsApps/x/codex.exe"), true);
+  assert.equal(isWindowsAppsAlias("C:\\tools\\MyWindowsAppsBackup\\codex.exe"), false);
+  assert.equal(isWindowsAppsAlias("C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd"), false);
+});
+
+test("the Store binary is skipped even though it exists and is readable", () => {
+  // Measured on a stock host: this file is readable, is not a reparse point, and
+  // still fails CreateProcess with EPERM. Only the path segment reveals it.
+  const storeDir = fakeWindowsAppsDir(["codex.exe"]);
+  const candidates = spawnableWindowsCandidates("codex", {
+    PATH: storeDir,
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+  });
+  assert.deepEqual(candidates, []);
+});
+
+test("with only the Store binary on PATH, resolution falls back to cmd.exe", () => {
+  const storeDir = fakeWindowsAppsDir(["codex.exe"]);
+  const comspec = "C:\\Windows\\system32\\cmd.exe";
+  const inv = resolveCodexInvocation("codex", ["features", "list"], "win32", {
+    PATH: storeDir,
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+    ComSpec: comspec,
+  });
+  assert.equal(inv.file, comspec);
+  assert.deepEqual(inv.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.equal(inv.options.windowsVerbatimArguments, true);
+  assert.match(inv.args[3], /codex/);
+});
+
+test("the npm .cmd shim routes through ComSpec instead of spawning directly", () => {
+  // A shell-less .cmd spawn is EINVAL after the CVE-2024-27980 hardening.
+  const dir = fakePathDir(["codex.cmd"]);
+  const comspec = "C:\\Windows\\system32\\cmd.exe";
+  const inv = resolveCodexInvocation("codex", ["features", "list"], "win32", {
+    PATH: dir,
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+    ComSpec: comspec,
+  });
+  assert.equal(inv.file, comspec);
+  assert.equal(inv.options.windowsVerbatimArguments, true);
+  assert.match(inv.args[3], /codex\.cmd/i);
+  assert.match(inv.args[3], /features/);
+});
+
+test("a real .exe earlier on PATH spawns directly, with no cmd.exe hop", () => {
+  const dir = fakePathDir(["codex.exe"]);
+  const inv = resolveCodexInvocation("codex", ["features", "list"], "win32", {
+    PATH: dir,
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+    ComSpec: "C:\\Windows\\system32\\cmd.exe",
+  });
+  assert.equal(inv.file.toLowerCase(), join(dir, "codex.exe").toLowerCase());
+  assert.deepEqual(inv.args, ["features", "list"]);
+  assert.equal(inv.options.windowsVerbatimArguments, undefined);
+});
+
+test("the npm shim is preferred when the Store dir sits earlier on PATH", () => {
+  // This is the exact live layout from issue #33: both are present, and the
+  // unusable one is NOT the one we may pick.
+  const storeDir = fakeWindowsAppsDir(["codex.exe"]);
+  const npmDir = fakePathDir(["codex.cmd"]);
+  const candidates = spawnableWindowsCandidates("codex", {
+    PATH: [storeDir, npmDir].join(";"),
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+  });
+  // The extension case comes from PATHEXT, so compare case-insensitively.
+  assert.deepEqual(
+    candidates.map((c) => c.toLowerCase()),
+    [join(npmDir, "codex.cmd").toLowerCase()],
+  );
+});
+
+test("an unresolvable codex still produces a runnable cmd.exe line, not a bare spawn", () => {
+  const inv = resolveCodexInvocation("codex", ["features", "list"], "win32", {
+    PATH: fakePathDir([]),
+    PATHEXT: ".EXE",
+    ComSpec: "cmd.exe",
+  });
+  assert.equal(inv.file, "cmd.exe");
+  assert.equal(inv.options.windowsVerbatimArguments, true);
+});
+
+test("arguments with spaces and metacharacters survive the cmd fallback", () => {
+  const inv = resolveCodexInvocation("codex", ["features", "C:\\Program Files\\a&b"], "win32", {
+    PATH: fakeWindowsAppsDir(["codex.exe"]),
+    PATHEXT: ".EXE",
+    ComSpec: "cmd.exe",
+  });
+  const line = inv.args[3];
+  assert.ok(line.includes("^&"), `ampersand not escaped in: ${line}`);
+  assert.ok(line.includes("Program^ Files"), `space not escaped in: ${line}`);
+  assert.ok(!/(^|[^^])&/.test(line), "a bare & would end the command line early");
+});
+
+test("a path-qualified command is not PATH-resolved, but a Store path is still refused", () => {
+  const inv = resolveCodexInvocation("C:\\tools\\codex.exe", [], "win32", { PATH: "C:\\bin" });
+  assert.equal(inv.file, "C:\\tools\\codex.exe");
+  assert.deepEqual(spawnableWindowsCandidates("C:\\x\\WindowsApps\\codex.exe", {}), []);
+});
+
+test("ComSpec is honored when set to a non-default shell path", () => {
+  const inv = resolveCodexInvocation("codex", [], "win32", {
+    PATH: fakePathDir([]),
+    PATHEXT: ".EXE",
+    ComSpec: "D:\\alt\\cmd.exe",
+  });
+  assert.equal(inv.file, "D:\\alt\\cmd.exe");
+});

--- a/plugins/codexclaw/components/cxc-ops/test/hook-trust.test.ts
+++ b/plugins/codexclaw/components/cxc-ops/test/hook-trust.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { supportsSymlinks } from "../test-support/symlink-support.ts";
 import {
   diagnoseHookTrust,
   identityHash,
@@ -342,7 +343,13 @@ test("retrustHooks requires bootstrapOk only when no entries exist for the plugi
   assert.deepEqual(diagnoseHookTrust(home, root, PLUGIN_KEY).map((item) => item.status), ["trusted"]);
 });
 
-test("retrustHooks preserves a config symlink and atomically updates its resolved target", () => {
+test("retrustHooks preserves a config symlink and atomically updates its resolved target", (t) => {
+  // config.toml is linked as a FILE, which a directory junction cannot express,
+  // so an unprivileged Windows host cannot build this fixture at all.
+  if (!supportsSymlinks().file) {
+    t.skip("file symlinks unavailable on this host: config-symlink preservation not exercised");
+    return;
+  }
   const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo symlink")] }] } });
   const home = tempDir("cxc-hook-link-home-");
   const targetDir = tempDir("cxc-hook-link-target-");
@@ -371,7 +378,13 @@ test("retrustHooks rolls back the resolved config when codex verification fails"
     return { status: 2, stderr: "invalid config" };
   };
 
-  assert.throws(() => retrustHooks(home, root, PLUGIN_KEY, false, failingRunner), /codex features list verification failed/);
+  // Pinned to a POSIX platform so this stays a ROLLBACK test: the win32 spawn
+  // shape is asserted separately, and on a real Windows host the resolver would
+  // otherwise rewrite the command into a cmd.exe hop here.
+  assert.throws(
+    () => retrustHooks(home, root, PLUGIN_KEY, false, failingRunner, "linux"),
+    /codex features list verification failed/,
+  );
   assert.deepEqual(calls, [{ command: "codex", args: ["features", "list"], codexHome: home }]);
   assert.equal(readFileSync(join(home, "config.toml"), "utf8"), before);
   assert.equal(diagnoseHookTrust(home, root, PLUGIN_KEY)[1].status, "untrusted");
@@ -422,3 +435,122 @@ test(
   assert.match(stdout.join(""), /backup: .*config\.toml\.bak-/);
   },
 );
+
+/**
+ * Issue #33 bug A: retrust must not spawn a bare `codex` on Windows.
+ *
+ * The verification runner is the injected seam, so these drive platform="win32"
+ * from any OS and assert on the spawn shape the runner is handed.
+ */
+test("retrustHooks verifies through a cmd.exe hop when only the Store codex is on PATH", () => {
+  const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo store")] }] } });
+  const home = makeCodexHome('[plugins."fixture@market"]\nenabled = true\n');
+  const seen: Array<{ file: string; args: string[]; verbatim?: boolean }> = [];
+  const runner: HookTrustRunner = (file, args, options) => {
+    seen.push({ file, args, verbatim: options.windowsVerbatimArguments });
+    return { status: 0 };
+  };
+  const storeDir = join("C:\\Program Files", "WindowsApps", "OpenAI.Codex_1.0_x64__a", "app");
+  const originalPath = process.env.PATH;
+  const originalComSpec = process.env.ComSpec;
+  const originalBin = process.env.CODEX_BIN;
+  process.env.PATH = storeDir;
+  process.env.ComSpec = "C:\\Windows\\system32\\cmd.exe";
+  delete process.env.CODEX_BIN;
+  try {
+    retrustHooks(home, root, PLUGIN_KEY, true, runner, "win32");
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalComSpec === undefined) delete process.env.ComSpec;
+    else process.env.ComSpec = originalComSpec;
+    if (originalBin !== undefined) process.env.CODEX_BIN = originalBin;
+  }
+  assert.equal(seen.length, 1);
+  // The bare "codex" spawn is what EPERMs on a Codex-desktop host.
+  assert.notEqual(seen[0].file, "codex");
+  assert.match(seen[0].file, /cmd\.exe$/i);
+  assert.deepEqual(seen[0].args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.equal(seen[0].verbatim, true);
+  assert.match(seen[0].args[3], /codex/);
+  assert.match(seen[0].args[3], /features/);
+});
+
+test("retrustHooks honors CODEX_BIN and still passes CODEX_HOME to the runner", () => {
+  const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo override")] }] } });
+  const home = makeCodexHome('[plugins."fixture@market"]\nenabled = true\n');
+  const binDir = tempDir("cxc-hook-codexbin-");
+  const override = join(binDir, "codex.exe");
+  writeFileSync(override, "");
+  const seen: Array<{ file: string; codexHome: string | undefined }> = [];
+  const runner: HookTrustRunner = (file, _args, options) => {
+    seen.push({ file, codexHome: options.env.CODEX_HOME });
+    return { status: 0 };
+  };
+  const originalBin = process.env.CODEX_BIN;
+  process.env.CODEX_BIN = override;
+  try {
+    retrustHooks(home, root, PLUGIN_KEY, true, runner, "win32");
+  } finally {
+    if (originalBin === undefined) delete process.env.CODEX_BIN;
+    else process.env.CODEX_BIN = originalBin;
+  }
+  assert.deepEqual(seen, [{ file: override, codexHome: home }]);
+});
+
+test("POSIX retrust still spawns a bare codex, unchanged", () => {
+  const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo posix")] }] } });
+  const home = makeCodexHome('[plugins."fixture@market"]\nenabled = true\n');
+  const seen: Array<{ file: string; args: string[] }> = [];
+  const runner: HookTrustRunner = (file, args) => {
+    seen.push({ file, args });
+    return { status: 0 };
+  };
+  const originalBin = process.env.CODEX_BIN;
+  delete process.env.CODEX_BIN;
+  try {
+    retrustHooks(home, root, PLUGIN_KEY, true, runner, "linux");
+  } finally {
+    if (originalBin !== undefined) process.env.CODEX_BIN = originalBin;
+  }
+  assert.deepEqual(seen, [{ file: "codex", args: ["features", "list"] }]);
+});
+
+/**
+ * Issue #33 bug B: a never-trusted install must name the exact recovery command.
+ * Nothing in codexclaw writes [hooks.state.*]; only the host Codex does, so the
+ * check reports rather than forges.
+ */
+test("doctor names the bootstrap retrust command when no trust entry exists at all", () => {
+  const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo fresh")] }] } });
+  const home = makeCodexHome('[plugins."fixture@market"]\nenabled = true\n');
+  const check = runHookTrustCheck(root, { codexHome: home, pluginKey: PLUGIN_KEY });
+  assert.equal(check.severity, "FAIL");
+  assert.match(check.evidence, /untrusted/);
+  assert.match(check.evidence, /actual=\(none\)/);
+  assert.ok(check.repair, "a fresh install must carry a repair line");
+  assert.match(check.repair ?? "", /cxc hooks retrust/);
+  assert.match(check.repair ?? "", /--bootstrap-ok/);
+  assert.match(check.repair ?? "", new RegExp(PLUGIN_KEY.replace("@", "@")));
+  // The remediation must say who owns the write, so nobody hand-forges entries.
+  assert.match(check.repair ?? "", /Codex/);
+});
+
+test("doctor's drift repair omits --bootstrap-ok, which would be the wrong advice", () => {
+  const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo drifted")] }] } });
+  const entries = listHookEntries(root, PLUGIN_KEY);
+  const home = makeCodexHome(trustSection(entries[0], "sha256:stale"));
+  const check = runHookTrustCheck(root, { codexHome: home, pluginKey: PLUGIN_KEY });
+  assert.equal(check.severity, "FAIL");
+  assert.match(check.evidence, /drifted/);
+  assert.match(check.repair ?? "", /cxc hooks retrust/);
+  assert.ok(!(check.repair ?? "").includes("--bootstrap-ok"), "drift is not a bootstrap case");
+});
+
+test("a fully trusted install carries no repair line", () => {
+  const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo trusted")] }] } });
+  const entries = listHookEntries(root, PLUGIN_KEY);
+  const home = makeCodexHome(trustSection(entries[0]));
+  const check = runHookTrustCheck(root, { codexHome: home, pluginKey: PLUGIN_KEY });
+  assert.equal(check.severity, "PASS");
+  assert.equal(check.repair, undefined);
+});

--- a/plugins/codexclaw/components/cxc-ops/test/manifest-targets.test.ts
+++ b/plugins/codexclaw/components/cxc-ops/test/manifest-targets.test.ts
@@ -10,10 +10,11 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { cpSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { supportsSymlinks, symlinkDirSync } from "../test-support/symlink-support.ts";
 import { TargetParseError, validateManifestTargets } from "../src/manifest-targets.ts";
 import { runDoctor } from "../src/doctor.ts";
 
@@ -148,12 +149,18 @@ test("B2: a ../ target resolving outside the plugin root is rejected", () => {
   ]);
 });
 
-test("B3: a symlink pointing outside the plugin root is rejected", () => {
+test("B3: a symlink pointing outside the plugin root is rejected", (t) => {
+  // escapesRoot compares realpaths, so linking the containing DIRECTORY reaches
+  // the same guard as a leaf link and works unprivileged on Windows via junction.
+  if (!supportsSymlinks().dir) {
+    t.skip("directory links unavailable on this host: symlink escape of the plugin root not exercised");
+    return;
+  }
   const root = makeRoot({ hookCommand: 'node "${PLUGIN_ROOT}/components/x/dist/cli.js"' });
   const outside = mkdtempSync(join(tmpdir(), "cxc-outside-"));
-  writeFileSync(join(outside, "evil.js"), "// elsewhere\n");
-  mkdirSync(join(root, "components", "x", "dist"), { recursive: true });
-  symlinkSync(join(outside, "evil.js"), join(root, "components", "x", "dist", "cli.js"));
+  writeFileSync(join(outside, "cli.js"), "// elsewhere\n");
+  mkdirSync(join(root, "components", "x"), { recursive: true });
+  symlinkDirSync(outside, join(root, "components", "x", "dist"));
   assert.deepEqual(validateManifestTargets(root), [
     { kind: "hook", message: "target escapes plugin root: components/x/dist/cli.js" },
   ]);

--- a/plugins/codexclaw/components/cxc-ops/test/map-affordance.test.ts
+++ b/plugins/codexclaw/components/cxc-ops/test/map-affordance.test.ts
@@ -13,11 +13,12 @@ import assert from "node:assert/strict";
 // Pin the cxc-resolve seam (B1): these tests assert literal `cxc ...` command
 // mentions, which would otherwise depend on whether the runner's PATH has cxc.
 process.env.CODEXCLAW_CXC = "cxc";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, symlinkSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { supportsSymlinks, symlinkDirSync } from "../test-support/symlink-support.ts";
 
 import {
   countSourceFiles,
@@ -191,15 +192,21 @@ test("degraded mode: no CODEXCLAW_CXC + cxc-free PATH falls back to the payload 
   }
 });
 
-test("direct-exec guard fires through a symlinked install path (plugin-cache regression)", () => {
+test("direct-exec guard fires through a symlinked install path (plugin-cache regression)", (t) => {
   // The real plugin cache reaches dist/cli.js through a symlinked components/ dir.
   // A resolve()-only guard compares the symlink path against import.meta.url's real
   // path and silently never runs main(). Prove the shipped dist works via a symlink.
+  // Linking the containing DIRECTORY mirrors the real cache layout more closely than
+  // a leaf file link, and a junction expresses it without elevation on Windows.
+  if (!supportsSymlinks().dir) {
+    t.skip("directory links unavailable on this host: symlinked install path not exercised");
+    return;
+  }
   const distCli = join(pluginRoot, "components", "cxc-ops", "dist", "cli.js");
   assert.ok(existsSync(distCli), "dist/cli.js must exist (run the build first)");
   const linkDir = tmp();
-  const link = join(linkDir, "cli-symlink.js");
-  symlinkSync(distCli, link);
+  symlinkDirSync(dirname(distCli), join(linkDir, "dist-symlink"));
+  const link = join(linkDir, "dist-symlink", "cli.js");
   const big = tmp();
   seedSources(big, MAP_AFFORDANCE_MIN_FILES + 2);
   const res = spawnSync(process.execPath, [link, "hook", "session-start"], {

--- a/plugins/codexclaw/components/messenger-bridge/test/telegram-adapter.test.ts
+++ b/plugins/codexclaw/components/messenger-bridge/test/telegram-adapter.test.ts
@@ -106,6 +106,20 @@ async function settle(): Promise<void> {
   await new Promise((r) => setTimeout(r, 30));
 }
 
+// Media turns (getFile + download + agent round-trip) outrun any fixed sleep on a
+// loaded CI runner, so poll for the observable outcome instead of guessing a delay.
+async function waitUntil(
+  predicate: () => boolean,
+  what: string,
+  timeoutMs = 15000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  assert.ok(predicate(), `timed out after ${timeoutMs}ms waiting for ${what}`);
+}
+
 function manualProgressClock() {
   let now = 10_000;
   let nextId = 1;
@@ -152,13 +166,7 @@ test("allowlisted message drives the agent and sends a reply", async () => {
       }),
     });
     await adapter.start();
-    // The download + agent round-trip races the fixed 30ms settle on loaded
-    // runners; poll for the observable outcome instead of sleeping. 15s covers
-    // the slowest observed CI cell (windows CRLF under load).
-    const deadline = Date.now() + 15000;
-    while (seen.length === 0 && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    await waitUntil(() => seen.length > 0, "the agent to observe the message");
     adapter.stop();
 
     assert.deepEqual(seen, ["hi there"]);
@@ -468,13 +476,16 @@ test("photo-only private message is downloaded and prefixed into the prompt", as
       }),
     });
     await adapter.start();
-    await settle();
+    await waitUntil(() => seen.length > 0, "the photo turn to reach the agent");
     adapter.stop();
 
     assert.equal(seen.length, 1);
     assert.ok(downloadedPath);
-    assert.equal(existsSync(downloadedPath), false);
-    assert.equal(existsSync(dirname(downloadedPath)), false);
+    // Cleanup runs after the agent callback resolves, so it also outlives a fixed sleep.
+    await waitUntil(
+      () => !existsSync(downloadedPath) && !existsSync(dirname(downloadedPath)),
+      "the temp media directory to be removed",
+    );
   } finally {
     await settle();
     db.close();

--- a/plugins/codexclaw/components/pabcd-state/test-support/symlink-support.ts
+++ b/plugins/codexclaw/components/pabcd-state/test-support/symlink-support.ts
@@ -1,0 +1,65 @@
+/**
+ * symlink-support.ts - shared host capability probe for the symlink guard tests.
+ *
+ * Issue #32: a stock non-admin Windows checkout cannot create symlinks, so
+ * symlinkSync threw EPERM before the refusal guards under test ever ran. Probe
+ * the host once and gate only the symlink-creating half of each case.
+ *
+ * This lives beside test/ rather than inside it: node --test treats every file
+ * under a test directory as a test file, and a helper module with no cases
+ * would report as an empty passing "test".
+ */
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface SymlinkSupport {
+  /** file -> file symlinks (needs Developer Mode or elevation on Windows) */
+  file: boolean;
+  /** directory links; junctions cover this on Windows without elevation */
+  dir: boolean;
+}
+
+/** Directory link that does not need elevation on Windows. */
+export function symlinkDirSync(target: string, path: string): void {
+  symlinkSync(target, path, process.platform === "win32" ? "junction" : "dir");
+}
+
+let symlinkProbe: SymlinkSupport | null = null;
+
+/**
+ * A denied link answers EPERM/EACCES (and UNKNOWN on some Windows filesystems).
+ * Any other failure is still treated as "unsupported" so a probe can never fail
+ * the suite on its own; the gated assertions report a skip instead.
+ */
+export function supportsSymlinks(): SymlinkSupport {
+  if (symlinkProbe) return symlinkProbe;
+  const probeDir = mkdtempSync(join(tmpdir(), "cxc-symlink-probe-"));
+  const support: SymlinkSupport = { file: false, dir: false };
+  try {
+    const target = join(probeDir, "target.txt");
+    writeFileSync(target, "probe");
+    try {
+      symlinkSync(target, join(probeDir, "file-link"), "file");
+      support.file = true;
+    } catch {
+      support.file = false;
+    }
+    const dirTarget = join(probeDir, "target-dir");
+    mkdirSync(dirTarget, { recursive: true });
+    try {
+      symlinkDirSync(dirTarget, join(probeDir, "dir-link"));
+      support.dir = true;
+    } catch {
+      support.dir = false;
+    }
+  } finally {
+    try {
+      rmSync(probeDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup of the probe dir; ignore
+    }
+  }
+  symlinkProbe = support;
+  return support;
+}

--- a/plugins/codexclaw/components/pabcd-state/test/goalplan.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/goalplan.test.ts
@@ -21,6 +21,7 @@ import {
 import { deriveSlug } from "../src/freeze.ts";
 import { parseGoalplanCliArgs, runGoalplanCli } from "../src/goalplan-cli.ts";
 import { readState } from "../src/state.ts";
+import { supportsSymlinks, symlinkDirSync } from "../test-support/symlink-support.ts";
 
 function tmp(): string {
   return mkdtempSync(join(tmpdir(), "cxc-goalplan-"));
@@ -65,7 +66,7 @@ test("030: absent or malformed -> readGoalplan returns null (never throws)", () 
   assert.equal(readGoalplan(cwd, "bad"), null);
 });
 
-test("goalplan slug is an identifier: stored traversal, mismatches, and symlink roots are rejected", () => {
+test("goalplan slug is an identifier: stored traversal, mismatches, and symlink roots are rejected", (t) => {
   const cwd = tmp();
   const plan = buildGoalplan({ objective: "safe plan", criteria: [{ scenario: "ok" }] });
   writeGoalplan(cwd, plan);
@@ -76,13 +77,23 @@ test("goalplan slug is an identifier: stored traversal, mismatches, and symlink 
   assert.throws(() => writeGoalplan(cwd, { ...plan, slug: "../../escaped" }), /invalid goalplan slug/);
   assert.equal(existsSync(join(cwd, "escaped", "goalplan.json")), false);
 
+  // The traversal assertions above already ran; only the linked-root half needs a link.
+  if (!supportsSymlinks().dir) {
+    t.skip("directory links unavailable on this host: symlinked state root not exercised");
+    return;
+  }
   const linked = tmp();
   const outside = tmp();
-  symlinkSync(outside, join(linked, ".codexclaw"));
+  symlinkDirSync(outside, join(linked, ".codexclaw"));
   assert.throws(() => writeGoalplan(linked, buildGoalplan({ objective: "linked root" })), /symlink/);
 });
 
-test("goalplan reads and ledger appends refuse symlink leaf files", () => {
+test("goalplan reads and ledger appends refuse symlink leaf files", (t) => {
+  // Leaf links must point at a FILE, so a junction cannot stand in here.
+  if (!supportsSymlinks().file) {
+    t.skip("file symlinks unavailable on this host: leaf-symlink refusal not exercised");
+    return;
+  }
   const cwd = tmp();
   const outside = join(tmp(), "outside.txt");
   writeFileSync(outside, "unchanged");

--- a/plugins/codexclaw/components/pabcd-state/test/source-receipt.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/source-receipt.test.ts
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { supportsSymlinks, symlinkDirSync } from "../test-support/symlink-support.ts";
 import { isReceiptError, parseSourceBoundReceipt } from "../src/source-receipt.ts";
 
 const IDENTITY = { kind: "resolved", commitSha: "abc1234", dirty: false, capturedAt: "2026-01-01T00:00:00.000Z" };
@@ -63,6 +64,24 @@ test("a zero-byte receipt is rejected by the evidence-root guard", () => {
   assert.match(r.error, /evidence-root guard/);
 });
 
+test("a receipt reached through a linked directory inside the evidence root is rejected", (t) => {
+  // Companion to the leaf-link case above, reaching the same realpath guard
+  // through a DIRECTORY link. Junctions need no elevation, so this half of the
+  // symlink coverage runs on a stock Windows checkout.
+  if (!supportsSymlinks().dir) {
+    t.skip("directory links unavailable on this host: linked-directory escape not exercised");
+    return;
+  }
+  const cwd = workspace();
+  const outside = mkdtempSync(join(tmpdir(), "cxc-receipt-outside-"));
+  writeFileSync(join(outside, "r.json"), JSON.stringify({ kind: "test", sourceIdentity: IDENTITY, createdAt: "x" }));
+  symlinkDirSync(outside, join(cwd, ".codexclaw", "evidence", "linked"));
+  // Lexically inside the evidence root; the realpath still lands outside it.
+  const r = parseSourceBoundReceipt(join(".codexclaw", "evidence", "linked", "r.json"), cwd, "test");
+  assert.ok(isReceiptError(r));
+  assert.match(r.error, /evidence-root guard/);
+});
+
 test("malformed JSON is rejected", () => {
   const cwd = workspace();
   const rel = writeReceipt(cwd, "bad.json", "{not json");
@@ -111,7 +130,13 @@ test("a receipt outside the evidence root is rejected", () => {
   assert.match(r.error, /evidence-root guard/);
 });
 
-test("a symlink into the evidence root is rejected", () => {
+test("a symlink into the evidence root is rejected", (t) => {
+  // The link must point at a receipt FILE, so a directory junction cannot
+  // stand in for it on an unprivileged Windows host.
+  if (!supportsSymlinks().file) {
+    t.skip("file symlinks unavailable on this host: evidence-root symlink refusal not exercised");
+    return;
+  }
   const cwd = workspace();
   const real = join(cwd, "elsewhere.json");
   writeFileSync(real, JSON.stringify({ kind: "test", sourceIdentity: IDENTITY, createdAt: "x" }));

--- a/plugins/codexclaw/components/pabcd-state/test/subagent-evidence.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/subagent-evidence.test.ts
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { supportsSymlinks, symlinkDirSync } from "../test-support/symlink-support.ts";
 
 import {
   runSubagentStopGate,
@@ -83,18 +84,35 @@ test("010: receipt pointing outside the evidence root is rejected", () => {
   assert.equal(JSON.parse(out).decision, "block");
 });
 
-test("010: symlinked receipt inside the root is rejected", () => {
+test("010: symlinked receipt inside the root is rejected", (t) => {
+  // The link target is a receipt FILE, which a directory junction cannot express.
+  if (!supportsSymlinks().file) {
+    t.skip("file symlinks unavailable on this host: leaf-symlink receipt refusal not exercised");
+    return;
+  }
   const cwd = tmp();
   const target = join(cwd, "secret.md");
   writeFileSync(target, "data");
   mkdirSync(join(cwd, ".codexclaw", "evidence"), { recursive: true });
   const link = join(cwd, ".codexclaw", "evidence", "link.md");
-  try {
-    symlinkSync(target, link);
-  } catch {
-    return; // platform without symlink perms: skip
-  }
+  symlinkSync(target, link);
   assert.equal(hasValidReceipt(cwd, ".codexclaw/evidence/link.md"), false);
+});
+
+test("010: receipt reached through a linked directory inside the root is rejected", (t) => {
+  // The realpath half of the same guard, reachable through a directory link.
+  // Junctions need no elevation, so this runs on a stock Windows checkout.
+  if (!supportsSymlinks().dir) {
+    t.skip("directory links unavailable on this host: linked-directory receipt escape not exercised");
+    return;
+  }
+  const cwd = tmp();
+  const outside = mkdtempSync(join(tmpdir(), "cxc-subev-outside-"));
+  writeFileSync(join(outside, "secret.md"), "data");
+  mkdirSync(join(cwd, ".codexclaw", "evidence"), { recursive: true });
+  symlinkDirSync(outside, join(cwd, ".codexclaw", "evidence", "linked"));
+  // Lexically inside the evidence root; the realpath lands outside it.
+  assert.equal(hasValidReceipt(cwd, ".codexclaw/evidence/linked/secret.md"), false);
 });
 
 test("010: empty receipt file is not valid", () => {

--- a/plugins/codexclaw/components/pabcd-state/test/worktree-guard.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/worktree-guard.test.ts
@@ -5,9 +5,10 @@
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join, sep } from "node:path";
+import { supportsSymlinks, symlinkDirSync } from "../test-support/symlink-support.ts";
 import {
   buildSessionStartContext,
   candidateWorktreeRoots,
@@ -152,12 +153,17 @@ test("detect: no .git entry anywhere up to slotRoot → managed but checkoutRoot
 
 // --- 2. canonicalization ------------------------------------------------------
 
-test("canonicalize: symlinked cwd resolves into the real managed path (symlink-in)", () => {
-  if (process.platform === "win32") return; // symlink privileges
+test("canonicalize: symlinked cwd resolves into the real managed path (symlink-in)", (t) => {
+  // The link target is the checkout DIRECTORY, so a junction expresses it and
+  // this case runs unprivileged on Windows instead of passing silently.
+  if (!supportsSymlinks().dir) {
+    t.skip("directory links unavailable on this host: symlink-in canonicalization not exercised");
+    return;
+  }
   const rig = makeRig();
   try {
     const link = join(rig.home, "link-checkout");
-    symlinkSync(rig.checkoutRoot, link);
+    symlinkDirSync(rig.checkoutRoot, link);
     const id = detectManagedWorktree(link, rig.env);
     assert.equal(id.managed, true);
     assert.equal(id.checkoutRoot, rig.checkoutRoot);
@@ -178,14 +184,18 @@ test("canonicalize: non-existent target resolves via nearest existing ancestor",
   }
 });
 
-test("guard: symlink pointing OUT of the slot does not leak protection or management", () => {
-  if (process.platform === "win32") return;
+test("guard: symlink pointing OUT of the slot does not leak protection or management", (t) => {
+  // Same shape: the escape hatch points at a directory, so a junction suffices.
+  if (!supportsSymlinks().dir) {
+    t.skip("directory links unavailable on this host: symlink-out leak check not exercised");
+    return;
+  }
   const rig = makeRig();
   try {
     const outside = mkdtempSync(join(tmpdir(), "cxc-wg-outside-"));
     try {
       const linkInside = join(rig.slotRoot, "escape");
-      symlinkSync(outside, linkInside);
+      symlinkDirSync(outside, linkInside);
       // lexical path is inside the slot but canonicalizes OUT: not managed
       const id = detectManagedWorktree(join(linkInside, "x"), rig.env);
       assert.equal(id.managed, false);

--- a/plugins/codexclaw/gui/src/server/middleware.ts
+++ b/plugins/codexclaw/gui/src/server/middleware.ts
@@ -21,6 +21,7 @@ import { spawnSync } from "node:child_process";
 import { splitLines } from "./text-lines.ts";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { homedir } from "node:os";
 import {
   BodyTooLargeError,
   localRequestRejection,
@@ -40,11 +41,22 @@ import {
 export function resolveProjectRoot(start: string = process.cwd(), env: NodeJS.ProcessEnv = process.env): string {
   const override = typeof env.CODEXCLAW_ROOT === "string" ? env.CODEXCLAW_ROOT.trim() : "";
   if (override.length > 0) return override;
+  // ~/.codexclaw is codexclaw's own GLOBAL store (recall index, skill cache), not a
+  // project. Without this exclusion any start dir outside a repo walks up to the
+  // filesystem root and resolves the user's entire home directory as the project.
+  // The compare is case-insensitive on win32: a start dir spelled "c:\users\me\..."
+  // walks up to "c:\users\me", which an exact compare would not match against the
+  // canonical "C:\Users\me" - and the exclusion would silently not apply.
+  const home = homedir();
+  const isHome = (candidate: string): boolean =>
+    process.platform === "win32"
+      ? candidate.toLowerCase() === home.toLowerCase()
+      : candidate === home;
   let firstCodexclaw: string | null = null;
   let dir = start;
   for (;;) {
     if (existsSync(join(dir, ".git"))) return dir;
-    if (firstCodexclaw === null && existsSync(join(dir, ".codexclaw"))) firstCodexclaw = dir;
+    if (firstCodexclaw === null && !isHome(dir) && existsSync(join(dir, ".codexclaw"))) firstCodexclaw = dir;
     const parent = dirname(dir);
     if (parent === dir) return firstCodexclaw ?? start; // filesystem root reached
     dir = parent;

--- a/plugins/codexclaw/gui/test/project-root.test.ts
+++ b/plugins/codexclaw/gui/test/project-root.test.ts
@@ -7,7 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { resolveProjectRoot } from "../src/server/middleware.ts";
@@ -57,4 +57,27 @@ test(".git outranks an intermediate .codexclaw (hook-state dirs at incidental de
   const nested = join(mid, "gui");
   mkdirSync(nested, { recursive: true });
   assert.equal(resolveProjectRoot(nested, {} as NodeJS.ProcessEnv), root);
+});
+
+test("~/.codexclaw is codexclaw's global store, not a project root", () => {
+  // A real user has ~/.codexclaw (recall index, skill cache). A start dir with no
+  // marker of its own must NOT resolve to the whole home directory just because the
+  // walk passes through it.
+  const bare = join(tmp(), "x", "y");
+  mkdirSync(bare, { recursive: true });
+  assert.notEqual(resolveProjectRoot(bare, {} as NodeJS.ProcessEnv), homedir());
+  assert.equal(resolveProjectRoot(bare, {} as NodeJS.ProcessEnv), bare);
+});
+
+test("the home exclusion survives a differently-cased path on win32", () => {
+  // Windows paths are case-insensitive, so a start dir spelled "c:\users\..." walks
+  // up to a lowercase spelling of home that an exact compare would miss.
+  if (process.platform !== "win32") return;
+  const bare = join(tmp(), "x", "y");
+  mkdirSync(bare, { recursive: true });
+  const lowered = bare.toLowerCase();
+  assert.notEqual(
+    resolveProjectRoot(lowered, {} as NodeJS.ProcessEnv).toLowerCase(),
+    homedir().toLowerCase(),
+  );
 });


### PR DESCRIPTION
Promotes `dev` to `main` for the 0.2.7 release.

## What this closes

The 11-cycle Windows/Linux optimization campaign finished its plan but left four
things that prevented shipping. All four are resolved here.

**#33 - `cxc hooks retrust` died on Windows before it could help.** The post-write
`codex features list` verification spawned a bare `codex`, which fails two separate
ways on a Codex-desktop host. The first PATH match is the Store-packaged
`WindowsApps\...\codex.EXE`; that file is readable, passes `X_OK`, and is not a
reparse point, yet `CreateProcess` still refuses it with `EPERM` - so the obvious
"skip unreadable reparse points" heuristic does not catch it. The npm shim beside it
is `codex.CMD`, which Node refuses to spawn shell-less after the CVE-2024-27980
hardening. Because verification failed for reasons unrelated to the config, a correct
write was rolled back on every run.

New `cxc-ops/src/codex-bin.ts` resolves the command before spawning it: `CODEX_BIN`
override, then a PATH/PATHEXT walk that skips WindowsApps by whole path segment, then
a caret-escaped `cmd.exe` hop. Live verification on a real Windows host:
`updated=22 appended=0`, and `cxc doctor` now reports
`[PASS] hook-trust: 22 hook hash(es) trusted`.

**#33 second half - no `[hooks.state.*]` entries after a fresh install.** Investigated
and dismissed as a codexclaw defect: nothing in this repository writes those entries.
Only the host Codex binary does, when the user approves the plugin's hooks. A silent
bootstrap would forge a trust decision the user never made, so instead `doctor`
distinguishes never-trusted from drifted and prints the exact recovery command.

**#32 - symlink guards could not run on a stock Windows checkout.** The tests died on
the `symlinkSync` that BUILT their hostile input, never reaching the guard. Several
sibling suites hid the same problem behind `if (process.platform === "win32") return`,
which reports "ok" while asserting nothing. A shared capability probe now gates only
the link-creating half, and directory cases use junctions - which need no elevation
and still report `isSymbolicLink() === true` - so most of these guards are genuinely
exercised on Windows for the first time. Only the three cases needing a link to a FILE
report a skip, with the reason stated.

**The `enforce-target` check blocked the release path it documents.** Every PR had to
target `dev` with no exemption for `dev` -> `main`, so this very PR was prefixed
`[WRONG BRANCH]` and told to retarget itself to the branch it is being promoted from.
Same-repository promotions are exempt now; a fork branch merely named `dev` is not.
The check also failed outright on a `FORBIDDEN` `convertPullRequestToDraft`, which the
default token is not always granted.

Two further defects in that repair, found by an independent audit: `botComment` was
captured once and never rebound after `createComment`, so the corrective update posted
a second comment and a later run read stale state and undrafted PRs the bot never
drafted; and `markReadyForReview()`'s result was discarded, so a refused restoration
cleared the state and announced success while the PR sat there drafted. Both fixed and
verified by `.codexclaw/wf-sim.mjs`, which runs the embedded workflow script against
mocked GitHub APIs across six scenarios. A re-auditor mutation-tested that harness with
10 injected regressions and it caught all 10.

**The red `windows-latest` CI cell.** A photo-only Telegram turn waited a fixed 30ms
for a getFile + download + agent round-trip. It polls for the observable outcome now
and fails with a named cause on timeout.

## Found while verifying

`resolveProjectRoot` treated any ancestor holding `.codexclaw/` as the project root,
and `~/.codexclaw` is codexclaw's own global store. On a real installation any start
directory outside a repository resolved the user's entire home directory as the
project. CI never caught it because runners have no `~/.codexclaw`. The comparison is
case-folded on Windows, where `c:\users\me` and `C:\Users\me` are one directory.

## Verification

Local, both platforms on Node 24:

- Native Windows: 1923 tests, 1923 pass, 0 fail, 6 skip
- WSL Ubuntu: 1923 tests, 1922 pass, 0 fail, 1 skip
- `inventory --check` OK, `gate.mjs` OK, `wf-sim.mjs` 19/19

Remote on `071eb40`: CI green on ubuntu-latest, windows-latest (both `autocrlf`
settings) and macos-latest; the WSL workflow green on both the drvfs and native-ext4
checkouts; Packed install lifecycle green on all three runners.

## Filed, not fixed here

#40 - `cxc receipt test -- npm test` hits the same Windows spawn class as #33
(`ENOENT` bare, `EINVAL` for `.cmd`), which blocks the documented C->D receipt path on
Windows. It wants the new resolver generalized past the `codex` binary, which is a
wider change than this release should carry.
