### PR TITLE
fix: Windows attest parity, plus issues #47, #48 and #49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ All notable changes to codexclaw are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.2.11] — 2026-08-22
+
+### Fixed
+
+- **codexclaw told Windows agents to run a command that cannot work.** Every
+  agent-facing surface handed out inline `--attest '<json>'`. PowerShell strips
+  the quotes from a single-quoted argument, and escaping them ends the quoted
+  span so the value splits at its first space — and every gated edge requires a
+  `did` narrative, which always contains spaces. There is no inline spelling
+  that works, so an agent following the instruction concludes the FSM is broken.
+
+  Two surfaces (`--help` and the Stop next-command) were already platform-aware,
+  which is what made the rest easy to overlook. Now fixed:
+
+  - the arming mandate injected at **prompt time**, which handed a failing
+    command to every agent starting loop work before it had run anything
+  - the goal-continuation Stop block, a sibling of the surface already fixed
+  - the `P -> A` plan-unit rejection, on the most-traveled gated edge
+  - the interview-override rejection, reached exactly when an agent is stuck
+  - the `pabcd`, `loop` and `interview` skills, which taught the inline form
+    as the grammar
+
+  Windows now gets the write-then-attest recipe: `'<json>' | Set-Content
+  -Encoding utf8 .codexclaw/attest.json` then `--attest-file`. POSIX output is
+  unchanged, pinned by a literal snapshot test.
+
+### Changed
+
+- `handleUserPromptSubmit`, `handleStop` and `buildGoalIdleBlock` take an
+  injected `platform`, so Linux CI exercises the win32 branches rather than
+  leaving them untested.
+- A continuation test asserted `/--attest/`, which is a prefix of
+  `--attest-file` and therefore passed on Windows no matter what the code did.
+  It now pins the POSIX form, with a sibling case for win32.
+
 ## [0.2.10] — 2026-08-22
 
 ### Added

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C930_passing-brightgreen" alt="1,930 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C933_passing-brightgreen" alt="1,933 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C930_passing-brightgreen" alt="1,930 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C933_passing-brightgreen" alt="1,933 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-1%2C930_passing-brightgreen" alt="1,930 tests passing">
+  <img src="https://img.shields.io/badge/tests-1%2C933_passing-brightgreen" alt="1,933 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-22-blue" alt="22 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI — status, subagent config, provider toggle, GUI launcher.",

