### PR TITLE
release(0.2.10): ship the release and verification guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to codexclaw are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.2.10] — 2026-08-22
+
+### Added
+
+- **A release guide.** The promotion path from `dev` to `main`, what the release
+  gate actually checks, and two traps that only show up once: a failed release
+  leaves a tag a repository ruleset forbids reusing, and a change to the
+  target-branch workflow cannot vouch for its own promotion because
+  `pull_request_target` always runs the base branch's copy.
+
+### Changed
+
+- **The build-test guide said "Node 22+".** CI pins 24, and Node 22 does not strip
+  TypeScript types without a flag, so `npm test` under it fails on every file at
+  once with `ERR_UNKNOWN_FILE_EXTENSION` - a version mismatch that reads like a
+  catastrophically broken tree. The guide now names the version, the symptom, what
+  the two CI lanes cover, and the defect classes that only appear on a real
+  installation rather than a runner.
+
+### Fixed
+
+- **A test harness turned a failed port bind into a routing bug.** The bridge
+  server harness fell back to port 0 when `address()` came back unusable, so the
+  failure surfaced several assertions later as `fetch failed: bad port`. It throws
+  at the bind now, naming what happened.
+
 ## [0.2.9] — 2026-08-22
 
 ### Changed

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI — status, subagent config, provider toggle, GUI launcher.",

