### PR TITLE
Unblock the 0.2.16 release: bind the tests badge to the suite that ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,20 @@ jobs:
       # Measure the suite ONCE and reuse the total. bash is pinned on purpose: the
       # windows runners default to PowerShell, which does not propagate a pipeline's
       # exit status, so `npm test | tee` there would report success over a failing
-      # suite. Same TAP grammar as release.yml, so one parser serves both callers.
+      # suite.
+      #
+      # The pattern anchors on the RIGHT, not on the leading glyph. `ℹ` is three UTF-8
+      # bytes, and `^.` only spans it in a UTF-8 locale: Git bash on the windows runners
+      # runs under C, where `^. tests` matches nothing. In a full log `tests <n>$` matches
+      # exactly one line — the TAP summary — because a test title never ends that way.
       - name: Run the suite
         id: suite
         shell: bash
         run: |
           set -euo pipefail
           npm test 2>&1 | tee /tmp/ci-suite.log
-          total="$(grep -Eo '^. tests [0-9]+' /tmp/ci-suite.log | tail -1 | grep -Eo '[0-9]+')"
+          # `|| true` so a miss reaches the explicit check below instead of dying on set -e.
+          total="$(grep -Eo 'tests [0-9]+$' /tmp/ci-suite.log | tail -1 | grep -Eo '[0-9]+' || true)"
           if [ -z "$total" ]; then
             echo "could not parse a test total out of the suite output" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,30 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - run: npm test
-      - run: node plugins/codexclaw/scripts/inventory.mjs --check
+      # Measure the suite ONCE and reuse the total. bash is pinned on purpose: the
+      # windows runners default to PowerShell, which does not propagate a pipeline's
+      # exit status, so `npm test | tee` there would report success over a failing
+      # suite. Same TAP grammar as release.yml, so one parser serves both callers.
+      - name: Run the suite
+        id: suite
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm test 2>&1 | tee /tmp/ci-suite.log
+          total="$(grep -Eo '^. tests [0-9]+' /tmp/ci-suite.log | tail -1 | grep -Eo '[0-9]+')"
+          if [ -z "$total" ]; then
+            echo "could not parse a test total out of the suite output" >&2
+            exit 1
+          fi
+          echo "total=$total" >> "$GITHUB_OUTPUT"
+      # The tests badge is the one published count that cannot be derived from the
+      # payload, so it is checked against what the suite just measured. Skipping this
+      # is how 2,026 survived three versions and stopped the release gate instead.
+      - name: Inventory and published counts
+        shell: bash
+        run: |
+          set -euo pipefail
+          node plugins/codexclaw/scripts/inventory.mjs --check --tests "${{ steps.suite.outputs.total }}"
       - run: node plugins/codexclaw/scripts/gate.mjs
       # The suites above are largely pure-function suites. This executes the spawn
       # ladders, the bench, and the bundle - the surfaces where the audited win32

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,21 @@ jobs:
         run: |
           set -euo pipefail
           npm test 2>&1 | tee /tmp/suite.log
-          pass="$(grep -Eo '^. pass [0-9]+' /tmp/suite.log | tail -1 | grep -Eo '[0-9]+')"
-          fail="$(grep -Eo '^. fail [0-9]+' /tmp/suite.log | tail -1 | grep -Eo '[0-9]+')"
           # The published badge counts TESTS. CI skips the repo-map live smoke, so
           # `pass` is environment-dependent while `tests` is not.
-          total="$(grep -Eo '^. tests [0-9]+' /tmp/suite.log | tail -1 | grep -Eo '[0-9]+')"
+          #
+          # Anchor on the right: `ℹ` is three UTF-8 bytes and `^.` only spans it in a
+          # UTF-8 locale. This job runs on ubuntu, where that held — but the same
+          # expression silently matched nothing under the C locale of Git bash, which is
+          # how it failed the first time it ran on a windows runner. Locale-independent
+          # here too, so the grammar cannot rot differently in the two workflows.
+          pass="$(grep -Eo 'pass [0-9]+$' /tmp/suite.log | tail -1 | grep -Eo '[0-9]+' || true)"
+          fail="$(grep -Eo 'fail [0-9]+$' /tmp/suite.log | tail -1 | grep -Eo '[0-9]+' || true)"
+          total="$(grep -Eo 'tests [0-9]+$' /tmp/suite.log | tail -1 | grep -Eo '[0-9]+' || true)"
+          if [ -z "$pass" ] || [ -z "$fail" ] || [ -z "$total" ]; then
+            echo "could not parse the suite summary (pass=$pass fail=$fail total=$total)" >&2
+            exit 1
+          fi
           echo "pass=$pass" >> "$GITHUB_OUTPUT"
           echo "fail=$fail" >> "$GITHUB_OUTPUT"
           echo "total=$total" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ A new plan you can actually finish.
   gate itself is unchanged: a plan that declares 2 or 3 still fails without an approved
   gate.
 