--- a/devlog/_plan/260822_attest_win_parity/000_plan.md
+++ b/devlog/_plan/260822_attest_win_parity/000_plan.md
@@ -1,0 +1,209 @@
+# 000 - attest instruction parity on Windows
+
+## The defect
+
+codexclaw tells Windows agents to run a command that cannot work.
+
+```
+cxc orchestrate A --session <id> --attest '{"from":"P","to":"A","did":"wrote the plan"}'
+-> orchestrate A: ...; attest JSON is not valid JSON
+```
+
+Measured cause (filed upstream as fuck-powershell#6): PowerShell strips the quotes
+from a single-quoted argument, so the CLI receives `{from:P,to:A,did:wrote the plan}`.
+Escaping the quotes appears to fix it and then splits the argument at the first
+space inside a value. There is no inline form that survives a `did` field, which
+is mandatory on every gated edge.
+
+## What is already correct
+
+- `renderOrchestrateHelp` (orchestrate-cli.ts:152) branches on platform.
+- `stopNextCommand` (hook.ts:1019) rewrites the Stop-reason command for win32.
+- `attest.ts:173` already leads with `--attest-file <path> (required on Windows)`
+  and is the wording to mirror elsewhere.
+
+An earlier draft of this doc claimed "the Stop hook is honest" as a blanket
+statement. An audit disproved it: `buildGoalIdleBlock` is also a Stop surface and
+is NOT platform-aware. `stopNextCommand` being fixed says nothing about its
+neighbours.
+
+## What is wrong
+
+| surface | line | what it says |
+|---|---|---|
+| `LOOP_ARM_DIRECTIVE` | hook.ts:469 | "Advance EVERY forward edge yourself with `cxc orchestrate <phase> --attest <json>`" |
+| `pabcd/SKILL.md` | 49, 99 | grammar and instruction both spell only `--attest <json>` |
+| `loop/SKILL.md` | 28 | "carrying the phase's real artifact" via `--attest <json>` |
+| `interview/SKILL.md` | 64, 142, 178 | three inline `--attest '{...}'` override examples |
+| `scan-cli.ts` | 134 | emits a runnable inline command in a user-facing error |
+| `buildGoalIdleBlock` | hook.ts:1132 | Stop block hands the agent an inline `--attest` P command |
+| `plan-gate.ts` | 41 | P->A rejection tells you to re-attest with an inline command |
+
+`plan-gate.ts:41` is the most-traveled of them all: it fires on the P->A gate,
+reached from both `hook.ts:70` and `orchestrate-cli.ts:393`. A second sweep
+missed it because the string is split across a `+` concatenation with an escaped
+quote, so `rg -F -e "--attest '"` cannot see it. Found by the round-2 auditor.
+
+Confirmed clean and needing no change: `map-affordance.ts:182` and
+`idle-edit.ts:55` mention `--attest` with no JSON literal;
+`orchestrate-grammar.ts` parses chat grammar, not a shell surface.
+
+The last two were MISSED by the first draft of this plan and found by a
+completeness sweep (`rg -l -F -e "--attest '"`). `scan-cli.ts:134` is the more
+serious of the two: it is not documentation, it is a runtime error message
+handing the user a command to copy, and on Windows that command fails.
+
+`attest.ts:173` already says "(required on Windows)" next to `--attest-file`, so
+it is correct and is the wording to mirror elsewhere.
+
+`LOOP_ARM_DIRECTIVE` is the worst of them because it is **injected at prompt
+time** by the UserPromptSubmit hook. Every agent starting loop work on Windows is
+handed a command that will fail, before it has run anything.
+
+This is not hypothetical: this session hit it, concluded the FSM was broken,
+and spent a cycle proving otherwise.
+
+## MODIFY map
+
+### 1. `components/pabcd-state/src/hook.ts` - LOOP_ARM_DIRECTIVE (:458)
+
+The constant is a plain `string`. Make it a function of platform, mirroring
+`stopNextCommand`, which keeps its table private and exports ONLY the function.
+
+BEFORE (:458)
+```ts
+export const LOOP_ARM_DIRECTIVE = [ ... ].join("\n");
+```
+
+AFTER
+```ts
+export function loopArmDirective(platform: NodeJS.Platform = process.platform): string
+```
+
+**No compatibility binding.** An earlier draft proposed keeping
+`export const LOOP_ARM_DIRECTIVE = loopArmDirective("linux")`. The audit
+rejected it and was right: there are zero out-of-tree importers, so it buys no
+compatibility, and it would permanently freeze a caller to POSIX text on Windows
+- reintroducing the exact bug being fixed. The single call site at :603 moves to
+the function.
+
+Step 4 gains a win32 branch naming the two-step recipe.
+
+### 2. `skills/pabcd/SKILL.md`
+
+Line 49 grammar gains the alternative; line 99 gains a Windows note. The skill is
+read by the agent, so the note must be short and imperative, not a discussion.
+
+### 3. `skills/loop/SKILL.md`
+
+Line 28 gains the same alternative.
+
+### 4. `skills/interview/SKILL.md`
+
+Three override examples at 64, 142 and 178. These teach the `override` escape
+hatch, which is exactly the moment a stuck agent reaches for them - so a form
+that fails on Windows is worst here.
+
+### 5. `components/pabcd-state/src/scan-cli.ts` - line 134
+
+A runtime error string. Make it platform-aware the same way `attest.ts:173`
+already is, or point at `--attest-file` unconditionally since that form works
+everywhere.
+
+### 6. `components/pabcd-state/src/hook.ts` - buildGoalIdleBlock (:1132)
+
+The line offering `cxc orchestrate P --session <id> --attest '{...}'` degrades
+exactly like the directive - the probe shows it arriving as
+`{from:IDLE,to:P,evidence:<diff-level plan...>}`. It needs the same treatment,
+which means `buildGoalIdleBlock` takes a `platform` parameter.
+
+### 7. `npm run build`
+
+`dist/` is committed and `test/dist-freshness.test.mjs:28` fails on src/dist
+drift. Editing only `src/` ships nothing and reddens CI. The installed payload
+at `~/.codex/plugins/cache/.../dist/hook.js:469` still carries the stale line,
+which is what produced the bad directive in this very session.
+
+### 8. `components/pabcd-state/src/plan-gate.ts` - line 41
+
+Same treatment as `scan-cli.ts`. Point at `--attest-file` unconditionally, since
+that form is correct on every platform.
+
+## TESTS
+
+Platform is INJECTED, so Linux CI drives the win32 branch. That is this repo's
+stated convention (`atomic-write.test.ts:4`), and the reason a
+"assert whatever is right for the host" test would be worthless: the CI matrix is
+mostly Linux, so the win32 path would never execute.
+
+1. `loopArmDirective("win32")` contains `--attest-file`, does NOT contain
+   `--attest <json>`, AND carries the two-step `Set-Content` recipe - the payload
+   an agent actually needs. A negative assertion alone would pass on text that is
+   merely different rather than correct; `orchestrate-cli.test.ts:161` pairs its
+   negative with a positive for the same reason.
+2. `loopArmDirective("linux")` equals a **literal snapshot** of today's text,
+   pinned in the test file.
+
+   An earlier draft proposed asserting `loopArmDirective("linux") === LOOP_ARM_DIRECTIVE`
+   while DEFINING the constant as `loopArmDirective("linux")`. That compares a
+   value to itself and passes no matter how badly the POSIX text is mangled - it
+   is a tautology, and it was the one guarantee the plan was selling. Caught by
+   audit. The snapshot must be literal text in the test.
+3. `buildGoalIdleBlock` with `platform: "win32"` does not emit an inline
+   `--attest '` and DOES emit the write-then-attest pair; with `"linux"` it still
+   emits the inline form.
+4. `handleUserPromptSubmit` gains platform injection so the directive it renders
+   is testable end to end rather than only at the helper.
+5. `hook.test.ts:296` (`/--attest <json>/`) is retargeted rather than deleted -
+   it becomes the POSIX-branch assertion.
+6. `hook-continuation.test.ts:441` asserts
+   `/cxc orchestrate P --session gi1 --attest/` and breaks on Windows once item 6
+   lands. Retarget it the same way. Missed by the first TESTS draft, which named
+   only `hook.test.ts:296`.
+7. `plan-gate.ts`'s rejection string is asserted somewhere - locate and retarget
+   before editing, rather than discovering it in CI.
+
+Signature note: `buildGoalIdleBlock(cwd, state, sessionId)` already takes three
+positional arguments at its call site, so `platform` must be a fourth OPTIONAL
+parameter or the existing call silently shifts.
+
+Note `stopNextCommand` currently has NO test. The pattern being copied is itself
+unverified, so this unit adds one for it too.
+
+## Verified precondition
+
+The recipe the fix points at was executed end to end before writing this plan:
+`Set-Content -Encoding utf8` writes a UTF-8 BOM (`head=efbbbf7b2266726f`), and
+the CLI reads it correctly - `orchestrate-cli.test.ts` already has a BOM
+tolerance case. So the recommendation is safe to make.
+
+## Audit record
+
+Round 1 returned VERDICT: fail with a P0 and three P1s. All were accepted:
+
+- P0 the POSIX-parity test was a tautology -> now a literal snapshot.
+- P1 three surfaces missed (`buildGoalIdleBlock`, `scan-cli.ts`,
+  `interview/SKILL.md`) -> added to the MODIFY map.
+- P1 no dist rebuild step -> added as item 7.
+- P1 the compat binding was the wrong shape -> dropped entirely.
+- P2 platform should be injected so Linux CI drives the win32 branch -> adopted.
+- P2 stale line reference `:455` -> corrected to `:458`.
+
+The auditor also reproduced both failure modes independently with the argv probe,
+confirming quote-stripping (`argc=2`) and space-splitting (`argc=4`).
+
+Round 2 returned VERDICT: near-pass (blockers=4 folded):
+
+- P1 `plan-gate.ts:41`, a fourth runtime emitter invisible to a `-F` sweep
+  because the string is concatenated -> added as MODIFY item 8.
+- P1 `hook-continuation.test.ts:441` would break unannounced -> added to TESTS.
+- P2 win32 assertions were negative-only -> now assert the recipe is present.
+- P2 `docs-site` ships five inline examples with no Windows note
+  (`quickstart.md:22,30,38,46,56`, `guides/pabcd.md:36,42`, `index.mdx:175`,
+  `reference/commands.md:62`) -> deferred to a follow-up unit; they are published
+  docs rather than a runtime failure, and folding a docs-site pass into this unit
+  would widen it past the code fix.
+
+The auditor also confirmed dropping the const is safe: three code references, all
+inside `hook.ts`, no barrel re-export, and `hook.test.ts` asserts on rendered
+output rather than importing it.

--- a/devlog/_plan/260822_pabcd-transition-selftest/000_plan.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/000_plan.md
@@ -1,0 +1,30 @@
+# 000 — pabcd-transition-selftest: Plan
+
+> DIFFLEVEL-ROADMAP-01: write this doc to full diff-level precision (exact paths,
+> NEW/MODIFY/DELETE, before/after diffs) BEFORE P -> A. An empty scaffold does not
+> satisfy the rule; the A-phase reviewer FAILS outline-only phase docs.
+
+## Objective
+
+Verify the persisted PABCD FSM transitions end-to-end in session 01a02962:
+IDLE -> P -> A -> B -> C -> D -> IDLE, including negative gate tests
+(no-attest rejection on gated edges). Evidence: per-edge exit codes and output.
+
+## Loop-spec
+
+- Loop archetype: verifier-defined
+- Write scope: devlog/_plan/260822_pabcd-transition-selftest/ only (no source changes)
+- Out-of-scope: any src/ edits
+- Budget / bounds: single cycle, this turn
+
+## Work-phase map (one phase = one full PABCD cycle)
+
+| WP | Doc | Slice | Depends on |
+|----|-----|-------|------------|
+| wp1 | 010_phase1.md | run one full FSM cycle and record each edge result | - |
+
+## Accept criteria
+
+- Each edge P->A, A->B, B->C, C->D returns exit 0 with correct phase echo
+- Gated edge without attest returns exit 1 with actionable error
+- Final state after D is IDLE

--- a/devlog/_plan/260822_pabcd-transition-selftest/010_phase1.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/010_phase1.md
@@ -1,0 +1,25 @@
+# 010 — Phase 1 (pabcd-transition-selftest)
+
+> DIFFLEVEL-ROADMAP-01: write this doc to full diff-level precision (exact paths,
+> NEW/MODIFY/DELETE, before/after diffs) BEFORE P -> A. An empty scaffold does not
+> satisfy the rule; the A-phase reviewer FAILS outline-only phase docs.
+
+## MODIFY / NEW / DELETE map
+
+(fill in: exact file paths with before/after diffs — a copy-paste-executable PRD)
+
+## TESTS
+
+- Negative: orchestrate A without --attest must exit 1 (already observed)
+- Positive: each attested edge exits 0 and echoes the correct from/to phases
+
+Edge attests:
+- P->A: did="wrote plan docs to diff level", planUnit=devlog/_plan/260822_pabcd-transition-selftest, workPhaseId=wp1
+- A->B: did="audited plan docs, scope ok"
+- B->C: did="docs-only build, nothing to compile"
+- C->D: did="verified per-edge exit codes"
+
+## Verification (C)
+
+- cxc orchestrate status --session <id> => phase matches the last completed edge
+- After D: phase=IDLE, exit 0

--- a/devlog/_plan/260822_pabcd-transition-selftest/020_powershell_probes.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/020_powershell_probes.md
@@ -1,0 +1,89 @@
+# 020 - the PowerShell probe harness and what it measured
+
+The transition failure that started this unit was not an FSM bug. Inline
+`--attest` JSON never reaches the CLI intact on PowerShell. Proving that needed a
+harness, and the harness then paid for itself four more times.
+
+## Harness
+
+Three probes under `.codexclaw/psprobe/`:
+
+| probe | answers |
+|---|---|
+| `argv.mjs` | what argv the child ACTUALLY received, one entry per line |
+| `bytes.mjs` | true bytes, detected BOM, and whether an anchor matches under utf8 vs utf16le |
+| `exit.mjs` | controllable exit code with one line on each stream |
+| `resolve.mjs` | whether a resolved shim path can actually be spawned |
+
+Everything below is measured output, not recollection.
+
+## 1. Escaping a quote ends the quoted span (filed #6)
+
+```
+'{"a":"b"}'          -> 1: "{a:b}"                  quotes eaten
+'{\"a\":\"b\"}'       -> 1: "{\"a\":\"b\"}"           looks fixed
+'{\"a\":\"b c\"}'     -> argc=3, split at the space  actually broken
+"b c d"              -> argc=1                      control: spaces are fine
+```
+
+The escape works right up until a value contains a space. Every alternative
+failed too: here-strings, `ConvertTo-Json` into a variable, and `--%` (which
+additionally swallowed `2>&1` as an argument).
+
+The one form that survives is PowerShell's doubling escape inside single quotes,
+verified end to end through `JSON.parse`:
+
+```powershell
+$j = '{""from"":""P"",""did"":""two words here""}'   # parses correctly
+```
+
+## 2. The recommended encoding fix still breaks grep (filed #7)
+
+| how | head | BOM | `/^not ok/` |
+|---|---|---|---|
+| `Set-Content` | `6e6f74...` | none | 1 |
+| `Out-File` | `fffe6e00...` | UTF-16LE | 0 |
+| `Out-File -Encoding utf8` | `efbbbf6e...` | **UTF-8 BOM** | **0** |
+| `[IO.File]::WriteAllText` | `6e6f74...` | none | 1 |
+
+`utf8NoBOM` does not exist on 5.1 — the binder lists the legal values and refuses.
+So both remediations the archive recommends fail on this host, one silently.
+
+## 3. Out-String inflates one line to eight (filed #8)
+
+```
+node exit.mjs 0 2>&1 | Out-String | Set-Content run.log
+lines: 8   (expected 2)
+```
+
+The extra six are the invocation position, the source line, a squiggle underline,
+and two metadata rows — your own script text becomes log content. `Set-Content`
+and `Select-String` on the same merged stream stay clean, so the formatter is the
+culprit, not the redirection.
+
+Worth recording as a negative result: `$LASTEXITCODE` propagated correctly as 3
+through `Select-String`, `Tee-Object`, `Out-String` and `Select-Object`. Exit
+codes are not part of this problem.
+
+## 4. Two resolvers, two different worlds (filed #9)
+
+```
+Get-Command npm -> npm.ps1  -> spawn EFTYPE
+where.exe npm   -> npm      -> spawn ENOENT
+```
+
+`Get-Command` ranks `.ps1` first; `where.exe` does not list it at all. And the
+`.cmd` fix needs double quoting, because `cmd /s /c` strips the outer pair:
+
+```
+"<path>" --version    -> 'C:\Program' is not recognized
+""<path>" --version"  -> exit 0, 10.9.2
+```
+
+## Deliberately not filed
+
+- Empty-string arguments vanishing — already covered by `oss-native-arg-quoting`.
+- `ErrorRecord` wrapping itself — already covered by `native-stderr-errorrecord`;
+  #8 covers only what happens when you render it.
+- Array splatting, trailing backslashes, leading `@`, and `-`-prefixed values all
+  behaved correctly and are not landmines.

--- a/devlog/_plan/260822_pabcd-transition-selftest/030_round2_probes.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/030_round2_probes.md
@@ -42,6 +42,30 @@ Same area, separate surprise: the captured value's TYPE depends on line count.
 One line is a `String`, two lines is an `Object[]`. So `-eq`, `.Trim()` and
 `.Length` silently change meaning when a tool adds a log line.
 
+## 7. Single-element unrolling (filed #12)
+
+The one that probably costs the most hours across all of these, because the code
+never changes - the data does.
+
+```
+one-line file:  Get-Content -> String    $c[0] = "h"      $c.Length = 5
+two-line file:  Get-Content -> Object[]  $c[0] = "hello"  $c.Length = 2
+empty file:     Get-Content -> $null     @($c).Count = 0
+```
+
+A line counter silently becomes a character counter. It is silent precisely
+because `String` happens to support both `[0]` and `.Length` with different
+meanings - if it did not, you would get a clean method-not-found instead.
+
+`@(...)` at the point of assignment fixes it, and applies to every unrolling
+cmdlet: `Get-ChildItem`, `Select-String`, `Import-Csv`, native capture.
+
+Also measured here: a failing native command does NOT stop the next statement.
+`node exit.mjs 1; node exit.mjs 0` runs both and leaves `$LASTEXITCODE=0`, so
+the failure is erased by the success that follows it. Worth knowing when writing
+multi-command lines, though it follows from the language rather than being a
+surprise on its own.
+
 ## Running index
 
 | # | category | what |
@@ -52,6 +76,7 @@ One line is a `String`, two lines is an `Object[]`. So `-eq`, `.Trim()` and
 | 9 | aliases | Get-Command vs where.exe disagree; both unrunnable |
 | 10 | args-quoting | `$1`/`$100` are variables; regex and money get deleted |
 | 11 | exit-codes | `if (nativecmd)` branches on output, not exit code |
+| 12 | collections | one-line file makes Get-Content a String; `[0]` and `.Length` change meaning |
 
 Skipped as already covered: empty-arg vanishing, `ErrorRecord` wrapping,
 `$?` unreliability, the UTF-16 `Out-File` default, `.ps1` shim precedence.

--- a/devlog/_plan/260822_pabcd-transition-selftest/030_round2_probes.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/030_round2_probes.md
@@ -1,0 +1,57 @@
+# 030 - round 2: interpolation and truthiness
+
+Second hunting pass with the same harness. Two more landmines, both silent, both
+of the worst kind: the shell does exactly what it promises and the result is
+wrong anyway.
+
+## 5. `$1`, `$2` and `$100` are real variable names (filed #10)
+
+```
+"s/(a)(b)/$2$1/"   -> "s/(a)(b)//"      sed backreferences deleted
+"{print $1}"       -> "{print }"        awk field deleted
+"$100-$200"        -> "-"               a price range became a hyphen
+```
+
+Digits are legal identifier characters, so these are unset variables expanding to
+empty. Proof that they are genuinely variables:
+
+```powershell
+$100 = "SET"; node argv.mjs "price $100"     # 0: "price SET"
+```
+
+`Set-StrictMode -Version Latest` does catch it, but it is off by default and
+nobody enables it in the shell where one-off commands get typed.
+
+Negative results worth keeping: globs (`*.ts`, `file[1].txt`), semicolons,
+commas, UNC paths and backtick-n all pass through intact. `$` is the whole
+problem, and single quotes solve all of it.
+
+## 6. `if (nativecmd)` tests output, not exit status (filed #11)
+
+| tool | exit | `if` says | correct? |
+|---|---|---|---|
+| silent, succeeds | 0 | falsy | no |
+| silent, fails | 1 | falsy | by accident |
+| prints, fails | 1 | truthy | no |
+| prints, succeeds | 0 | truthy | by accident |
+
+The branch tracks verbosity. Quiet well-behaved tools are exactly the ones it
+always gets wrong.
+
+Same area, separate surprise: the captured value's TYPE depends on line count.
+One line is a `String`, two lines is an `Object[]`. So `-eq`, `.Trim()` and
+`.Length` silently change meaning when a tool adds a log line.
+
+## Running index
+
+| # | category | what |
+|---|---|---|
+| 6 | args-quoting | escaping a quote ends the quoted span |
+| 7 | encoding | the recommended encoding fix writes a BOM; utf8NoBOM absent on 5.1 |
+| 8 | streams | Out-String inflates 2 lines to 8, injects script source |
+| 9 | aliases | Get-Command vs where.exe disagree; both unrunnable |
+| 10 | args-quoting | `$1`/`$100` are variables; regex and money get deleted |
+| 11 | exit-codes | `if (nativecmd)` branches on output, not exit code |
+
+Skipped as already covered: empty-arg vanishing, `ErrorRecord` wrapping,
+`$?` unreliability, the UTF-16 `Out-File` default, `.ps1` shim precedence.

--- a/devlog/_plan/260822_pabcd-transition-selftest/040_round3_probes.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/040_round3_probes.md
@@ -1,0 +1,54 @@
+# 040 - round 3: comparison operators
+
+## 8. `-ne` against a list is a filter, not a boolean (filed #13)
+
+The most dangerous one found so far, because it fails toward "allow".
+
+```powershell
+$forbidden = @("admin","root"); $user = "admin"
+if ($forbidden -ne $user) { "ALLOWED" } else { "denied" }   # ALLOWED
+```
+
+With a collection on the left, comparison operators return the matching elements
+rather than a boolean:
+
+```
+@("x","y","x") -eq "x"  ->  Object[] count=2  value=x,x
+@("x","y")     -ne "x"  ->  count=1           value=y
+```
+
+`$forbidden -ne "admin"` is `@("root")`, which is truthy. The check is really
+asking "are there entries that are not admin", and there are.
+
+The failure curve is the problem:
+
+```
+@("admin")         -ne "admin"  -> falsy  -> denied   correct
+@("admin","root")  -ne "admin"  -> truthy -> ALLOWED  wrong
+@()                -ne anything -> falsy  -> denied   correct
+```
+
+One entry works. Two entries invert it. So it passes the unit test and the first
+deploy, then breaks when someone extends a config list.
+
+`-contains` is the fix and was verified. Also recorded: `-contains` is
+membership, NOT substring - `"hello" -contains "ell"` is False while
+`"hello".Contains("ell")` is True. The operator that sounds like substring search
+is membership, and the ones that look like comparison are filters.
+
+Negative results from this pass: `-like` wildcards, `$Matches` population after
+`-match`, and case-insensitive-by-default `-eq` with `-ceq` as the sensitive form
+all behave as documented and are not landmines.
+
+## Running index
+
+| # | category | what |
+|---|---|---|
+| 6 | args-quoting | escaping a quote ends the quoted span |
+| 7 | encoding | recommended encoding fix writes a BOM; utf8NoBOM absent on 5.1 |
+| 8 | streams | Out-String inflates 2 lines to 8, injects script source |
+| 9 | aliases | Get-Command vs where.exe disagree; both unrunnable |
+| 10 | args-quoting | `$1`/`$100` are variables; regex and money get deleted |
+| 11 | exit-codes | `if (nativecmd)` branches on output, not exit code |
+| 12 | collections | one-line file makes Get-Content a String |
+| 13 | collections | `-ne` against a list is a filter; denylists fail open |

--- a/devlog/_plan/260822_pabcd-transition-selftest/040_round3_probes.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/040_round3_probes.md
@@ -40,6 +40,38 @@ Negative results from this pass: `-like` wildcards, `$Matches` population after
 `-match`, and case-insensitive-by-default `-eq` with `-ceq` as the sensitive form
 all behave as documented and are not landmines.
 
+## 9. `return` does not mean return (filed #14)
+
+```powershell
+function Get-WorkDir {
+    New-Item -ItemType Directory -Path "$env:TEMP\wd" -Force
+    return "$env:TEMP\wd"
+}
+$d = Get-WorkDir
+$d.GetType().Name    # Object[]   -- you asked for a path
+```
+
+`return` only sets the exit point; every expression that emits output
+contributes to the result. `New-Item` emits a `DirectoryInfo`, so the real
+return is `@(DirectoryInfo, String)`.
+
+The corruption surfaces far from its cause:
+
+```
+"path is: $d"     -> the path printed TWICE
+node argv.mjs $d  -> argc=2, the same path as two arguments
+Test-Path $d      -> True, twice   (the sanity check confirms the broken value)
+```
+
+`| Out-Null` on the side-effect cmdlet restores `String` and `argc=1`. Note
+`Write-Host` does NOT pollute (it bypasses the output stream) while
+`Write-Output` does, which is why people conclude the rule is about logging when
+it is actually about the output stream.
+
+This is the same unrolling rule as #12 seen from the producer side: a function
+whose side-effect cmdlet happens to be quiet returns a clean scalar, and starts
+returning an array the day it creates something.
+
 ## Running index
 
 | # | category | what |
@@ -52,3 +84,4 @@ all behave as documented and are not landmines.
 | 11 | exit-codes | `if (nativecmd)` branches on output, not exit code |
 | 12 | collections | one-line file makes Get-Content a String |
 | 13 | collections | `-ne` against a list is a filter; denylists fail open |
+| 14 | collections | `return` does not suppress other output; functions leak extra values |

--- a/devlog/_plan/260822_pabcd-transition-selftest/050_round4_probes.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/050_round4_probes.md
@@ -1,0 +1,55 @@
+# 050 - round 4: serialization
+
+## 10. `ConvertTo-Json` destroys data at depth 3 (filed #15)
+
+The highest-stakes find of the loop: it loses production data and stays green.
+
+```powershell
+$config = @{ name="svc"; deploy=@{ staging=@{ env=@{ DB_URL="..."; API_KEY="..." } } } }
+$config | ConvertTo-Json -Compress
+# {"deploy":{"staging":{"env":"System.Collections.Hashtable"}},"name":"svc"}
+```
+
+The DB URL and API key are gone. Default `-Depth` is 2, and anything deeper is
+not truncated but rendered with `.ToString()` - which for a hashtable is its
+type name.
+
+Three properties make this worse than ordinary truncation:
+
+- the output is still VALID JSON, so schema-less consumers accept it
+- the replacement is a plausible-looking string, so a spot check misreads it
+- stderr is empty (measured: 0 ErrorRecords), so CI stays green
+
+`config -> environment -> variables` is three levels. This is not an exotic
+shape.
+
+`-Depth 10` fixes it and was verified. A CI assertion that greps the output for
+`System\.Collections` is cheap insurance.
+
+## Adjacent findings, same probe
+
+**Hashtable key order is not insertion order.** `@{b=2;a=1;c=3}.Keys` returns
+`c,a,b`, so serialized output is not byte-stable across runs and content hashing
+or diffing on it is unreliable. `[ordered]@{}` when it matters.
+
+**`ConvertFrom-Json` returns `PSCustomObject`, not a hashtable**, so
+`.ContainsKey()` does not exist and a serialize/parse round trip does not give
+back the type you started with.
+
+Negative result: `+=` on an array works correctly (count=2, `Object[]`). It is a
+performance footgun, not a correctness one, so it was not filed.
+
+## Running index
+
+| # | category | what |
+|---|---|---|
+| 6 | args-quoting | escaping a quote ends the quoted span |
+| 7 | encoding | recommended encoding fix writes a BOM; utf8NoBOM absent on 5.1 |
+| 8 | streams | Out-String inflates 2 lines to 8, injects script source |
+| 9 | aliases | Get-Command vs where.exe disagree; both unrunnable |
+| 10 | args-quoting | `$1`/`$100` are variables; regex and money get deleted |
+| 11 | exit-codes | `if (nativecmd)` branches on output, not exit code |
+| 12 | collections | one-line file makes Get-Content a String |
+| 13 | collections | `-ne` against a list is a filter; denylists fail open |
+| 14 | collections | `return` does not suppress other output |
+| 15 | serialization | ConvertTo-Json -Depth 2 default destroys nested data silently |

--- a/devlog/_plan/260822_pabcd-transition-selftest/060_closeout.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/060_closeout.md
@@ -20,6 +20,7 @@ PowerShell - and the probe built to prove that became a hunting tool.
 | 15 | serialization | `ConvertTo-Json -Depth 2` default replaces nested data with a type name |
 | 16 | env-paths | `Test-Path` validates a trailing-space path that Node cannot open |
 | 17 | exit-codes | `Start-Process` never sets `$LASTEXITCODE`; a failure inherits the last success |
+| 18 | parsing | `[double]"3,14"` is `314` with no error; `InvariantCulture` does not fix it |
 
 Every one was measured on this host before filing, with the probe output pasted
 into the issue verbatim.
@@ -37,6 +38,7 @@ Three of them fail in the dangerous direction specifically:
 - #15 secrets vanish from a config while the JSON stays valid
 - #16 a validation step certifies a path the consumer cannot open
 - #17 a CI gate passes on a process that exited 1
+- #18 a measurement is silently off by a factor of 100
 
 And two are traps set by the *fix* rather than the original bug: #7 (the
 recommended encoding still breaks anchored grep) and #6 (the escape works right
