### PR TITLE
[WRONG BRANCH] fix(cxc-ops): spawn codex verifier through win-exec on Windows

### DIFF
--- a/plugins/codexclaw/components/cxc-ops/dist/hook-trust.js
+++ b/plugins/codexclaw/components/cxc-ops/dist/hook-trust.js
@@ -13,6 +13,7 @@ import {
 import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { renameWithRetry } from "./atomic-write.js";
+import { commandInvocation } from "./win-exec.js";
 
 const EVENT_LABELS = {
   PreToolUse: "pre_tool_use",
@@ -369,9 +370,18 @@ function resolvedConfigPath(configPath        )         {
 }
 
 function verifyCodexConfig(codexHome        , runner                 )       {
-  const result = runner("codex", ["features", "list"], {
+  // Windows: `codex` is an npm .cmd shim, and a bare command name skips PATHEXT
+  // resolution, so a shell-less spawn fails outright. With the Codex desktop app
+  // installed it is worse — the first `codex` on PATH is a WindowsApps
+  // app-execution alias, an unreadable reparse point that raises EPERM rather
+  // than ENOENT. Route through commandInvocation() for the same PATHEXT lookup
+  // and cmd.exe escaping doctor.ts already uses; `shell: true` is not an option
+  // because Node leaves cmd metacharacters unescaped (see win-exec.ts).
+  const invocation = commandInvocation("codex", ["features", "list"]);
+  const result = runner(invocation.file, invocation.args, {
     encoding: "utf8",
     env: { ...process.env, CODEX_HOME: codexHome },
+    ...invocation.options,
   });
   if (result.status !== 0) {
     const detail = result.error?.message ?? result.stderr?.trim() ?? `exit ${String(result.status)}`;

--- a/plugins/codexclaw/components/cxc-ops/src/hook-trust.ts
+++ b/plugins/codexclaw/components/cxc-ops/src/hook-trust.ts
@@ -13,6 +13,7 @@ import {
 import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { renameWithRetry } from "./atomic-write.ts";
+import { commandInvocation } from "./win-exec.ts";
 
 const EVENT_LABELS = {
   PreToolUse: "pre_tool_use",
@@ -83,7 +84,7 @@ interface TrustedHashLine {
 type HookTrustRunner = (
   command: string,
   args: string[],
-  options: { encoding: "utf8"; env: NodeJS.ProcessEnv },
+  options: { encoding: "utf8"; env: NodeJS.ProcessEnv; windowsVerbatimArguments?: boolean },
 ) => { status: number | null; stderr?: string; error?: Error };
 
 function assertSupportedPlatform(): void {}
@@ -369,9 +370,18 @@ function resolvedConfigPath(configPath: string): string {
 }
 
 function verifyCodexConfig(codexHome: string, runner: HookTrustRunner): void {
-  const result = runner("codex", ["features", "list"], {
+  // Windows: `codex` is an npm .cmd shim, and a bare command name skips PATHEXT
+  // resolution, so a shell-less spawn fails outright. With the Codex desktop app
+  // installed it is worse — the first `codex` on PATH is a WindowsApps
+  // app-execution alias, an unreadable reparse point that raises EPERM rather
+  // than ENOENT. Route through commandInvocation() for the same PATHEXT lookup
+  // and cmd.exe escaping doctor.ts already uses; `shell: true` is not an option
+  // because Node leaves cmd metacharacters unescaped (see win-exec.ts).
+  const invocation = commandInvocation("codex", ["features", "list"]);
+  const result = runner(invocation.file, invocation.args, {
     encoding: "utf8",
     env: { ...process.env, CODEX_HOME: codexHome },
+    ...invocation.options,
   });
   if (result.status !== 0) {
     const detail = result.error?.message ?? result.stderr?.trim() ?? `exit ${String(result.status)}`;

--- a/plugins/codexclaw/components/cxc-ops/test/hook-trust.test.ts
+++ b/plugins/codexclaw/components/cxc-ops/test/hook-trust.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../src/hook-trust.ts";
 import { runHookTrustCheck } from "../src/doctor.ts";
 import { main } from "../src/cli.ts";
+import { commandInvocation } from "../src/win-exec.ts";
 
 const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const PLUGIN_KEY = "fixture@market";
@@ -342,6 +343,30 @@ test("retrustHooks requires bootstrapOk only when no entries exist for the plugi
   assert.deepEqual(diagnoseHookTrust(home, root, PLUGIN_KEY).map((item) => item.status), ["trusted"]);
 });
 
+test("retrustHooks spawns the codex verifier through the platform invocation shape", () => {
+  const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo verify")] }] } });
+  const home = makeCodexHome('[plugins."fixture@market"]\nenabled = true\n');
+  const calls: Array<{ file: string; args: string[] }> = [];
+  const capture: HookTrustRunner = (file, args) => {
+    calls.push({ file, args });
+    return { status: 0, stdout: "", stderr: "", error: null };
+  };
+
+  retrustHooks(home, root, PLUGIN_KEY, true, capture);
+
+  assert.equal(calls.length, 1);
+  const [call] = calls;
+  // A bare "codex" here is the Windows bug: Node skips PATHEXT for bare command
+  // names and cannot spawn the npm .cmd shim shell-lessly, so retrust died with
+  // EPERM while doctor — which already routes through win-exec — kept working.
+  const expected = commandInvocation("codex", ["features", "list"]);
+  assert.equal(call.file, expected.file);
+  assert.deepEqual(call.args, expected.args);
+  if (process.platform === "win32") {
+    assert.ok(call.file !== "codex", "must not spawn a bare command name on Windows");
+  }
+});
+
 test("retrustHooks preserves a config symlink and atomically updates its resolved target", () => {
   const root = makePlugin({ hooks: { Stop: [{ hooks: [command("echo symlink")] }] } });
   const home = tempDir("cxc-hook-link-home-");
@@ -372,7 +397,8 @@ test("retrustHooks rolls back the resolved config when codex verification fails"
   };
 
   assert.throws(() => retrustHooks(home, root, PLUGIN_KEY, false, failingRunner), /codex features list verification failed/);
-  assert.deepEqual(calls, [{ command: "codex", args: ["features", "list"], codexHome: home }]);
+  const invocation = commandInvocation("codex", ["features", "list"]);
+  assert.deepEqual(calls, [{ command: invocation.file, args: invocation.args, codexHome: home }]);
   assert.equal(readFileSync(join(home, "config.toml"), "utf8"), before);
   assert.equal(diagnoseHookTrust(home, root, PLUGIN_KEY)[1].status, "untrusted");
 });


### PR DESCRIPTION
Fixes the second half of #33.

## Problem

`hooks retrust` is unusable on Windows — it fails before writing anything:

```
cxc-ops hooks retrust: codex features list verification failed: spawnSync codex EPERM
```

`verifyCodexConfig()` spawned a bare `"codex"`. Node skips PATHEXT for bare command names and refuses shell-less `.cmd` spawns after the CVE-2024-27980 hardening, so the npm shim never launches. With the Codex desktop app installed it is worse: the first `codex` on PATH is a WindowsApps app-execution alias, an unreadable reparse point, which is why this surfaces as `EPERM` rather than `ENOENT`.

`doctor.ts` already routes through `commandInvocation()`; `hook-trust.ts` did not. That asymmetry is exactly why `doctor` passes while `retrust` dies.

This is worth fixing because hook trust is currently never registered at install time on Windows (#33, Bug A — likely Codex-side), which makes `retrust` the only recovery path. With it broken, affected users have no way out at all.

## Change

Route the verifier spawn through the existing `win-exec.ts` helper and widen `HookTrustRunner` to carry `windowsVerbatimArguments`.

Deliberately **not** `shell: true` — `win-exec.ts` documents why (Node leaves cmd metacharacters unescaped, so a path containing `&` or `^` becomes command injection).

`dist/hook-trust.js` is regenerated via `scripts/build.mjs` since build output is checked in.

## Verification

End-to-end against a **sandboxed** `CODEX_HOME` (a temp copy, not the real one), with no PATH workaround:

```
updated=22 appended=0
backup: ...\Temp\cxc-verify-a1c166c9\config.toml.bak-...
```

Before this change the identical command failed with `spawnSync codex EPERM`.

Tests:

- Added `retrustHooks spawns the codex verifier through the platform invocation shape`, which asserts the spawn matches `commandInvocation()` and, on Windows, never spawns a bare command name. It fails against the old code.
- Updated the existing rollback test, which hard-coded `command: "codex"` and so encoded the bug.
- `cxc-ops` suite: 157 pass / 3 fail on this branch vs 156 pass / 3 fail on `main`. The 3 failures are identical on both and are pre-existing symlink tests that need Windows Developer Mode (`EPERM: symlink`) — unrelated to this change.
- `scripts/gate.mjs`: OK.

Verified only on Windows 11 / Node v24.15.0. `commandInvocation()` is a passthrough on POSIX, so non-Windows behavior is unchanged by construction, but a CI run would confirm.

## Note

`retrust` is not mentioned in the docs, so a Windows user hitting this has no way to discover the recovery command exists. Happy to add a troubleshooting line in a follow-up if you want it.
