### PR TITLE
test(messenger-bridge): report POSIX-only cases as skips, not silent passes

### DIFF
--- a/devlog/_plan/260822_win_closeout/060_release.md
+++ b/devlog/_plan/260822_win_closeout/060_release.md
@@ -52,3 +52,36 @@ and the evidence-root realpath coverage from the symlink sweep). Badges regenera
 | WSL workflow (drvfs + native ext4) | green |
 | Packed install lifecycle | green on all three runners |
 | release gate | passed, published |
+
+# 061 - the 0.2.8 follow-on
+
+0.2.7 shipped before the #40 receipt fix existed, so that work needed its own
+release. 0.2.8 carries it: every version surface bumped, the published test count
+moved to 1930, and the changelog split between the 0.2.7 section that actually
+shipped those entries and a new 0.2.8 section.
+
+## One more defect the WSL lane caught
+
+PR #43's WSL job failed on a test that has nothing to do with the change:
+
+```
++   '  LAUNCH: r1-20260822102332
+-   '  LAUNCH: r1-20260822102331
+AssertionError: CRLF must produce the same dispatch text
+```
+
+"review-round-cli reads a CRLF config.toml the same as an LF one" calls the CLI
+twice and compares the outputs verbatim, but the dispatch text embeds a LAUNCH id
+built from a second-resolution timestamp. Whenever the two calls straddle a second
+boundary the ids differ by one digit and the test fails for a reason unrelated to
+line endings. It passed locally on both Windows and WSL because the two calls
+usually land in the same second; a loaded CI runner is where the boundary gets
+crossed.
+
+The launch line is asserted by SHAPE and normalized before the comparison, so the
+CRLF-vs-LF equivalence the test exists to prove is still checked while the clock is
+not. 12 consecutive local runs pass, and the WSL lane went green.
+
+## Final state
+
+`v0.2.8` is the latest release. Zero open issues.

--- a/plugins/codexclaw/components/messenger-bridge/test/runner.test.ts
+++ b/plugins/codexclaw/components/messenger-bridge/test/runner.test.ts
@@ -228,8 +228,12 @@ test("runTurn: an oversized tool record does not suppress the later final messag
   });
 });
 
-test("runTurn: timeout kills a process group after the direct child has exited", async () => {
-  if (process.platform === "win32") return;
+// Process groups and signal-0 liveness probes are POSIX concepts; Windows kills a
+// tree with taskkill /T instead, which terminate-child.test.ts covers. Report the
+// gap as a skip rather than returning early, which would pass while asserting nothing.
+test("runTurn: timeout kills a process group after the direct child has exited", {
+  skip: process.platform === "win32" ? "POSIX process groups; Windows tree-kill is covered by terminate-child.test.ts" : false,
+}, async () => {
   const dir = mkdtempSync(join(tmpdir(), "cxc-runner-pgid-"));
   const pidFile = join(dir, "pid");
   const previous = process.env.FAKE_CODEX_PID_FILE;

--- a/plugins/codexclaw/components/messenger-bridge/test/token-intake.test.ts
+++ b/plugins/codexclaw/components/messenger-bridge/test/token-intake.test.ts
@@ -52,8 +52,12 @@ test("readTokenFromFile: reads and removes owner-only file", () => {
   }
 });
 
-test("readTokenFromFile: rejects world-readable file on Unix", () => {
-  if (process.platform === "win32") return;
+// Windows has no Unix permission bits, so chmod cannot construct the hostile input
+// this case needs. A skip states that; an early return would report ok while
+// asserting nothing.
+test("readTokenFromFile: rejects world-readable file on Unix", {
+  skip: process.platform === "win32" ? "no Unix permission bits on Windows: the world-readable refusal cannot be constructed" : false,
+}, () => {
   const dir = mkdtempSync(join(tmpdir(), "cxc-token-"));
   try {
     const path = join(dir, "token");


### PR DESCRIPTION
Two cases bailed with a bare 'if (process.platform === win32) return', which reports ok on Windows while asserting nothing - the same pattern the #32 sweep removed from the pabcd-state and cxc-ops suites.

Neither can genuinely run on Windows, and that is fine: process groups and a signal-0 liveness probe are POSIX concepts (Windows kills a tree with taskkill /T, which terminate-child.test.ts already covers), and Windows has no Unix permission bits, so chmod cannot build the world-readable file the refusal test needs. They now say so through node:test's skip reason instead of pretending to have passed.

Verified through the repaired receipt runner on Windows: 1930 tests, 1922 pass, 0 fail, 8 skip.