@@ -132,3 +134,29 @@ parsing (`[double]`, date formats) under a non-en-US locale, and `$PSDefault`
 `ParameterValues` leaking into child scopes. The culture one looks especially
 promising on a Korean-locale host, where decimal separators and date ordering
 differ from what most scripts assume.
+
+Update: the culture lead paid off immediately and became #18. `[double]"3,14"`
+returns `314` - and `[double]"3,14159"` returns `314159`, off by a factor of
+100,000. The casts accept group separators, so a comma-decimal string parses
+*successfully* as a different magnitude. `InvariantCulture` does not help
+because it also treats `,` as grouping; only a `NumberStyles` without
+`AllowThousands` makes the parse strict. It does not require a non-en-US host
+either - an en-US machine mangles comma-decimal DATA, which is where such
+strings actually come from.
+
+Remaining unprobed: remoting serialization, scheduled tasks, ExecutionPolicy
+with signed scripts, and `$PSDefaultParameterValues` scope leakage.
+
+## A closing note on the method
+
+Filing #18 failed on the first attempt, and the failure was #6:
+
+```
+gh issue create --title "parsing: [double]\"3,14\" is 314 ..."
+-> unknown arguments ["is" "314" "with" "no" "error," ...]
+```
+
+The escaped quotes ended the quoted span and the title shattered into flags -
+the exact behaviour filed hours earlier. Assigning the title to a
+single-quoted variable first fixed it. Twelve issues in, the archive was already
+load-bearing for the work that produced it.