+- **The published tests badge is checked against the suite that ran.** The README badge
+  had said 2,026 since the suite passed that mark, and the release gate — which binds
+  the published number to the measured one — refused 0.2.16 for it. Skills and hooks
+  could never drift this way because both are counted from the payload; a test total
+  only exists once a suite has run, so nothing compared it. `inventory.mjs --check`
+  now takes an optional `--tests <measured-total>`, and CI passes the total from the
+  `npm test` run it already performs, so this drift fails on a pull request instead of
+  at the release gate three versions later.
+
 - **The `finalGate` reason stops naming a flag that does not exist.** It told the reader
   to run `cxc review-round open --lane final_gate`, which no parser accepts, so the round
   opened as a plan audit and was then refused for being one. The reason now states that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ A new plan you can actually finish.
   `npm test` run it already performs, so this drift fails on a pull request instead of
   at the release gate three versions later.
 
+- **The suite-summary parser no longer depends on the shell's locale.** Both workflows
+  read how many tests ran with `grep -Eo '^. tests [0-9]+'`. `node --test` prefixes that
+  line with `ℹ`, three UTF-8 bytes that `^.` only spans in a UTF-8 locale — so under the
+  C locale of Git bash on the windows runners the pattern matched nothing and the step
+  failed on a suite that had passed with `fail 0`. Both workflows now anchor on the value
+  instead of the glyph, report an unparseable summary explicitly rather than dying inside
+  the pipeline, and a new test runs every extracted pattern under both locales.
+
 - **The `finalGate` reason stops naming a flag that does not exist.** It told the reader
   to run `cxc review-round open --lane final_gate`, which no parser accepts, so the round
   opened as a plan audit and was then refused for being one. The reason now states that

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C026_passing-brightgreen" alt="2,026 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C273_passing-brightgreen" alt="2,273 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C273_passing-brightgreen" alt="2,273 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C276_passing-brightgreen" alt="2,276 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C026_passing-brightgreen" alt="2,026 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C273_passing-brightgreen" alt="2,273 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C273_passing-brightgreen" alt="2,273 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C276_passing-brightgreen" alt="2,276 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C026_passing-brightgreen" alt="2,026 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C273_passing-brightgreen" alt="2,273 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C273_passing-brightgreen" alt="2,273 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C276_passing-brightgreen" alt="2,276 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260830_goalplan-v1-default/040_release_gate_badge.md
+++ b/devlog/_plan/260830_goalplan-v1-default/040_release_gate_badge.md
@@ -112,6 +112,43 @@ running the same `npm test` under the same Node, so the matrix still tests the
 platform, not the shell. The parse reuses the release workflow's TAP expression so
 one grammar serves both callers, and a missing/unparseable total fails the step
 instead of silently passing an empty argument.
