### PR TITLE
release(0.2.8): version bump for the #40 receipt fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to codexclaw are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.2.8] — 2026-08-22
+
+### Fixed
+
+- **`cxc receipt test` could not run `npm` on Windows (#40).** The receipt runner
+  handed user argv to a shell-less `spawnSync`, so bare `npm` was `ENOENT`
+  (PATHEXT resolution is a shell behavior `spawnSync` does not perform) and an
+  explicit `npm.cmd` was `EINVAL` (Node refuses shell-less `.cmd` spawns after
+  the CVE-2024-27980 hardening). That matters more than a normal CLI papercut:
+  `orchestrate C -> D` requires a `testReceiptPath` and names this command as the
+  way to produce one, so the documented path to close a work-phase did not work
+  on Windows for the most common test command there is.
+
+  The runner now resolves through the shared `win-exec` helper, which routes only
+  `.cmd`/`.bat` through a caret-escaped `ComSpec` line and spawns a resolved
+  `.exe` directly. `shell: true` was deliberately not used: the command is
+  user-supplied, and Node does not escape cmd metacharacters in that mode, so a
+  path containing `&` or `^` would become an injection. `shell: false` still
+  holds, and the recorded command stays the argv you typed.
+
+- **A Windows PATH was split with the host's separator.** `resolveWindowsCommand`
+  used `node:path`'s `delimiter`, which follows the platform it runs on. When the
+  win32-only resolution walk was exercised from a Linux runner that is `:`, so a
+  `;`-separated Windows PATH collapsed into a single bogus directory entry and
+  resolved nothing. The separator is literal now, and a test asserts that the four
+  copies of the helper stay byte-identical so they cannot drift apart silently.
+
+## [0.2.7] — 2026-08-22
+
 ### Fixed
 
 - **`cxc hooks retrust` could not verify its own write on Windows (#33).** The

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.1.1",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI — status, subagent config, provider toggle, GUI launcher.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.7+codex.20260818121334",
+  "version": "0.2.8+codex.20260818121334",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI — doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge — cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/pabcd-state/test/crlf-inputs.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/crlf-inputs.test.ts
@@ -125,8 +125,18 @@ test("review-round-cli reads a CRLF config.toml the same as an LF one", () => {
   const toml = "[features.multi_agent_v2]\nenabled = true\n";
   const lf = dispatchTextWithConfig(toml, "crlf-lf");
   const crlf = dispatchTextWithConfig(toml.replace(/\n/g, "\r\n"), "crlf-crlf");
-  const tail = (text: string): string => text.split("\n").slice(1).join("\n");
+  // The LAUNCH token embeds a second-resolution timestamp, so two calls that
+  // straddle a second boundary differ by one digit for a reason that has nothing
+  // to do with line endings. Assert its SHAPE, then compare the rest.
+  const LAUNCH = /^ {2}LAUNCH: \w+-\d{14}$/m;
+  const tail = (text: string): string =>
+    text.split("\n").slice(1).join("\n").replace(LAUNCH, "  LAUNCH: <id>");
   assert.match(tail(lf), /agent_type explorer/, "LF baseline detects the v2 surface");
+  assert.match(
+    crlf.split("\n").slice(1).join("\n"),
+    LAUNCH,
+    "the CRLF run still emits a launch id",
+  );
   assert.equal(tail(crlf), tail(lf), "CRLF must produce the same dispatch text");
 });
 

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.1.1",
+  "version": "0.2.8",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) — subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.7+codex.20260818121334",
-    "packageVersion": "0.2.7"
+    "manifestVersion": "0.2.8+codex.20260818121334",
+    "packageVersion": "0.2.8"
   },
   "skills": [
     {
@@ -257,49 +257,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "hasTests": true
     }
   ]


### PR DESCRIPTION
0.2.7 shipped before the #40 receipt-spawn fix landed, so that work needs its own release. Every surface check-versions.mjs inspects moves to 0.2.8, the published test count moves to 1930, and the changelog entries written during the closeout are split between the 0.2.7 section that actually shipped them and a new 0.2.8 section for #40.