--- a/devlog/_plan/260822_pabcd-transition-selftest/060_closeout.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/060_closeout.md
@@ -107,3 +107,28 @@ correctly.
 
 The rule that made this productive: never report a behaviour you have not
 watched a process actually perform.
+
+## Corrections to the existing archive
+
+Two filings are not new landmines so much as corrections, and they are worth
+calling out because someone following the archive's advice today gets burned:
+
+- **#7** `oss-outfile-bom` recommends `Out-File -Encoding utf8` on 5.1 and
+  `Set-Content -Encoding utf8NoBOM` on 7+. On this 5.1 host the first still
+  writes a BOM and scores zero anchored matches, and the second is not a legal
+  parameter value - the binder lists the accepted enum names and refuses.
+- **#6** the natural next step after `oss-native-arg-quoting` is to start
+  escaping quotes. That appears to work and then silently changes the argument
+  count the first time a value contains a space.
+
+A workaround that has not been executed on the host it targets is a guess. Both
+of these were caught by running the recommendation rather than trusting it.
+
+## If you extend this
+
+Surfaces still unprobed: remoting and `Invoke-Command` serialization, scheduled
+tasks, `ExecutionPolicy` interaction with signed scripts, culture-dependent
+parsing (`[double]`, date formats) under a non-en-US locale, and `$PSDefault`
+`ParameterValues` leaking into child scopes. The culture one looks especially
+promising on a Korean-locale host, where decimal separators and date ordering
+differ from what most scripts assume.

--- a/devlog/_plan/260822_pabcd-transition-selftest/060_closeout.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/060_closeout.md
@@ -1,0 +1,76 @@
+# 060 - closeout: eleven landmines, and what was deliberately left alone
+
+This unit started as a PABCD self-test after a transition failed. The failure
+turned out not to be the FSM at all - inline `--attest` JSON never survives
+PowerShell - and the probe built to prove that became a hunting tool.
+
+## What was filed
+
+| # | category | what it costs you |
+|---|---|---|
+| 6 | args-quoting | escaping a quote ends the quoted span; one argument becomes several |
+| 7 | encoding | the archive's own recommended fix writes a BOM; `utf8NoBOM` absent on 5.1 |
+| 8 | streams | `Out-String` inflates 2 lines to 8 and injects your script's source |
+| 9 | aliases | `Get-Command` and `where.exe` disagree; both return unrunnable paths |
+| 10 | args-quoting | `$1`/`$100` are variables; sed backreferences and money get deleted |
+| 11 | exit-codes | `if (nativecmd)` branches on output volume, not exit status |
+| 12 | collections | a one-line file makes `Get-Content` a String; `[0]` returns a character |
+| 13 | collections | `-ne` against a list is a filter; a denylist fails OPEN |
+| 14 | collections | `return` does not suppress other output; functions leak values |
+| 15 | serialization | `ConvertTo-Json -Depth 2` default replaces nested data with a type name |
+| 16 | env-paths | `Test-Path` validates a trailing-space path that Node cannot open |
+
+Every one was measured on this host before filing, with the probe output pasted
+into the issue verbatim.
+
+## The pattern worth naming
+
+Nine of the eleven are **silent**. That is not an accident of selection - it is
+what makes PowerShell landmines expensive. The shell does exactly what it
+documents, produces a plausible result, exits 0, and the damage surfaces later in
+someone else's process.
+
+Three of them fail in the dangerous direction specifically:
+
+- #13 a denylist reports ALLOWED for the value it exists to block
+- #15 secrets vanish from a config while the JSON stays valid
+- #16 a validation step certifies a path the consumer cannot open
+
+And two are traps set by the *fix* rather than the original bug: #7 (the
+recommended encoding still breaks anchored grep) and #6 (the escape works right
+up until a value contains a space).
+
+## Deliberately not filed
+
+Checked against the archive and skipped as already covered:
+
+- empty-string arguments vanishing -> `oss-native-arg-quoting`
+- `ErrorRecord` wrapping itself -> `native-stderr-errorrecord`
+- `$?` being unreliable -> `exit-code-vs-dollar-q`
+- the UTF-16 `Out-File` default -> `oss-outfile-bom`
+- `.ps1` shim precedence -> `npm-ps1-not-comspec`
+
+Measured and found NOT to be landmines - recorded so nobody re-tests them:
+
+- globs (`*.ts`, `file[1].txt`), semicolons, commas, UNC paths, backtick-n:
+  all pass through argv intact
+- array splatting, trailing backslashes, leading `@`, dash-prefixed values: fine
+- `$LASTEXITCODE` propagation through `Select-String`, `Tee-Object`,
+  `Out-String` and `Select-Object`: correct in every case
+- `-like` wildcards, `$Matches` population, `-eq`/`-ceq` case sensitivity: as
+  documented
+- `+=` on an array: a performance footgun, not a correctness bug
+
+## The harness
+
+`probes/` holds four scripts, committed so every claim reruns:
+
+| probe | answers |
+|---|---|
+| `argv.mjs` | what argv the child ACTUALLY received |
+| `bytes.mjs` | true bytes, BOM, anchored match under utf8 vs utf16le |
+| `exit.mjs` | controllable exit code with output on both streams |
+| `resolve.mjs` | whether a resolved shim path can be spawned |
+
+The rule that made this productive: never report a behaviour you have not
+watched a process actually perform.

--- a/devlog/_plan/260822_pabcd-transition-selftest/060_closeout.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/060_closeout.md
@@ -19,6 +19,7 @@ PowerShell - and the probe built to prove that became a hunting tool.
 | 14 | collections | `return` does not suppress other output; functions leak values |
 | 15 | serialization | `ConvertTo-Json -Depth 2` default replaces nested data with a type name |
 | 16 | env-paths | `Test-Path` validates a trailing-space path that Node cannot open |
+| 17 | exit-codes | `Start-Process` never sets `$LASTEXITCODE`; a failure inherits the last success |
 
 Every one was measured on this host before filing, with the probe output pasted
 into the issue verbatim.
@@ -35,6 +36,7 @@ Three of them fail in the dangerous direction specifically:
 - #13 a denylist reports ALLOWED for the value it exists to block
 - #15 secrets vanish from a config while the JSON stays valid
 - #16 a validation step certifies a path the consumer cannot open
+- #17 a CI gate passes on a process that exited 1
 
 And two are traps set by the *fix* rather than the original bug: #7 (the
 recommended encoding still breaks anchored grep) and #6 (the escape works right
@@ -60,6 +62,37 @@ Measured and found NOT to be landmines - recorded so nobody re-tests them:
 - `-like` wildcards, `$Matches` population, `-eq`/`-ceq` case sensitivity: as
   documented
 - `+=` on an array: a performance footgun, not a correctness bug
+
+## 11. `Start-Process` leaves the result invisible (filed #17)
+
+```powershell
+node -e "process.exit(3)"; "before=$LASTEXITCODE"      # before=3
+Start-Process -FilePath node -ArgumentList "-e","process.exit(7)" -Wait -NoNewWindow
+"after=$LASTEXITCODE"                                   # after=3
+```
+
+`Start-Process` is a cmdlet, not a native invocation, so it never touches
+`$LASTEXITCODE` - the variable is not zeroed, it is LEFT ALONE holding the
+previous command's value. A CI gate written correctly against `$LASTEXITCODE`
+therefore reports on a command from an earlier step:
+
+```
+node -e "process.exit(0)"; Start-Process ... exit 1; if ($LASTEXITCODE -eq 0)
+-> CI GATE PASSED (wrong)
+```
+
+`$?` does not rescue it either - it is True, because launching succeeded.
+
+Output has the matching trap: `$out.StandardOutput` is empty while the text
+visibly prints to the console, so it looks captured and is not. `-PassThru` plus
+`.ExitCode`, and `-RedirectStandardOutput` to a file, are the working forms.
+
+The archive's two Start-Process cases are both about ARGUMENTS reaching it;
+grepping them for ExitCode, LASTEXITCODE and PassThru returns nothing.
+
+Negative results from this pass: `& $exe` with a spaced path, `Invoke-Expression`
+with embedded quotes, and `Start-Process -Wait -PassThru` exit capture all work
+correctly.
 
 ## The harness
 

--- a/devlog/_plan/260822_pabcd-transition-selftest/probes/README.md
+++ b/devlog/_plan/260822_pabcd-transition-selftest/probes/README.md
@@ -1,0 +1,69 @@
+# PowerShell landmine probes
+
+Four scripts that answer questions about what a shell ACTUALLY did, rather than
+what it claims. Every case filed from this unit was measured with one of these
+first; nothing was reported from recollection.
+
+## `argv.mjs` - what did the child really receive?
+
+```powershell
+node argv.mjs --attest '{"a":"b c"}'
+# argc=2
+# 0: "--attest"
+# 1: "{a:b c}"          <- quotes gone
+```
+
+Use it whenever a CLI rejects input you believe you sent correctly. If the error
+names words from your own prose, the shell split the argument.
+
+## `bytes.mjs` - what is actually in that file?
+
+```powershell
+"not ok 1" | Out-File -Encoding utf8 run.log
+node bytes.mjs run.log "^not ok"
+# bytes=13 head=efbbbf6e6f74206f bom=UTF-8 BOM
+# utf8 matches=0        <- the BOM broke the anchor
+# utf16le matches=0
+```
+
+Use it when a grep returns zero and you are sure the content is there. Reports
+the anchor match under both decodings, because decoding correctly is not
+sufficient - a surviving BOM still defeats `^`.
+
+## `exit.mjs` - a child with a known exit code and both streams
+
+```powershell
+node exit.mjs 3
+# stdout-line
+# stderr-line     (exits 3)
+```
+
+Use it as a controlled subject when testing how a construct propagates failure.
+It is how `if (nativecmd)` was shown to branch on output volume, and how
+`Start-Process` was shown never to touch `$LASTEXITCODE`.
+
+## `resolve.mjs` - can this resolved path actually be spawned?
+
+```powershell
+node resolve.mjs "C:\Program Files\nodejs\npm.ps1"
+# result=EFTYPE
+node resolve.mjs "C:\Program Files\nodejs\npm.cmd"
+# result=exit 0 / stdout=10.9.2
+```
+
+Use it when a tool "exists" but will not run. Note the `.cmd` branch wraps the
+ComSpec line in a second pair of quotes, because `cmd /s /c` strips the outer
+pair - without that, a path containing a space fails with
+`'C:\Program' is not recognized`.
+
+## Method
+
+Three rules that made this productive:
+
+1. Measure the observable, not the intent. `argc` and byte offsets do not have
+   opinions.
+2. Verify the workaround too. Several "fixes" from the wider archive turned out
+   to fail on this host (`Out-File -Encoding utf8`, `utf8NoBOM`).
+3. Record the negative results. Half the value of a probe run is knowing that
+   globs, UNC paths and `$LASTEXITCODE` propagation are fine, so nobody spends
+   an afternoon re-testing them.