+
+### What actually broke on Windows, and the amendment (C-phase finding)
+
+Pinning bash was necessary but not sufficient. CI run `33286176438` failed both
+windows jobs at "Run the suite" while reporting `tests 2273`, `fail 0`,
+`skipped 7` — a suite that had passed. The reused expression was the defect:
+
+```
+grep -Eo '^. tests [0-9]+'
+```
+
+`node --test` prefixes its summary with `ℹ`, which is three UTF-8 bytes, and `^.`
+only spans that under a multibyte-aware locale. Git bash on the windows runners
+runs under `C`, where the pattern matches nothing; ubuntu's UTF-8 locale is why the
+release workflow never showed it. Proved directly:
+
+```
+LC_ALL=en_US.UTF-8 grep -Eo '^. tests [0-9]+'  ->  ℹ tests 2273
+LC_ALL=C           grep -Eo '^. tests [0-9]+'  ->  (no match)
+LC_ALL=C           grep -Eo 'tests [0-9]+$'    ->  tests 2273
+```
+
+With no match the total came back empty and `set -e` killed the step at the grep,
+before the explicit emptiness check could name the problem. Two amendments:
+
+1. Anchor on the value (`tests [0-9]+$`) instead of the leading glyph, in BOTH
+   workflows — `release.yml` carries the same latent bug and would hit it the day it
+   runs anywhere but ubuntu. On a real 2,300-line log that pattern matches exactly
+   one line, the summary, because a test title never ends that way.
+2. Add `|| true` to the capture so a miss reaches the explicit check and reports
+   "could not parse a test total" instead of dying anonymously.
+
+New file `plugins/codexclaw/test/suite-summary-parse.test.mjs` extracts every
+summary pattern from both workflow files and runs it under `C` and `en_US.UTF-8`,
+asserting identical matches and that the digits read are the summary's rather than a
+test title's trailing number. Restoring the old anchor makes it fail on any machine,
+so this cannot regress silently again.
 IN scope: the published tests count and its protection. OUT of scope: the badge
 *mechanism* (shields.io markup, `PUBLISHED_SURFACES`), the gate rule in
 `release-gate.ts`, the version numbers, historical counts in `CHANGELOG.md` and