--- a/devlog/_plan/260822_win_closeout/070_verification_notes.md
+++ b/devlog/_plan/260822_win_closeout/070_verification_notes.md
@@ -1,0 +1,49 @@
+# 070 - what dual-platform verification actually costs
+
+Notes from running this campaign's checks on a real Windows host and a real WSL
+distro, kept because each one cost time to discover.
+
+## Node version is not incidental
+
+CI pins Node 24. The host's PATH `node` was 22.14, which does not strip TypeScript
+types without a flag, so `npm test` failed on EVERY file with
+`ERR_UNKNOWN_FILE_EXTENSION: Unknown file extension ".ts"`. That looks like a
+catastrophic breakage and is actually a version mismatch. The same applied inside
+WSL, where the distro's `node` was also 22.
+
+Use the Node the CI matrix uses before concluding anything about a red suite.
+
+## The two WSL checkouts are not interchangeable
+
+The WSL workflow deliberately tests twice: once on `/mnt/c` (drvfs) and once on
+native ext4. They are different filesystems with different locking and permission
+behavior, and the doctor is expected to TELL THEM APART. A green run on one says
+nothing about the other.
+
+## Some failures are the host, not the tree
+
+Three classes showed up locally that CI cannot reproduce:
+
+- `~/.codexclaw` exists on a real installation and does not exist on a runner. That
+  difference hid a production bug where the GUI resolved the user's entire home
+  directory as the project root - green in CI, red locally.
+- Symlink creation needs elevation on Windows. Junctions do not, which is why most of
+  the guards could be converted to run rather than skip.
+- The WindowsApps `codex.EXE` alias only exists where the Codex desktop app is
+  installed, which is exactly the population that hit #33.
+
+A runner-only verification story would have missed all three.
+
+## Flakes hide behind "unrelated"
+
+Two failures during this campaign looked unrelated to the change under test and were
+real defects in the tests themselves:
+
+- A CRLF equivalence test compared a second-resolution timestamp across two CLI
+  calls. It only fails when the calls straddle a second boundary, which a loaded CI
+  runner does and a developer machine usually does not.
+- The bridge server harness fell back to port 0 when `address()` came back unusable,
+  so a failed bind surfaced several assertions later as `fetch failed: bad port` and
+  read like a routing bug. It now throws at the bind.
+
+Neither was caused by the work in flight, and both would have kept costing time.

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -94,6 +94,7 @@ export default defineConfig({
           items: [
             { label: "Dogfood & Dev Symlink", slug: "development/dogfood-dev-symlink" },
             { label: "Build & Test", slug: "development/build-test" },
+            { label: "Cutting a Release", slug: "development/release" },
             { label: "Parity Roadmap", slug: "development/parity-roadmap" },
           ],
         },

--- a/docs-site/src/content/docs/development/build-test.md
+++ b/docs-site/src/content/docs/development/build-test.md
@@ -44,5 +44,33 @@ transition records the test tail and a zero exit code as evidence — see the
 
 ## Node version
 
-Use Node.js 22+. The build relies on built-in TypeScript type stripping, and the hooks and CLI
-run under `node` directly.
+Use Node.js 24, which is what the CI matrix pins. The build and the suite rely on built-in
+TypeScript type stripping, and the hooks and CLI run under `node` directly.
+
+Node 22 does not strip types without an explicit flag, so running `npm test` under it fails on
+every file at once:
+
+```
+TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
+```
+
+That is a version mismatch, not a broken tree. Check `node --version` before investigating a
+suite that appears to have failed everywhere, including inside WSL, where the distro's `node`
+is often older than the one on the Windows side.
+
+## Verifying on Windows and WSL
+
+Cross-platform behavior is covered by two workflows, and both matter:
+
+- `ci.yml` runs ubuntu-latest, macos-latest, and windows-latest twice - once with
+  `core.autocrlf=false` and once with `true`, because a default Windows git install sets
+  `true` and that is the configuration that turns CRLF-safe-today readers into broken ones.
+- `wsl.yml` runs a real WSL2 distro twice: once on the `/mnt/c` drvfs checkout and once on
+  native ext4. Those are different filesystems with different locking and permission behavior,
+  so a green run on one says nothing about the other.
+
+Some defects only appear on a real installation. `~/.codexclaw` (the global recall index and
+skill cache) exists on a developer machine and not on a runner, symlink creation needs elevation
+on Windows while junctions do not, and the Store-packaged `codex` alias only exists where the
+Codex desktop app is installed. If you are chasing a Windows report, reproduce it on a Windows
+host rather than trusting a green matrix.

--- a/docs-site/src/content/docs/development/release.md
+++ b/docs-site/src/content/docs/development/release.md
@@ -1,0 +1,67 @@
+---
+title: Cutting a Release
+description: The promotion path from dev to main, what the release gate checks, and the traps that only show up once.
+---
+
+`dev` is the integration branch. `main` moves by maintainer promotion and carries
+releases. Every release is a `dev` -> `main` pull request followed by a run of the
+Release workflow.
+
+## The path
+
+1. Land the work on `dev` and let CI, WSL and Packed install lifecycle go green on
+   that exact commit. The release gate reads conclusions by SHA, so a green run from
+   a neighbouring commit does not count.
+2. Bump every version surface. `check-versions.mjs` enumerates them:
+   `package.json`, the plugin manifest, every component and workspace package, and
+   the two inventory fields. The manifest and inventory may carry `+codex.<stamp>`
+   build metadata; the others may not.
+3. Regenerate the inventory with the measured test count:
+   `node plugins/codexclaw/scripts/inventory.mjs --write --tests <n>`. Take `<n>`
+   from the `tests` line of a real run, not `pass` - CI skips the repo-map live
+   smoke, so `pass` is environment-dependent while `tests` is not.
+4. Open the promotion PR from `dev` to `main` and merge it once checks are green.
+5. Run the Release workflow against `main`.
+
+## What the gate actually checks
+
+`cxc release verify` fails closed. It wants the exact-SHA conclusions of the other
+workflows, a suite measured in the same run, the inventory hash the docs were
+generated from, and the packed-install lifecycle. It is worth trusting: during the
+0.2.7 campaign it refused three times, and every refusal was a real mismatch rather
+than gate noise.
+
+The two you will meet most often:
+
+```
+- platform-ci is missing
+- published tests=1901 but the measured suite reported 1924
+```
+
+The first means the other workflows have not finished on this SHA. The second means
+step 3 was skipped or the count moved after it - adding tests during a release cycle
+is normal, so re-measure and regenerate rather than editing the badge by hand.
+
+## Two traps worth knowing before you hit them
+
+**A failed release leaves a tag you cannot reuse.** A repository ruleset forbids
+force-updating and deleting version tags, so if a release attempt fails after the tag
+is pushed, that tag stays pinned to the commit that failed. Retagging is not an
+option. Run the Release workflow through `workflow_dispatch` against `main`
+instead of the `push: tags` trigger, which is what `v0.2.7` had to do.
+
+**A workflow change cannot vouch for its own promotion.** The `enforce-target` check
+runs on `pull_request_target`, which always executes the workflow file from the BASE
+branch. So a PR that changes that workflow is still judged by `main`'s old copy, and
+the first promotion after such a change can never benefit from it. Merge that one with
+`--admin`; the next promotion is the real confirmation.
+
+## Promotions are exempt from the target-branch rule
+
+`enforce-target` requires PRs to target `dev`, with one exemption: a `dev` -> `main`
+PR from this repository. A fork branch merely named `dev` is not exempt, since the
+check compares `head.repo.full_name`.
+
+If the token cannot draft a PR, the check warns instead of failing - the title prefix
+and the explanatory comment are the enforcement that matters, and a permission the
+repository never granted should not turn into a red check.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.9+codex.20260818121334",
+  "version": "0.2.10+codex.20260818121334",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI — doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge — cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/messenger-bridge/test/server.test.ts
+++ b/plugins/codexclaw/components/messenger-bridge/test/server.test.ts
@@ -26,9 +26,20 @@ async function startHarness(withGui = true, controller?: BridgeControllerLike, r
   }
   const db = openBridgeDb(cwd);
   const server = createBridgeServer({ db, cwd, guiDir, version: "0.1.0-test", controller, readmePath });
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
   const address = server.address();
   const port = typeof address === "object" && address ? address.port : 0;
+  // Falling back to 0 turns a failed bind into "fetch failed: bad port" several
+  // assertions later, which reads like a routing bug. Say what actually happened.
+  if (port === 0) {
+    throw new Error(`bridge server did not bind an ephemeral port (address: ${JSON.stringify(address)})`);
+  }
   return { cwd, db, server, base: `http://127.0.0.1:${port}` };
 }
 

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) — subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.9+codex.20260818121334",
-    "packageVersion": "0.2.9"
+    "manifestVersion": "0.2.10+codex.20260818121334",
+    "packageVersion": "0.2.10"
   },
   "skills": [
     {
@@ -257,49 +257,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasTests": true
     }
   ]


### PR DESCRIPTION
Adds a release guide (the promotion path, what the release gate checks, and two traps that only show up once), corrects the build-test guide's Node version claim from 22+ to the 24 that CI pins, and fixes a test harness that turned a failed port bind into what looked like a routing bug.

Every version surface moves to 0.2.10.