--- a/devlog/_plan/260822_pabcd-transition-selftest/probes/argv.mjs
+++ b/devlog/_plan/260822_pabcd-transition-selftest/probes/argv.mjs
@@ -1,0 +1,6 @@
+// Prints the child's raw argv, one per line with an index, so nothing is hidden
+// by console formatting or by a shell that "helpfully" re-joins.
+//   node probes/argv.mjs --attest '{"a":"b c"}'
+const args = process.argv.slice(2);
+console.log("argc=" + args.length);
+args.forEach((a, i) => console.log(i + ": " + JSON.stringify(a)));

--- a/devlog/_plan/260822_pabcd-transition-selftest/probes/bytes.mjs
+++ b/devlog/_plan/260822_pabcd-transition-selftest/probes/bytes.mjs
@@ -1,0 +1,22 @@
+// Reports the true bytes of a file: leading hex, detected BOM, and whether an
+// anchor matches under utf8 vs utf16le decoding.
+//   node probes/bytes.mjs run.log "^not ok"
+import { readFileSync } from "node:fs";
+
+const [file, anchor = "^not ok"] = process.argv.slice(2);
+const raw = readFileSync(file);
+const head = raw.slice(0, 8).toString("hex");
+
+const bom =
+  head.startsWith("fffe") ? "UTF-16LE BOM"
+  : head.startsWith("feff") ? "UTF-16BE BOM"
+  : head.startsWith("efbbbf") ? "UTF-8 BOM"
+  : "none";
+
+const re = new RegExp(anchor, "m");
+const count = (text) => text.split(/\r?\n/).filter((l) => re.test(l)).length;
+
+console.log("file=" + file);
+console.log("bytes=" + raw.length + " head=" + head + " bom=" + bom);
+console.log("utf8 matches=" + count(raw.toString("utf8")));
+console.log("utf16le matches=" + count(raw.toString("utf16le")));

--- a/devlog/_plan/260822_pabcd-transition-selftest/probes/exit.mjs
+++ b/devlog/_plan/260822_pabcd-transition-selftest/probes/exit.mjs
@@ -1,0 +1,7 @@
+// A child with a controllable exit code and one line on each stream, for
+// testing how a shell propagates and merges them.
+//   node probes/exit.mjs 3
+const code = Number(process.argv[2] ?? 0);
+process.stdout.write("stdout-line\n");
+process.stderr.write("stderr-line\n");
+process.exit(code);

--- a/devlog/_plan/260822_pabcd-transition-selftest/probes/resolve.mjs
+++ b/devlog/_plan/260822_pabcd-transition-selftest/probes/resolve.mjs
@@ -1,0 +1,21 @@
+// Can a resolved shim path actually be spawned? .cmd/.bat go through ComSpec,
+// everything else directly.
+//   node probes/resolve.mjs "C:\Program Files\nodejs\npm.cmd"
+import { spawnSync } from "node:child_process";
+
+const target = process.argv[2];
+const isBatch = /\.(cmd|bat)$/i.test(target);
+
+// cmd /s /c strips the OUTER pair of quotes from the whole command line, so a
+// path that needs quoting must be wrapped twice: "" "path" args "".
+const res = isBatch
+  ? spawnSync(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", `""${target}" --version"`], {
+      encoding: "utf8",
+      windowsVerbatimArguments: true,
+    })
+  : spawnSync(target, ["--version"], { encoding: "utf8" });
+
+console.log("target=" + target);
+console.log("result=" + (res.error ? res.error.code : "exit " + res.status));
+console.log("stdout=" + (res.stdout ?? "").trim());
+console.log("stderr=" + (res.stderr ?? "").trim().slice(0, 300));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.10+codex.20260818121334",
+  "version": "0.2.11+codex.20260818121334",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI — doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge — cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/dist/hook.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/hook.js
@@ -455,26 +455,49 @@ export const TRIGGER_AUTHORITY_NOTE = [
   "`cxc orchestrate <I|P|A|B|C|D> --session <id>` — work edges carry --attest.",
 ].join(" ");
 