--- a/devlog/_plan/260830_goalplan-v1-default/040_release_gate_badge.md
+++ b/devlog/_plan/260830_goalplan-v1-default/040_release_gate_badge.md
@@ -1,0 +1,147 @@
+# 040 wp5 — publish the 0.2.16 GitHub Release
+
+Depends on: 030. The version bump, the commits, and the `dev`→`main` promotion all
+landed (main at `aaf0e70a`, 0.2.16). What did NOT happen is the GitHub Release: the
+last published tag is `v0.2.13`, so 0.2.14, 0.2.15 and 0.2.16 exist as code and as an
+installed plugin cache but not as a release artifact.
+
+## Why the release workflow refuses
+
+A dry run of `release.yml` at 0.2.16 (run `33285027088`) failed closed at
+"Verify the release gate":
+
+```
+version kind: stable
+release verify: NOT READY — 1 blocker(s):
+  - published tests=2026 but the measured suite reported 2271
+```
+
+That is rule 5 in `release-gate.ts:371-385`: the number the docs publish must equal
+the number the suite actually measured on the candidate commit. The chain is:
+
+1. `README.md` / `README.ko.md` / `README.zh.md` carry a shields.io badge
+   `badge/tests-2%2C026_passing`.
+2. `inventory.mjs` `PUBLISHED_SURFACES` parses that badge as the published tests
+   count and `--published` prints it.
+3. `release.yml` feeds that value to `release inventory --published-tests`, which
+   stores it as `manifest.publishedCounts.tests`.
+4. The gate compares it against `testSuite.total` measured by `npm test` in the
+   same job.
+
+So the blocker is a genuine stale-doc report, not a gate defect. The badge was last
+synced when the suite had 2,026 tests; the suite has grown to 2,271 since.
+
+## Which number is correct: 2271, not 2273
+
+A local `npm test` reports **2273**, the release job measured **2271**. The
+difference is NOT platform skew and must not be papered over:
+
+- The user's worktree carries an uncommitted edit to
+  `components/cxc-ops/test/ast-grep.test.ts` that adds two tests
+  (5 → 7 `test(` calls).
+- Re-running the suite in a detached worktree at `HEAD` (`cb677571`) with the CI
+  environment (`CODEXCLAW_SKIP_REPOMAP_SMOKE=1 CI=1`) reports `tests 2271`,
+  `pass 2270`, `fail 0`, `skipped 1` — exactly what CI measured.
+
+The badge describes the shipped tree, so **2271** is the honest value. Writing 2273
+would make the badge describe an unpublished local edit and would re-break the gate
+on the next release.
+
+## Why a number fix alone is not enough
+
+`inventory.mjs --check` (run in CI at `ci.yml:43`) cross-checks published **skills**
+and **hooks** against the payload, and `readPublished()` catches the three READMEs
+disagreeing *with each other* — but nothing compares the tests badge to a real suite
+result. The count does not exist until a suite has run, so the script cannot derive
+it the way it derives skills and hooks. That asymmetry is why skills/hooks badges
+cannot drift while the tests badge drifted for three versions and was first caught by
+the release job, after the build and after the promotion to `main`.
+
+### The guard cannot be an ordinary test (audit blocker 2)
+
+The first draft of this plan proposed a test asserting "the badge equals the number
+`node --test` reports". That is not implementable:
+
+- The root test script is one glob over every suite (`package.json:24`), so a test
+  that shells out to `npm test` to learn the total re-invokes its own glob —
+  unbounded recursion.
+- Excluding itself from that inner run makes it both very slow and dishonest: it
+  would no longer measure the suite that actually ships.
+- Any *committed* total is refused by design: `inventory.json` deliberately stores
+  no test count, and `inventory.test.mjs:58-66` asserts that absence. A checked-in
+  number would be a second source of truth, which is the drift class this whole
+  mechanism exists to prevent.
+
+So the guard belongs where the number already arrives from outside: the checker takes
+the measured total as an argument.
+
+### The guard also cannot hardcode 2,271 (audit blocker 1)
+
+Adding any file under the test glob changes the total, so a badge fixed at 2,271 in
+the same commit that adds a new test is wrong on arrival. The badge is therefore
+written LAST, from a measurement of the final tree, and the number here is
+descriptive rather than a target.
+
+## Change map
+
+| File | Change |
+|------|--------|
+| `plugins/codexclaw/scripts/inventory.mjs` | `check()` accepts an optional `expectedTests`; when supplied, a published tests count that differs is a violation. New CLI form `--check --tests <total>` |
+| `.github/workflows/ci.yml` | tee the existing `npm test` output, parse its TAP `tests` total, and pass it to `inventory.mjs --check --tests <total>` — one measurement, no second suite run |
+| `plugins/codexclaw/test/inventory.test.mjs` | NEW tests: a wrong-but-self-consistent badge across all three READMEs is a violation when a measured total is supplied, and the matching total passes |
+| `README.md`, `README.ko.md`, `README.zh.md` | tests badge + `alt` text 2,026 → the final measured total, via `inventory.mjs --write --tests <total>` |
+| `CHANGELOG.md` | note the badge correction and the new drift check under 0.2.16 |
+
+`--write` also rewrites `plugins/codexclaw/inventory.json` unconditionally (audit
+blocker 4). It is byte-clean today, so the expectation is that the file does not
+change; if it does, that is a real inventory drift to inspect, not noise to commit.
+
+### The CI capture must not swallow a failing suite (audit residual)
+
+The CI matrix runs Windows twice (`ci.yml:13-27`) and the current `- run: npm test`
+step uses the platform-default shell, which is PowerShell on `windows-latest`.
+Piping `npm test` into a log there would report success even when the suite fails,
+because PowerShell does not propagate a pipeline's exit status the way
+`set -o pipefail` does. Turning a red suite green is a far worse defect than the
+stale badge this unit is fixing.
+
+The capture step is therefore pinned to `shell: bash` (available on all three
+runners) with `set -euo pipefail` and `tee`, mirroring the release workflow's
+existing measurement (`release.yml:74-85`). Bash on the Windows runner keeps
+running the same `npm test` under the same Node, so the matrix still tests the
+platform, not the shell. The parse reuses the release workflow's TAP expression so
+one grammar serves both callers, and a missing/unparseable total fails the step
+instead of silently passing an empty argument.
+IN scope: the published tests count and its protection. OUT of scope: the badge
+*mechanism* (shields.io markup, `PUBLISHED_SURFACES`), the gate rule in
+`release-gate.ts`, the version numbers, historical counts in `CHANGELOG.md` and
+`docs-site` (audit: do not mechanically rewrite those), and anything under
+`devlog/` other than this unit.
+
+## Accept criteria
+
+1. `inventory.mjs --check --tests <wrong>` exits non-zero naming the drift;
+   `--check --tests <measured>` exits 0. Bare `--check` keeps its old behavior, so
+   no existing caller breaks.
+2. The new tests FAIL when the badge disagrees with the supplied total and PASS when
+   it agrees — mutation-proved by reverting the production change, not assumed.
+3. `npm test` is green and its final `tests` total equals the badge in all three
+   READMEs.
+4. The release workflow dry run at 0.2.16 passes "Verify the release gate".
+5. A real (non-dry) run publishes `v0.2.16` with the payload tarball, `SHA256SUMS`,
+   and the candidate manifest attached.
+
+### Activation scenario for the new guard
+
+The conditional path is "published tests count disagrees with the measured total".
+C triggers it in a scratch tree: rewrite the badge to a wrong value in all three
+READMEs — self-consistent, so today's `--check` passes it — then run the check with
+the real measured total. The observable effect is a violation naming the published
+and measured numbers. Without the all-three mutation the test would pass vacuously
+through the existing cross-surface check instead of exercising the new comparison.
+
+## Risk
+
+Low. One script function gains an optional argument, one CI line, two tests, three
+doc lines. The release workflow is dispatched dry-run first, and the real run only
+publishes a tag and assets; it does not touch `main`'s tree.