-export const LOOP_ARM_DIRECTIVE = [
-  "[codexclaw: LOOP — orchestrate arming mandate (ORCH-MANDATE-01)]",
-  "A loop/goalplan claim without persisted FSM evidence is INVALID, and the PABCD FSM is not",
-  "armed right now. Arm it with explicit commands before narrating any loop work:",
-  "1. Session id: take it ONLY from your most recent SessionStart binding line",
-  "   (SESSION-IDENTITY-01 — never an id seen in transcript history).",
-  "2. `cxc orchestrate status --session <id>` — read the real phase first.",
-  "3. HOTL (user asked for autonomous / continue-until-done): create_goal with a detailed",
-  '   objective -> `cxc loop init --objective "<same text>" --session <id>` -> register',
-  "   workPhases[] + criteria[] in the goalplan -> `cxc orchestrate P --session <id>`.",
-  "   HITL (no such ask): enter the cycle explicitly via `cxc orchestrate I|P --session <id>`.",
-  "4. Advance EVERY forward edge yourself with `cxc orchestrate <phase> --attest <json>` —",
-  "   a phase without its persisted transition + artifact did not happen (ORCH-ARTIFACT-01).",
-  "   When a goalplan is bound, include the active workPhaseId in every gated attest",
-  "   (one work-phase = one full PABCD cycle).",
-  "5. After D closes to IDLE with work remaining under an active goal, immediately re-enter",
-  "   with `cxc orchestrate P --session <id>` (LOOP-UNIT-CHAIN-01).",
-  "Load and obey cxc-loop + cxc-pabcd when available. Work done outside the FSM does not",
-  "count as loop progress — re-enter and attest it.",
-].join("\n");
+/**
+ * The arming mandate, injected at prompt time by UserPromptSubmit.
+ *
+ * Step 4 is platform-dependent because PowerShell cannot pass inline JSON as one
+ * argv token: single quotes are stripped (`{from:P,to:A,did:wrote the plan}`) and
+ * escaping them ends the quoted span so the value splits at its first space. Every
+ * gated edge requires a `did` narrative, which always contains spaces, so there is
+ * no inline spelling that works. Telling a Windows agent otherwise is how it
+ * concludes the FSM is broken. Same reasoning as `stopNextCommand` below.
+ */
+export function loopArmDirective(platform                  = process.platform)         {
+  const advance = platform === "win32"
+    ? [
+        "4. Advance EVERY forward edge yourself. On Windows write the JSON first, then attest:",
+        "   `'<json>' | Set-Content -Encoding utf8 .codexclaw/attest.json` then",
+        "   `cxc orchestrate <phase> --session <id> --attest-file .codexclaw/attest.json` —",
+        "   inline --attest cannot survive PowerShell argument parsing (quotes are stripped,",
+        "   and escaping them splits the value at its first space).",
+      ]
+    : [
+        "4. Advance EVERY forward edge yourself with `cxc orchestrate <phase> --attest <json>` —",
+      ];
+  return [
+    "[codexclaw: LOOP — orchestrate arming mandate (ORCH-MANDATE-01)]",
+    "A loop/goalplan claim without persisted FSM evidence is INVALID, and the PABCD FSM is not",
+    "armed right now. Arm it with explicit commands before narrating any loop work:",
+    "1. Session id: take it ONLY from your most recent SessionStart binding line",
+    "   (SESSION-IDENTITY-01 — never an id seen in transcript history).",
+    "2. `cxc orchestrate status --session <id>` — read the real phase first.",
+    "3. HOTL (user asked for autonomous / continue-until-done): create_goal with a detailed",
+    '   objective -> `cxc loop init --objective "<same text>" --session <id>` -> register',
+    "   workPhases[] + criteria[] in the goalplan -> `cxc orchestrate P --session <id>`.",
+    "   HITL (no such ask): enter the cycle explicitly via `cxc orchestrate I|P --session <id>`.",
+    ...advance,
+    "   a phase without its persisted transition + artifact did not happen (ORCH-ARTIFACT-01).",
+    "   When a goalplan is bound, include the active workPhaseId in every gated attest",
+    "   (one work-phase = one full PABCD cycle).",
+    "5. After D closes to IDLE with work remaining under an active goal, immediately re-enter",
+    "   with `cxc orchestrate P --session <id>` (LOOP-UNIT-CHAIN-01).",
+    "Load and obey cxc-loop + cxc-pabcd when available. Work done outside the FSM does not",
+    "count as loop progress — re-enter and attest it.",
+  ].join("\n");
+}
 
 const STAGE_LABELS                                 = {
   I: "INTERVIEW",
@@ -553,7 +576,10 @@ export function handleSessionStart(payload                     )         {
  *  - mode 3 (active, no trigger, same phase): inject the short stage header
  *    every turn (compaction-immune, jwc M2 parity).
  */
-export function handleUserPromptSubmit(payload                         )         {
+export function handleUserPromptSubmit(
+  payload                         ,
+  platform                  = process.platform,
+)         {
   if (payload.hook_event_name !== "UserPromptSubmit") return "";
   const turn = payload.turn_id ?? "";
   const state = readState(payload.cwd, payload.session_id);
@@ -598,9 +624,9 @@ export function handleUserPromptSubmit(payload                         )        
     });
     const parts           = [];
     // 260724 WP1: resolve the invocation at emit time (constant untouched). Safe
-    // per resolveCxcInDirective: every cxc command in LOOP_ARM_DIRECTIVE is
+    // per resolveCxcInDirective: every cxc command in the arming directive is
     // backticked; "cxc-loop"/"cxc-pabcd" skill nouns carry no "`cxc " prefix.
-    parts.push(resolveCxcInDirective(LOOP_ARM_DIRECTIVE));
+    parts.push(resolveCxcInDirective(loopArmDirective(platform)));
     if (agbrowseRequested) parts.push(AGBROWSE_SEARCH_DIRECTIVE);
     return buildContextOutput("UserPromptSubmit", parts.join("\n\n"));
   }
@@ -1125,11 +1151,21 @@ export function readStopWorkContext(cwd        , state       )                  
  * the remaining work is named; when it is bound but unregistered (empty), the block says
  * to fill it; when none is bound, it points at `cxc loop init`.
  */
-export function buildGoalIdleBlock(cwd        , state       , sessionId        )         {
+export function buildGoalIdleBlock(
+  cwd        ,
+  state       ,
+  sessionId        ,
+  platform                  = process.platform,
+)         {
+  // Same PowerShell constraint as loopArmDirective: inline JSON cannot survive
+  // argument parsing, so win32 gets the write-then-attest pair instead.
+  const startNext = platform === "win32"
+    ? `Either start the next work-phase now: write the JSON with \`'{"from":"IDLE","to":"P","evidence":"<diff-level plan for the next work-phase>"}' | Set-Content -Encoding utf8 .codexclaw/attest.json\` then run \`cxc orchestrate P --session ${sessionId} --attest-file .codexclaw/attest.json\``
+    : `Either start the next work-phase now: \`cxc orchestrate P --session ${sessionId} --attest '{"from":"IDLE","to":"P","evidence":"<diff-level plan for the next work-phase>"}'\``;
   const lines = [
     "[codexclaw — goal continuation] A host goal is ACTIVE but no PABCD cycle is in flight.",
     "GOAL-IDLE-CONTINUE-01: IDLE is not the end while the goal is active (LOOP-CONTINUE-01). Do not end the turn here.",
-    `Either start the next work-phase now: \`cxc orchestrate P --session ${sessionId} --attest '{"from":"IDLE","to":"P","evidence":"<diff-level plan for the next work-phase>"}'\``,
+    startNext,
     'or close the goal honestly: `update_goal` status "complete" (only when the recorded criteria are proven — the E8 gate checks a bound goalplan) or status "blocked" for an external blocker.',
     "LOOP-UNIT-CHAIN-01: work-phases chain HETEROGENEOUS units in one session — an independent feature/plan discovered mid-loop is simply the NEXT work-phase (append it to the goalplan, then orchestrate P). \"Needs its own PABCD\" is a plan statement, not a session boundary; do not close the goal while naming remaining features that fit the objective.",
   ];
@@ -1222,7 +1258,10 @@ function objectivePlateau(cwd        , sessionId        )               {
  *    Side effect by design: the counter write creates the session state file, so the
  *    suggested orchestrate command passes the G2 unknown-session guard afterwards.
  */
-export function handleStop(payload             )         {
+export function handleStop(
+  payload             ,
+  platform                  = process.platform,
+)         {
   if (payload.hook_event_name !== "Stop") return "";
 
   const state = readState(payload.cwd, payload.session_id);
@@ -1243,7 +1282,7 @@ export function handleStop(payload             )         {
     // bail: don't pile on during context-pressure/compaction recovery.
     if (isContextPressureTail(readTranscriptTail(payload.transcript_path))) return "";
     if (bumpStopCounter(payload.cwd, state) === "release") return "";
-    return buildGoalIdleBlock(payload.cwd, state, payload.session_id);
+    return buildGoalIdleBlock(payload.cwd, state, payload.session_id, platform);
   }
 
   // C-RENDER-GROUNDING-01 advisory: when phase === C and render-artifact files were

--- a/plugins/codexclaw/components/pabcd-state/dist/plan-gate.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/plan-gate.js
@@ -37,8 +37,10 @@ export function validatePlanArtifacts(att                    , cwd        )     
       reason:
         'P -> A requires "planUnit": the devlog/_plan/YYMMDD_slug/ unit this plan lives in ' +
         "(DIFFLEVEL-ROADMAP-01 — the plan must exist as numbered files, not chat). " +
-        "Scaffold one with `cxc plan init <slug>` if missing, write the docs, then re-attest " +
-        'with --attest \'{"from":"P","to":"A","did":"...","planUnit":"devlog/_plan/..."}\'.',
+        "Scaffold one with `cxc plan init <slug>` if missing, write the docs, then re-attest. " +
+        "Put the JSON in a file and pass --attest-file <path> (required on Windows, where " +
+        "inline JSON cannot survive shell argument parsing): " +
+        '{"from":"P","to":"A","did":"...","planUnit":"devlog/_plan/..."}',
     };
   }
   const unit = isAbsolute(att.planUnit) ? att.planUnit : resolve(cwd, att.planUnit);

--- a/plugins/codexclaw/components/pabcd-state/dist/scan-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/scan-cli.js
@@ -131,7 +131,8 @@ export function parseScanCliArgs(
         return {
           error:
             "scan record: --dim cannot set 'max'. That level gates I->P via isInterviewReady; " +
-            "use `cxc orchestrate P --session <id> --attest '{\"from\":\"I\",\"to\":\"P\",\"did\":\"<reason>\",\"override\":true}'` " +
+            "write {\"from\":\"I\",\"to\":\"P\",\"did\":\"<reason>\",\"override\":true} to a file and run " +
+            "`cxc orchestrate P --session <id> --attest-file <path>` (the file flag is required on Windows) " +
             "so the bypass is attested and recorded in the ledger.",
         };
       }

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/pabcd-state/src/hook.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/hook.ts
@@ -455,26 +455,49 @@ export const TRIGGER_AUTHORITY_NOTE = [
   "`cxc orchestrate <I|P|A|B|C|D> --session <id>` — work edges carry --attest.",
 ].join(" ");
 
-export const LOOP_ARM_DIRECTIVE = [
-  "[codexclaw: LOOP — orchestrate arming mandate (ORCH-MANDATE-01)]",
-  "A loop/goalplan claim without persisted FSM evidence is INVALID, and the PABCD FSM is not",
-  "armed right now. Arm it with explicit commands before narrating any loop work:",
-  "1. Session id: take it ONLY from your most recent SessionStart binding line",
-  "   (SESSION-IDENTITY-01 — never an id seen in transcript history).",
-  "2. `cxc orchestrate status --session <id>` — read the real phase first.",
-  "3. HOTL (user asked for autonomous / continue-until-done): create_goal with a detailed",
-  '   objective -> `cxc loop init --objective "<same text>" --session <id>` -> register',
-  "   workPhases[] + criteria[] in the goalplan -> `cxc orchestrate P --session <id>`.",
-  "   HITL (no such ask): enter the cycle explicitly via `cxc orchestrate I|P --session <id>`.",
-  "4. Advance EVERY forward edge yourself with `cxc orchestrate <phase> --attest <json>` —",
-  "   a phase without its persisted transition + artifact did not happen (ORCH-ARTIFACT-01).",
-  "   When a goalplan is bound, include the active workPhaseId in every gated attest",
-  "   (one work-phase = one full PABCD cycle).",
-  "5. After D closes to IDLE with work remaining under an active goal, immediately re-enter",
-  "   with `cxc orchestrate P --session <id>` (LOOP-UNIT-CHAIN-01).",
-  "Load and obey cxc-loop + cxc-pabcd when available. Work done outside the FSM does not",
-  "count as loop progress — re-enter and attest it.",
-].join("\n");
+/**
+ * The arming mandate, injected at prompt time by UserPromptSubmit.
+ *
+ * Step 4 is platform-dependent because PowerShell cannot pass inline JSON as one
+ * argv token: single quotes are stripped (`{from:P,to:A,did:wrote the plan}`) and
+ * escaping them ends the quoted span so the value splits at its first space. Every
+ * gated edge requires a `did` narrative, which always contains spaces, so there is
+ * no inline spelling that works. Telling a Windows agent otherwise is how it
+ * concludes the FSM is broken. Same reasoning as `stopNextCommand` below.
+ */
+export function loopArmDirective(platform: NodeJS.Platform = process.platform): string {
+  const advance = platform === "win32"
+    ? [
+        "4. Advance EVERY forward edge yourself. On Windows write the JSON first, then attest:",
+        "   `'<json>' | Set-Content -Encoding utf8 .codexclaw/attest.json` then",
+        "   `cxc orchestrate <phase> --session <id> --attest-file .codexclaw/attest.json` —",
+        "   inline --attest cannot survive PowerShell argument parsing (quotes are stripped,",
+        "   and escaping them splits the value at its first space).",
+      ]
+    : [
+        "4. Advance EVERY forward edge yourself with `cxc orchestrate <phase> --attest <json>` —",
+      ];
+  return [
+    "[codexclaw: LOOP — orchestrate arming mandate (ORCH-MANDATE-01)]",
+    "A loop/goalplan claim without persisted FSM evidence is INVALID, and the PABCD FSM is not",
+    "armed right now. Arm it with explicit commands before narrating any loop work:",
+    "1. Session id: take it ONLY from your most recent SessionStart binding line",
+    "   (SESSION-IDENTITY-01 — never an id seen in transcript history).",
+    "2. `cxc orchestrate status --session <id>` — read the real phase first.",
+    "3. HOTL (user asked for autonomous / continue-until-done): create_goal with a detailed",
+    '   objective -> `cxc loop init --objective "<same text>" --session <id>` -> register',
+    "   workPhases[] + criteria[] in the goalplan -> `cxc orchestrate P --session <id>`.",
+    "   HITL (no such ask): enter the cycle explicitly via `cxc orchestrate I|P --session <id>`.",
+    ...advance,
+    "   a phase without its persisted transition + artifact did not happen (ORCH-ARTIFACT-01).",
+    "   When a goalplan is bound, include the active workPhaseId in every gated attest",
+    "   (one work-phase = one full PABCD cycle).",
+    "5. After D closes to IDLE with work remaining under an active goal, immediately re-enter",
+    "   with `cxc orchestrate P --session <id>` (LOOP-UNIT-CHAIN-01).",
+    "Load and obey cxc-loop + cxc-pabcd when available. Work done outside the FSM does not",
+    "count as loop progress — re-enter and attest it.",
+  ].join("\n");
+}
 
 const STAGE_LABELS: Partial<Record<Phase, string>> = {
   I: "INTERVIEW",
@@ -553,7 +576,10 @@ export function handleSessionStart(payload: SessionStartPayload): string {
  *  - mode 3 (active, no trigger, same phase): inject the short stage header
  *    every turn (compaction-immune, jwc M2 parity).
  */
-export function handleUserPromptSubmit(payload: UserPromptSubmitPayload): string {
+export function handleUserPromptSubmit(
+  payload: UserPromptSubmitPayload,
+  platform: NodeJS.Platform = process.platform,
+): string {
   if (payload.hook_event_name !== "UserPromptSubmit") return "";
   const turn = payload.turn_id ?? "";
   const state = readState(payload.cwd, payload.session_id);
@@ -598,9 +624,9 @@ export function handleUserPromptSubmit(payload: UserPromptSubmitPayload): string
     });
     const parts: string[] = [];
     // 260724 WP1: resolve the invocation at emit time (constant untouched). Safe
-    // per resolveCxcInDirective: every cxc command in LOOP_ARM_DIRECTIVE is
+    // per resolveCxcInDirective: every cxc command in the arming directive is
     // backticked; "cxc-loop"/"cxc-pabcd" skill nouns carry no "`cxc " prefix.
-    parts.push(resolveCxcInDirective(LOOP_ARM_DIRECTIVE));
+    parts.push(resolveCxcInDirective(loopArmDirective(platform)));
     if (agbrowseRequested) parts.push(AGBROWSE_SEARCH_DIRECTIVE);
     return buildContextOutput("UserPromptSubmit", parts.join("\n\n"));
   }
@@ -1125,11 +1151,21 @@ export function readStopWorkContext(cwd: string, state: State): StopWorkContext 
  * the remaining work is named; when it is bound but unregistered (empty), the block says
  * to fill it; when none is bound, it points at `cxc loop init`.
  */
-export function buildGoalIdleBlock(cwd: string, state: State, sessionId: string): string {
+export function buildGoalIdleBlock(
+  cwd: string,
+  state: State,
+  sessionId: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  // Same PowerShell constraint as loopArmDirective: inline JSON cannot survive
+  // argument parsing, so win32 gets the write-then-attest pair instead.
+  const startNext = platform === "win32"
+    ? `Either start the next work-phase now: write the JSON with \`'{"from":"IDLE","to":"P","evidence":"<diff-level plan for the next work-phase>"}' | Set-Content -Encoding utf8 .codexclaw/attest.json\` then run \`cxc orchestrate P --session ${sessionId} --attest-file .codexclaw/attest.json\``
+    : `Either start the next work-phase now: \`cxc orchestrate P --session ${sessionId} --attest '{"from":"IDLE","to":"P","evidence":"<diff-level plan for the next work-phase>"}'\``;
   const lines = [
     "[codexclaw — goal continuation] A host goal is ACTIVE but no PABCD cycle is in flight.",
     "GOAL-IDLE-CONTINUE-01: IDLE is not the end while the goal is active (LOOP-CONTINUE-01). Do not end the turn here.",
-    `Either start the next work-phase now: \`cxc orchestrate P --session ${sessionId} --attest '{"from":"IDLE","to":"P","evidence":"<diff-level plan for the next work-phase>"}'\``,
+    startNext,
     'or close the goal honestly: `update_goal` status "complete" (only when the recorded criteria are proven — the E8 gate checks a bound goalplan) or status "blocked" for an external blocker.',
     "LOOP-UNIT-CHAIN-01: work-phases chain HETEROGENEOUS units in one session — an independent feature/plan discovered mid-loop is simply the NEXT work-phase (append it to the goalplan, then orchestrate P). \"Needs its own PABCD\" is a plan statement, not a session boundary; do not close the goal while naming remaining features that fit the objective.",
   ];
@@ -1222,7 +1258,10 @@ function objectivePlateau(cwd: string, sessionId: string): PlateauCheck {
  *    Side effect by design: the counter write creates the session state file, so the
  *    suggested orchestrate command passes the G2 unknown-session guard afterwards.
  */
-export function handleStop(payload: StopPayload): string {
+export function handleStop(
+  payload: StopPayload,
+  platform: NodeJS.Platform = process.platform,
+): string {
   if (payload.hook_event_name !== "Stop") return "";
 
   const state = readState(payload.cwd, payload.session_id);
@@ -1243,7 +1282,7 @@ export function handleStop(payload: StopPayload): string {
     // bail: don't pile on during context-pressure/compaction recovery.
     if (isContextPressureTail(readTranscriptTail(payload.transcript_path))) return "";
     if (bumpStopCounter(payload.cwd, state) === "release") return "";
-    return buildGoalIdleBlock(payload.cwd, state, payload.session_id);
+    return buildGoalIdleBlock(payload.cwd, state, payload.session_id, platform);
   }
 
   // C-RENDER-GROUNDING-01 advisory: when phase === C and render-artifact files were

--- a/plugins/codexclaw/components/pabcd-state/src/plan-gate.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/plan-gate.ts
@@ -37,8 +37,10 @@ export function validatePlanArtifacts(att: Attestation | null, cwd: string): Pla
       reason:
         'P -> A requires "planUnit": the devlog/_plan/YYMMDD_slug/ unit this plan lives in ' +
         "(DIFFLEVEL-ROADMAP-01 — the plan must exist as numbered files, not chat). " +
-        "Scaffold one with `cxc plan init <slug>` if missing, write the docs, then re-attest " +
-        'with --attest \'{"from":"P","to":"A","did":"...","planUnit":"devlog/_plan/..."}\'.',
+        "Scaffold one with `cxc plan init <slug>` if missing, write the docs, then re-attest. " +
+        "Put the JSON in a file and pass --attest-file <path> (required on Windows, where " +
+        "inline JSON cannot survive shell argument parsing): " +
+        '{"from":"P","to":"A","did":"...","planUnit":"devlog/_plan/..."}',
     };
   }
   const unit = isAbsolute(att.planUnit) ? att.planUnit : resolve(cwd, att.planUnit);

--- a/plugins/codexclaw/components/pabcd-state/src/scan-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/scan-cli.ts
@@ -131,7 +131,8 @@ export function parseScanCliArgs(
         return {
           error:
             "scan record: --dim cannot set 'max'. That level gates I->P via isInterviewReady; " +
-            "use `cxc orchestrate P --session <id> --attest '{\"from\":\"I\",\"to\":\"P\",\"did\":\"<reason>\",\"override\":true}'` " +
+            "write {\"from\":\"I\",\"to\":\"P\",\"did\":\"<reason>\",\"override\":true} to a file and run " +
+            "`cxc orchestrate P --session <id> --attest-file <path>` (the file flag is required on Windows) " +
             "so the bypass is attested and recorded in the ledger.",
         };
       }

--- a/plugins/codexclaw/components/pabcd-state/test/hook-continuation.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/hook-continuation.test.ts
@@ -435,12 +435,15 @@ test("GOAL-IDLE-CONTINUE-01: active goal at IDLE blocks with the arming command"
   try {
     withGoalsDb([{ thread_id: "gi1", status: "active" }], () => {
       // no state file at all (019f4407 shape: goal created, FSM never entered)
-      const out = handleStop(stop(cwd, "gi1"));
+      const out = handleStop(stop(cwd, "gi1"), "linux");
       const parsed = JSON.parse(out.trim());
       assert.equal(parsed.decision, "block");
       assert.match(parsed.reason, /goal continuation/);
       assert.match(parsed.reason, /GOAL-IDLE-CONTINUE-01/);
-      assert.match(parsed.reason, /cxc orchestrate P --session gi1 --attest/);
+      // `--attest` is a PREFIX of `--attest-file`, so the old assertion passed on
+      // win32 by accident. Pin the POSIX form explicitly; the win32 branch is
+      // asserted separately below.
+      assert.match(parsed.reason, /cxc orchestrate P --session gi1 --attest '\{/);
       assert.match(parsed.reason, /update_goal/);
       assert.match(parsed.reason, /LOOP-UNIT-CHAIN-01/, "IDLE block must teach heterogeneous work-phase chaining");
       assert.match(parsed.reason, /cxc loop init/, "unbound session must be pointed at loop init");
@@ -448,6 +451,29 @@ test("GOAL-IDLE-CONTINUE-01: active goal at IDLE blocks with the arming command"
       const st = readState(cwd, "gi1");
       assert.equal(st.stopBlockPhase, "IDLE");
       assert.equal(st.stopBlockCount, 1);
+    });
+  } finally { rmSync(cwd, { recursive: true, force: true }); }
+});
+
+// fuck-powershell#6: the IDLE block is a Stop surface like stopNextCommand, and it
+// degraded the same way - the probe shows the inline JSON arriving as
+// {from:IDLE,to:P,evidence:<diff-level plan for the next work-phase>}.
+// Platform is injected so Linux CI drives the win32 branch.
+test("GOAL-IDLE-CONTINUE-01: the win32 block teaches the file flag, not inline attest", () => {
+  const cwd = freshCwd();
+  try {
+    withGoalsDb([{ thread_id: "gi1", status: "active" }], () => {
+      const parsed = JSON.parse(handleStop(stop(cwd, "gi1"), "win32").trim());
+      assert.equal(parsed.decision, "block");
+      assert.doesNotMatch(parsed.reason, /--attest '\{/);
+      assert.match(parsed.reason, /--attest-file \.codexclaw\/attest\.json/);
+      // The recipe, not just the flag: a negative alone would pass on text that is
+      // merely different rather than usable.
+      assert.match(parsed.reason, /Set-Content -Encoding utf8 \.codexclaw\/attest\.json/);
+      // The rest of the block must survive the branch.
+      assert.match(parsed.reason, /GOAL-IDLE-CONTINUE-01/);
+      assert.match(parsed.reason, /update_goal/);
+      assert.match(parsed.reason, /LOOP-UNIT-CHAIN-01/);
     });
   } finally { rmSync(cwd, { recursive: true, force: true }); }
 });

--- a/plugins/codexclaw/components/pabcd-state/test/hook.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/hook.test.ts
@@ -17,6 +17,7 @@ import {
   handleUserPromptSubmit,
   handleStop,
   phaseDirective,
+  loopArmDirective,
   withFooter,
   type UserPromptSubmitPayload,
   type StopPayload,
@@ -206,6 +207,54 @@ test("handleUserPromptSubmit: agbrowse request injects search directive without 
   }
 });
 
+// fuck-powershell#6: PowerShell strips the quotes from an inline JSON argument and,
+// once you escape them, splits the value at its first space. Every gated edge needs a
+// `did` narrative, which always has spaces, so no inline spelling works there. The
+// directive is injected at prompt time, so handing a Windows agent the POSIX form is
+// how it concludes the FSM is broken before running anything.
+//
+// Platform is injected so Linux CI drives the win32 branch (atomic-write.test.ts §1).
+test("win32 arming directive teaches the file flag, not inline attest", () => {
+  const win = loopArmDirective("win32");
+  assert.match(win, /--attest-file \.codexclaw\/attest\.json/);
+  assert.doesNotMatch(win, /--attest <json>/);
+  // A negative alone would pass on text that is merely DIFFERENT. Assert the agent
+  // actually receives the two-step recipe it needs.
+  assert.match(win, /Set-Content -Encoding utf8 \.codexclaw\/attest\.json/);
+  // Everything else must survive the branch.
+  assert.match(win, /ORCH-MANDATE-01/);
+  assert.match(win, /LOOP-UNIT-CHAIN-01/);
+  assert.match(win, /ORCH-ARTIFACT-01/);
+});
+
+// The POSIX text is pinned as a LITERAL snapshot rather than compared against the
+// function that produces it: a self-comparison passes no matter how badly the text is
+// mangled, which is exactly the guarantee this test exists to provide.
+test("posix arming directive is byte-identical to its pinned snapshot", () => {
+  const expected = [
+    "[codexclaw: LOOP — orchestrate arming mandate (ORCH-MANDATE-01)]",
+    "A loop/goalplan claim without persisted FSM evidence is INVALID, and the PABCD FSM is not",
+    "armed right now. Arm it with explicit commands before narrating any loop work:",
+    "1. Session id: take it ONLY from your most recent SessionStart binding line",
+    "   (SESSION-IDENTITY-01 — never an id seen in transcript history).",
+    "2. `cxc orchestrate status --session <id>` — read the real phase first.",
+    "3. HOTL (user asked for autonomous / continue-until-done): create_goal with a detailed",
+    '   objective -> `cxc loop init --objective "<same text>" --session <id>` -> register',
+    "   workPhases[] + criteria[] in the goalplan -> `cxc orchestrate P --session <id>`.",
+    "   HITL (no such ask): enter the cycle explicitly via `cxc orchestrate I|P --session <id>`.",
+    "4. Advance EVERY forward edge yourself with `cxc orchestrate <phase> --attest <json>` —",
+    "   a phase without its persisted transition + artifact did not happen (ORCH-ARTIFACT-01).",
+    "   When a goalplan is bound, include the active workPhaseId in every gated attest",
+    "   (one work-phase = one full PABCD cycle).",
+    "5. After D closes to IDLE with work remaining under an active goal, immediately re-enter",
+    "   with `cxc orchestrate P --session <id>` (LOOP-UNIT-CHAIN-01).",
+    "Load and obey cxc-loop + cxc-pabcd when available. Work done outside the FSM does not",
+    "count as loop progress — re-enter and attest it.",
+  ].join("\n");
+  assert.equal(loopArmDirective("linux"), expected);
+  assert.equal(loopArmDirective("darwin"), expected);
+});
+
 test("ORCH-MANDATE-01: detectLoopArmRequest catches loop/goalplan/continue-until-done intent (EN+KO)", () => {
   assert.equal(detectLoopArmRequest("cxc-loop로 진행하자"), true);
   assert.equal(detectLoopArmRequest("HOTL 모드로 돌려줘"), true);
@@ -286,7 +335,7 @@ test("260714 wp4: B directive starves context to the active work-phase iff bound
 test("ORCH-MANDATE-01: loop request against un-armed FSM injects the arming mandate", () => {
   const cwd = freshCwd();
   try {
-    const out = handleUserPromptSubmit(ups("이 유닛 cxc-loop로 알아서 끝까지 해줘", cwd, "s1", "t1"));
+    const out = handleUserPromptSubmit(ups("이 유닛 cxc-loop로 알아서 끝까지 해줘", cwd, "s1", "t1"), "linux");
     assert.notEqual(out, "");
     const parsed = JSON.parse(out.trimEnd());
     const ctx = parsed.hookSpecificOutput.additionalContext as string;

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) — subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.10+codex.20260818121334",
-    "packageVersion": "0.2.10"
+    "manifestVersion": "0.2.11+codex.20260818121334",
+    "packageVersion": "0.2.11"
   },
   "skills": [
     {
@@ -257,49 +257,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "hasTests": true
     }
   ]

--- a/plugins/codexclaw/skills/interview/SKILL.md
+++ b/plugins/codexclaw/skills/interview/SKILL.md
@@ -61,7 +61,9 @@ The loop that prevents it:
 `--dim <dimension>=<low|mid|high>` records an explicit assertion when coverage alone
 understates what you know. It deliberately cannot set `max`: that level gates I -> P through
 `isInterviewReady`, and the sanctioned way past an unready interview is the attested
-`cxc orchestrate P --attest '{"override":true,...}'`, which leaves a ledger row.
+`cxc orchestrate P --attest-file <path>` carrying `{"override":true,...}`, which
+leaves a ledger row. (The file flag is required on Windows: PowerShell cannot pass
+inline JSON as a single argument.)
 
 ## Show the state before asking (INTERVIEW-RENDER-01)
 
@@ -139,7 +141,7 @@ and INTERVIEW-INDEPENDENT-01 governs batching by independence rather than count.
 There is no build/execute path out of Interview — the only forward move is Plan, normally after
 the readiness gate passes, unless the human explicitly overrides (override is recorded as an
 audit entry); the agent CLI path also supports override via
-`--attest '{"override":true}'` with equivalent ledger transparency.
+an attest carrying `{"override":true}` with equivalent ledger transparency.
 `proceed` means "advance to Plan", not permission to implement; the evolving
 plan/devlog stay draft interview artifacts until then.
 A chosen `proceed` executes as a real transition — `cxc orchestrate P --session <id>` (or the
@@ -175,7 +177,8 @@ The interview runtime is shipped, not planned:
   into each task message.
 - Readiness gating requires recorded scan evidence (`scanRounds >= 1`) before I -> P.
 - Agent I→P override: when the agent CLI path (`cxc orchestrate P --session <id>
-  --attest '{"from":"I","to":"P","did":"<reason>","override":true}'`) encounters
+  --attest-file <path>`, carrying
+  `{"from":"I","to":"P","did":"<reason>","override":true}`) encounters
   an unready interview tracker, it bypasses the readiness gate — mirroring the
   human chat override in `applyHumanTransition`. The tracker is NOT modified;
   `flags.interview` is pre-flipped at the transition level. The ledger records

--- a/plugins/codexclaw/skills/loop/SKILL.md
+++ b/plugins/codexclaw/skills/loop/SKILL.md
@@ -25,7 +25,9 @@ for EVERY loop entry or re-entry:
    `cxc orchestrate P --session <id>`; HITL -> `cxc orchestrate I|P --session <id>`
    (or the human chat free-pass).
 4. Advance the four gated work edges (P>A, A>B, B>C, C>D) with
-   `cxc orchestrate <phase> --attest <json>` carrying the phase's real artifact
+   `cxc orchestrate <phase> --attest <json>` — or `--attest-file <path>`, which is
+   REQUIRED on Windows because PowerShell cannot pass inline JSON as one argument —
+   carrying the phase's real artifact
    (ORCH-ARTIFACT-01). Entry edges (IDLE→P, I→P) are explicit commands without an
    attest JSON — the shipped gate (`dist/attest.js` GATED_TRANSITIONS) gates exactly
    those four. A phase without its persisted transition did not happen — the

--- a/plugins/codexclaw/skills/pabcd/SKILL.md
+++ b/plugins/codexclaw/skills/pabcd/SKILL.md
@@ -46,7 +46,16 @@ You can return to Interview (I) from any phase to clarify requirements; the plan
 The chat command grammar is:
 
 ```text
-orchestrate <I|P|A|B|C|D|status|reset> [--attest <json>]
+orchestrate <I|P|A|B|C|D|status|reset> [--attest <json> | --attest-file <path>]
+```
+
+**On Windows use `--attest-file`.** PowerShell strips the quotes from inline JSON
+and, once you escape them, splits the value at its first space — and every gated
+edge needs a `did` narrative, which has spaces. Write the JSON first, then attest:
+
+```powershell
+'<json>' | Set-Content -Encoding utf8 .codexclaw/attest.json
+cxc orchestrate A --session <id> --attest-file .codexclaw/attest.json
 ```
 
 Accepted prefixes include `$codexclaw:cxc-orchestrate`, `$cxc-pabcd`,
@@ -96,7 +105,8 @@ the evidence produced by the phase being advanced.
 Chat and CLI control the same persisted FSM and ledger; invocation source selects
 the gate. A line-anchored chat `orchestrate <verb>` is a human free-pass, while
 illegal edges remain refused. Agents use
-`cxc orchestrate <verb> --session <id> --attest <json>` and provide real evidence.
+`cxc orchestrate <verb> --session <id> --attest <json>` (or `--attest-file <path>`,
+required on Windows) and provide real evidence.
 `A>B` requires `auditOutput` plus `auditVerdict`; near-pass also requires
 `auditResidual`.
 `C>D` requires `checkOutput` and a passing `exitCode` — omitting it is refused, since a check with no outcome is not a check.


### PR DESCRIPTION
Promotes `dev` to `main` for 0.2.11.

## What this fixes

codexclaw told Windows agents to run a command that cannot work. Every
agent-facing surface handed out inline `--attest '<json>'`:

```
cxc orchestrate A --session <id> --attest '{"from":"P","to":"A","did":"wrote the plan"}'
-> attest JSON is not valid JSON
```

PowerShell strips the quotes from a single-quoted argument, so the CLI receives
`{from:P,to:A,did:wrote the plan}`. Escaping them appears to fix it and then
splits the argument at the first space inside a value. Every gated edge requires
a `did` narrative, which always has spaces, so **there is no inline spelling that
works**. An agent following the instruction concludes the FSM is broken — which
is exactly what happened in the session that found this.

Filed upstream as [fuck-powershell#6](https://github.com/lidge-jun/fuck-powershell/issues/6).

## Why it survived this long

`renderOrchestrateHelp` and `stopNextCommand` were already platform-aware. That
made it easy to assume the rest were too. They were not, and the worst offender
was the one nobody looks at: `LOOP_ARM_DIRECTIVE` is injected at **prompt time**
by the UserPromptSubmit hook, so every agent starting loop work on Windows was
handed a failing command before running anything.

Six surfaces fixed: the arming mandate, the goal-continuation Stop block, the
`P -> A` plan-unit rejection (the most-traveled gated edge), the interview
override rejection (reached exactly when an agent is stuck), and the `pabcd`,
`loop` and `interview` skills.

## Audit

Two rounds, both useful.

Round 1 returned **fail** on a P0 I would have shipped: the proposed
POSIX-parity test compared `loopArmDirective("linux")` against a constant
*defined as* `loopArmDirective("linux")` — a tautology that passes no matter how
badly the text is mangled. It is now a literal snapshot, and I mutation-tested it
by changing one word of the directive and confirming it fails.

Round 2 returned **near-pass** and found `plan-gate.ts:41`, a fourth runtime
emitter my own sweep could not see because the string is split across a `+`
concatenation with an escaped quote, so `rg -F` cannot match it.

It also caught that `hook-continuation.test.ts` asserted `/--attest/` — a
**prefix** of `--attest-file` — so it stayed green on Windows regardless of the
code. That test now pins the POSIX form, with a sibling case for win32.

## Verification

Platform is injected through `handleUserPromptSubmit`, `handleStop` and
`buildGoalIdleBlock`, so Linux CI drives the win32 branches rather than leaving
them untested — this repo's own convention (`atomic-write.test.ts`).

- native Windows: 1933 tests, 1925 pass, 0 fail, 8 skip
- WSL Ubuntu: 1933 tests, 1932 pass, 0 fail, 1 skip
- shipped `dist/` verified directly: `loopArmDirective("win32")` prints the
  `Set-Content` recipe, `"linux"` prints the inline form

## Deferred

`docs-site` carries five inline examples with no Windows note. Left to a
follow-up rather than widening this unit past the code fix.