--- a/plugins/codexclaw/scripts/inventory.mjs
+++ b/plugins/codexclaw/scripts/inventory.mjs
@@ -18,6 +18,7 @@
  *
  * Usage:
  *   node plugins/codexclaw/scripts/inventory.mjs --check
+ *   node plugins/codexclaw/scripts/inventory.mjs --check --tests <measured-total>
  *   node plugins/codexclaw/scripts/inventory.mjs --write [--tests <n>]
  *   node plugins/codexclaw/scripts/inventory.mjs --hash
  *   node plugins/codexclaw/scripts/inventory.mjs --published
@@ -286,7 +287,7 @@ export function applyBlocks(inventory, options = {}) {
 }
 
 export function check(options = {}) {
-  const { pluginRoot = PLUGIN_ROOT, repoRoot = REPO_ROOT } = options;
+  const { pluginRoot = PLUGIN_ROOT, repoRoot = REPO_ROOT, expectedTests = null } = options;
   const violations = [];
   const inventory = collectInventory(pluginRoot, repoRoot);
 
@@ -313,6 +314,19 @@ export function check(options = {}) {
   if (published.counts.hooks != null && published.counts.hooks !== inventory.hooks.length) {
     violations.push(
       "published hooks=" + published.counts.hooks + " but " + inventory.hooks.length + " ship",
+    );
+  }
+
+  // Skills and hooks can be counted from the payload; the test total cannot — it only
+  // exists once a suite has run. So the caller measures it and passes it in. Without
+  // this comparison the tests badge is checked only against its own copies, which is
+  // how it drifted to 2,026 across three versions and stopped the release gate
+  // instead of CI (devlog/_plan/260830_goalplan-v1-default/040).
+  if (expectedTests != null && published.counts.tests != null &&
+      published.counts.tests !== expectedTests) {
+    violations.push(
+      "published tests=" + published.counts.tests + " but the measured suite reported " +
+        expectedTests + " — run inventory.mjs --write --tests " + expectedTests,
     );
   }
 
@@ -363,13 +377,24 @@ if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import
     process.exit(0);
   }
 
-  const result = check();
+  // --tests on a check is the externally measured suite total. Bare --check keeps its
+  // old behavior so no existing caller has to change.
+  const expectedArg = argValue("--tests");
+  const expectedTests = expectedArg == null ? null : Number(expectedArg);
+  if (expectedArg != null && !Number.isInteger(expectedTests)) {
+    console.error("[codexclaw inventory] --tests must be an integer");
+    process.exit(1);
+  }
+
+  const result = check({ expectedTests });
   if (result.ok) {
     console.log(
       "[codexclaw inventory] OK — " +
         result.inventory.skills.length + " skills, " +
         result.inventory.hooks.length + " hooks, " +
-        result.inventory.components.length + " components; sets and published counts agree.",
+        result.inventory.components.length + " components; sets and published counts agree" +
+        (expectedTests == null ? "" : " (tests badge matches the measured " + expectedTests + ")") +
+        ".",
     );
     process.exit(0);
   }

--- a/plugins/codexclaw/test/inventory.test.mjs
+++ b/plugins/codexclaw/test/inventory.test.mjs
@@ -166,3 +166,58 @@ test("inventory hash is stable and changes with content", () => {
   const mutated = { ...inv, skills: inv.skills.slice(0, -1) };
   assert.notEqual(h1, inventoryHash(mutated));
 });
+
+// The tests badge is the only published count that cannot be derived from the payload,
+// so readPublished() can only prove the three READMEs agree with EACH OTHER. A wrong
+// value written to all three is self-consistent and passed the old check: that is how
+// 2,026 survived three releases and surfaced as a release-gate blocker instead of a CI
+// failure. check({ expectedTests }) is the comparison against a real measurement.
+function rewriteTestsBadge(dir, count) {
+  const pretty = count.toLocaleString("en-US").replace(/,/g, "%2C");
+  for (const f of ["README.md", "README.ko.md", "README.zh.md"]) {
+    const p = join(dir, f);
+    const body = readFileSync(p, "utf8").replace(
+      /(badge\/tests-)([\d%C,]+)(_passing)/g,
+      (_m, a, _b, c) => a + pretty + c,
+    );
+    writeFileSync(p, body);
+  }
+}
+
+test("a self-consistent but wrong tests badge fails against a measured total", () => {
+  const { dir, plugin } = scratch();
+  try {
+    rewriteTestsBadge(dir, 1234);
+
+    // Premise: the mutation is invisible to the surface-agreement check, so the
+    // assertion below cannot pass through the pre-existing violation.
+    const { counts, violations } = readPublished(dir);
+    assert.equal(counts.tests, 1234);
+    assert.deepEqual(violations, [], "all three surfaces must still agree");
+
+    const bare = check({ pluginRoot: plugin, repoRoot: dir });
+    assert.equal(bare.ok, true, "bare check must ignore the tests count: " + bare.violations.join(" | "));
+
+    const measured = check({ pluginRoot: plugin, repoRoot: dir, expectedTests: 4321 });
+    assert.equal(measured.ok, false);
+    assert.ok(
+      measured.violations.some((v) =>
+        v.includes("published tests=1234") && v.includes("measured suite reported 4321"),
+      ),
+      measured.violations.join(" | "),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a tests badge equal to the measured total passes", () => {
+  const { dir, plugin } = scratch();
+  try {
+    rewriteTestsBadge(dir, 4321);
+    const result = check({ pluginRoot: plugin, repoRoot: dir, expectedTests: 4321 });
+    assert.equal(result.ok, true, result.violations.join(" | "));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/plugins/codexclaw/test/suite-summary-parse.test.mjs
+++ b/plugins/codexclaw/test/suite-summary-parse.test.mjs
@@ -1,0 +1,117 @@
+// The TAP summary parser the CI and release workflows use to learn how many tests ran.
+//
+// It broke the first time it executed on a windows runner: `node --test` prefixes its
+// summary with `ℹ`, three UTF-8 bytes, and `grep -Eo '^. tests [0-9]+'` only spans that
+// with a multibyte-aware `.`. Git bash on the windows runners runs under the C locale,
+// where the pattern matched nothing, the total came back empty, and the step failed on a
+// suite that had actually passed with `fail 0`. Ubuntu's UTF-8 locale hid it.
+//
+// So the grammar is extracted from the workflows and exercised under BOTH locales here.
+// A future edit that reintroduces a leading-glyph anchor fails on any machine.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..", "..");
+
+// A realistic log: a test title that ends in a number, one that ends in the word tests,
+// then the summary block. Only the summary lines may be matched.
+const SAMPLE_LOG = [
+  "✔ resolves a port when PATHEXT lists 3",
+  "✔ a helper that ships no tests",
+  "✔ rejects a manifest declaring 12 tests",
+  "ℹ tests 2273",
+  "ℹ suites 0",
+  "ℹ pass 2266",
+  "ℹ fail 0",
+  "ℹ cancelled 0",
+  "ℹ skipped 7",
+  "ℹ todo 0",
+  "ℹ duration_ms 172365.0608",
+  "",
+].join("\n");
+
+/** Every `grep -Eo '<pattern>'` a workflow uses to read the suite summary. */
+function summaryPatterns(workflow) {
+  const body = readFileSync(join(repoRoot, ".github", "workflows", workflow), "utf8");
+  const found = [];
+  for (const m of body.matchAll(/grep -Eo '([^']*(?:tests|pass|fail)[^']*)'/g)) {
+    found.push(m[1]);
+  }
+  return found;
+}
+
+function grepUnder(locale, pattern, logPath) {
+  const r = spawnSync("grep", ["-Eo", pattern, logPath], {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: locale, LANG: locale },
+  });
+  return (r.stdout ?? "").trim().split("\n").filter(Boolean);
+}
+
+function withSampleLog(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-tap-"));
+  try {
+    const p = join(dir, "suite.log");
+    writeFileSync(p, SAMPLE_LOG);
+    return fn(p);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("both workflows declare a summary pattern to parse", () => {
+  for (const wf of ["ci.yml", "release.yml"]) {
+    assert.ok(summaryPatterns(wf).length > 0, wf + " declares no suite-summary grep");
+  }
+});
+
+test("every workflow summary pattern resolves identically under C and UTF-8", () => {
+  withSampleLog((logPath) => {
+    for (const wf of ["ci.yml", "release.yml"]) {
+      for (const pattern of summaryPatterns(wf)) {
+        const c = grepUnder("C", pattern, logPath);
+        const utf8 = grepUnder("en_US.UTF-8", pattern, logPath);
+        assert.ok(
+          c.length > 0,
+          wf + ": pattern " + JSON.stringify(pattern) +
+            " matches nothing under the C locale, which is what Git bash uses on the" +
+            " windows runners. Anchor on the value, not on the leading glyph.",
+        );
+        assert.deepEqual(
+          c,
+          utf8,
+          wf + ": pattern " + JSON.stringify(pattern) + " is locale-dependent",
+        );
+      }
+    }
+  });
+});
+
+test("the parsed totals are the summary numbers, not a test title's digits", () => {
+  withSampleLog((logPath) => {
+    const expected = { tests: "2273", pass: "2266", fail: "0" };
+    for (const wf of ["ci.yml", "release.yml"]) {
+      for (const pattern of summaryPatterns(wf)) {
+        const kind = ["tests", "pass", "fail"].find((k) => pattern.includes(k));
+        if (!kind) continue;
+        // The workflows take the LAST match and then extract its digits.
+        const matches = grepUnder("C", pattern, logPath);
+        const digits = /([0-9]+)/.exec(matches[matches.length - 1] ?? "");
+        assert.ok(digits, wf + ": no digits in " + JSON.stringify(pattern));
+        assert.equal(
+          digits[1],
+          expected[kind],
+          wf + ": pattern " + JSON.stringify(pattern) + " read " + digits[1] +
+            " instead of the summary's " + expected[kind] +
+            " — a test title's trailing number was matched",
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The 0.2.16 GitHub Release was blocked by its own gate:

```
release verify: NOT READY - 1 blocker(s):
  - published tests=2026 but the measured suite reported 2271
```

That was an honest report. The README tests badge had not moved since the suite passed
2,026, and the release gate binds the published number to the measured one. Skills and
hooks cannot drift this way because both are counted from the payload; a test total has
no such source, so nothing compared it and the drift survived three versions before
surfacing at the last step before publication.

Two fixes plus their guards:

- `inventory.mjs check()` takes an optional `expectedTests`, exposed as
  `--check --tests <total>`. CI passes the total from the `npm test` run it already
  performs, so this drift now fails on a pull request.
- Both workflows parsed the TAP summary with `grep -Eo '^. tests [0-9]+'`. `node --test`
  prefixes that line with a three-byte UTF-8 glyph, and `^.` only spans it in a
  multibyte-aware locale. Git bash on the windows runners is `C`, so the first CI run
  of the new step failed both windows jobs on a suite that had passed with `fail 0`.
  Both workflows now anchor on the value, and `release.yml` is fixed rather than left
  latent.

Badges move 2,026 -> 2,276.

## Testing

- CI at `0445e50a`: **4/4 SUCCESS**, including both windows jobs. Packed install
  lifecycle: success.
- Suite measured in a detached clean worktree so the local dirty tree could not inflate
  the count: `EXIT=0`, `tests 2276`.
- `inventory.mjs --check --tests 2276` and `gate.mjs`: both OK.
- Non-vacuity proved by mutation, not assumed: neutering the badge comparison fails
  `inventory.test.mjs`; restoring the old grep anchor fails `suite-summary-parse.test.mjs`
  with the C-locale message.

## Not done here

Publishing the release itself. That is a workflow dispatch against `main` once this
lands.
