### PR TITLE
fix(packaging): align Git installs with compiled release payloads

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C523_passing-brightgreen" alt="2,523 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C524_passing-brightgreen" alt="2,524 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C523_passing-brightgreen" alt="2,523 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C524_passing-brightgreen" alt="2,524 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C523_passing-brightgreen" alt="2,523 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C524_passing-brightgreen" alt="2,524 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260905_codex_code_mode_pr_research/080_ssh_applied_delivery.md
+++ b/devlog/_plan/260905_codex_code_mode_pr_research/080_ssh_applied_delivery.md
@@ -1,0 +1,101 @@
+# SSH applied-state delivery
+
+C4 satisfy-spec operator work authorized by the2026-09-06 user request. Depends
+on070's exact-head PR/promotion/release gates. No host writes before the published
+artifact SHA, frozen Git SHA and expected plugin version agree.
+
+## Concrete operator sequence
+
+Use an ignored one-shot helper under the session evidence/operator directory, not
+a production plugin/runtime module. Inputs: absolute normal CODEX_HOME, previously
+verified installed payload root, native Codex executable, full release SHA,
+expected manifest version, and expected per-file content manifest extracted from
+the verified release archive. Execute only on the three established installations.
+
+Before changing native registration, copy the complete old payload to an exclusive
+host-local backup root/plugins/codexclaw. Copy the repository's existing unchanged
+.agents/plugins/marketplace.json alongside it (same name and relative source).
+Verify every copied file hash and reject symlinks/non-files. This provides a normal
+local-marketplace rollback source even if the old cache is pruned. Back up current
+normal config privately on the same host; never print or copy credentials off-host.
+
+Main verifies each CLI and path with read-only commands. Then use native CLI:
+marketplace remove codexclaw; marketplace add lidge-jun/codexclaw --ref FULL_SHA;
+plugin add codexclaw@codexclaw --json. Resolve installedPath from this result,
+require it inside that CODEX_HOME, and compare every relative file hash and version
+to the published artifact. Do not edit the cache or config by hand.
+
+Run the installed payload's hooks retrust --key codexclaw@codexclaw --codex-home
+HOME, with no bootstrap override. Run doctor --json in a fresh process with native
+Codex and Node on PATH. Assert manifest/hooks/hook-trust/install-root PASS and the
+expected version, not merely exit0. Record before/after, per-command exit and
+installed identity; no model substitution, external notification or app shutdown.
+
+If install or verification fails after the registration change, stop promotion to
+the next host. Restore through marketplace remove/add LOCAL_BACKUP_ROOT/plugin add,
+normal re-trust and exact old-file-hash verification. Do not rely on a previous Git
+SHA reproducing a possibly locally updated old cache. Preserve all failure logs.
+If rollback also fails, report both failures and require direction; never retry
+blindly or clear the user's config, sessions, credentials or unrelated plugins.
+
+## Host bindings
+
+macmini: home /Users/junny; Node24.20.0 available for operator/check execution;
+native Codex0.146.0 remains unchanged. suji: home /Users/neuralarcadepro, existing
+native Codex0.147.0 and Node. Windows: C:\Users\user, native codex.exe from the
+existing npm package, C:\Program Files\nodejs\node.exe. Preflight confirms exact
+native paths before mutation; .cmd/POSIX wrapper behavior is not guessed.
+The old installed version at inventory is0.2.16+codex.260830094500 on all three.
+
+Installed files and a fresh CLI's validated hook trust establish available applied
+state, not hot reload of existing Codex conversations. Do not terminate those
+processes; disclose fresh-session pickup when needed. Unreachable win/oracle/ocx-ci
+remain unknown and cannot be included in an all-host success claim.
+
+## Evidence and boundaries
+
+Source confirmation of remove/add semantics is recorded by Lagrange from native
+Codex reference d2d5b702 at marketplace_add, marketplace_remove and store. Existing
+Packed install lifecycle CI exercises immutable-ref downgrade/upgrade on0.147.0;
+it does not certify0.146.0, Windows, this helper or current production trust.
+Operator preparation/rollback must be verified before promotion; actual host
+receipts, not source inspection, establish deployment success.
+
+## Helper audit fold-back
+
+Gauss identified five issues before any execution. Folded: canonical/disjoint
+paths and backup/template/release identity validation before removal; uncertain
+timeout/signal outcomes stop with recorded PID and recovery-required status rather
+than racing rollback; case-normalized pinned CODEX_BIN/PATH plus actual bare lookup;
+regular immutable config-byte copy with mode0600 or restricted Windows ACL; raw
+diagnostics stay host-local with sanitized outer summaries. Ordinary terminal
+failure still inspects native registration before local-source rollback.
+Further re-review and isolated execution remain required, not assumed passed.
+
+Second review found an uncertainty-loss edge if command-log writing failed after
+a timeout. Fixed by classifying outcome/PID/signal before logging and treating any
+receipt-write failure as recovery-required without automatic mutation. Outer
+failure-log errors cannot suppress the sanitized recovery summary. Final Gauss
+interdiff verdict PASS on helper SHA256
+b05b8a7d499592ce8fad2e85403fab922a034627a439afb2c810d15656b01951.
+Lagrange owns only the isolated macmini native lifecycle proof; production remains
+main-owned. Empty isolated-home initial trust setup is explicit CI-style bootstrap;
+the helper and all production re-trust calls have no bootstrap override.
+
+## First isolated execution: failure recovered
+
+Codex0.146.0, isolated HOME, old048ae759 install and trust initialization succeed.
+Helper backup succeeds; candidate375c02a file match fails before candidate trust
+because seven generated files are absent from Git. Automatic rollback restores
+all880 old files exactly and passes all four required doctor checks without a
+bootstrap override. No candidate applied receipt exists; separate verify/explicit
+rollback steps were NOT RUN after the failure.081 owns the packaging correction.
+Old-file digest:19289d50a1b4b50b8b20fd09363eac3ee1dd5e00f536d4f6d9846c271dff1594.
+The restored registration points to the local backup; original config byte
+identity is not claimed. Full logs remain in the isolated root and the private
+operator/lifecycle-check-* evidence files. No production write occurred.
+
+One diagnostic-only helper correction captures the original failure stage before
+rollback changes the current command stage. Current helper SHA256:
+83a925d2533abecef9883c301dba7b020f460e33b6ca1a450c6dc4926d8d5775.
+Gauss's narrow review found no behavior/recovery-policy change in that interdiff.

--- a/devlog/_plan/260905_codex_code_mode_pr_research/081_compiled_payload_parity.md
+++ b/devlog/_plan/260905_codex_code_mode_pr_research/081_compiled_payload_parity.md
@@ -1,0 +1,55 @@
+# Release blocker: compiled payload parity
+
+C4 bounded packaging repair, discovered during080's isolated deployment check.
+Goal: Git marketplace installation and the release archive contain the same
+compiler output. No new runtime behavior, dispatcher, dependencies or feature
+activation. Native rollback succeeded; production is untouched. Retain that FAIL.
+
+## Reproduced failure and cause
+
+Exact375c02a build directory has918 payload files; Git installation has911.
+Seven src/*.ts files are tracked, and build.mjs compiles them, but their generated
+dist/*.js files are ignored and untracked. Release.yml archives the post-build
+directory, while native Git installation copies the tracked snapshot. The existing
+packaging test covers runtime-reachable imports only; it misses these dormant
+library modules. git diff --exit-code also ignores untracked generated files.
+
+## Exact change map
+
+NEW, generated only by the existing remote Node24 build:
+- plugins/codexclaw/components/cxc-ops/dist/activation-trace.js
+- plugins/codexclaw/components/cxc-ops/dist/scouting-bundle.js
+- plugins/codexclaw/components/cxc-ops/dist/win-paths.js
+- plugins/codexclaw/components/messenger-bridge/dist/token-intake.js
+- plugins/codexclaw/components/subagent-config/dist/capabilities.js
+- plugins/codexclaw/components/subagent-config/dist/capability-lock.js
+- plugins/codexclaw/components/subagent-config/dist/dispatch-contract.js
+
+These are already compiled into release archives from existing tracked sources;
+commit their actual output with git add -f, consistent with the current dist policy.
+Do not change source bodies, add runtime imports or remove files from the expected
+inventory to hide the mismatch. Global dist ignore remains unchanged.
+
+MODIFY plugins/codexclaw/test/packaging.test.mjs: preserve all three existing tests;
+add one contract comparing every existing compiler source's output path against
+Git-tracked files, using build.mjs COMPONENTS/listTsFiles and one git ls-files -z
+snapshot (avoid one extra Git subprocess per generated file on drvfs).
+The independent boundary is filesystem compiler inputs versus Git index membership.
+Run it on the unmodified index first: it must fail for exactly these seven outputs;
+then stage actual generated outputs and require PASS. No prose assertions/skips.
+
+MODIFY generated root README badges via inventory.mjs --write --tests N after
+the successful full run. Expect one new test, but use the measured total, not2524
+until observed. No version reuse after publication;0.2.17 is still unpublished.
+
+## Delivery and proof
+
+Publish a focused repair PR to dev before allowing promotion PR66. Revalidate
+the resulting dev head and promotion checks; prior375c02a green CI cannot waive
+this observed packaging failure. Main keeps the active managed checkout and all
+research records. Gauss audits the plan/interdiff; Lagrange repeats the same
+isolated operator lifecycle only after the corrected ref is published.
+
+Evidence: remote RED/green packaging test, compiled bytes from unchanged sources,
+full suite/count/gate, exact-head CI/packed/WSL, and native candidate file/trust
+match plus explicit rollback. No release or production update until these pass.

--- a/devlog/_plan/260905_codex_code_mode_pr_research/082_packaging_repair_evidence.md
+++ b/devlog/_plan/260905_codex_code_mode_pr_research/082_packaging_repair_evidence.md
@@ -1,0 +1,25 @@
+# Compiled parity repair evidence
+
+081 plan independently approved by Gauss, including the one-call NUL-delimited
+Git membership check. No original test assertion, source body or runtime wiring
+was changed.
+
+On macmini, fresh source375c02a plus the new packaging test:
+
+- RED: packaging exit1; original three tests pass and the new test identifies
+  exactly the seven missing Git-tracked compiler outputs.
+- Build: existing Node24.20.0 build emits the outputs from unchanged sources.
+  Explicitly stage those seven generated files, without changing the oracle.
+- GREEN: same packaging command4pass/0fail/0skip.
+- Full suite:2524total,2523pass,0fail,0cancelled,1 existing repo-map skip;
+  69,532.825ms, exit0. The generator updates root README badges to measured2524.
+
+Evidence in session remote root R: release-packaging-{red,build,green,suite}.log.
+Source fixture: R/release-packaging-source. Copies of all seven compiled outputs
+in the main checkout match the file hashes already captured from the original
+375c02a Node24 build in operator/lifecycle-check-expected.json. Nothing was
+hand-edited in generated output; global dist ignore is unchanged.
+
+This closes the bounded packaging test failure. New-ref CI, successful native
+candidate lifecycle, publication and production delivery are still required;
+the first isolated apply failure and successful recovery remain recorded in080.

--- a/plugins/codexclaw/components/cxc-ops/dist/activation-trace.js
+++ b/plugins/codexclaw/components/cxc-ops/dist/activation-trace.js
@@ -1,0 +1,151 @@
+/**
+ * activation-trace.ts — opt-in eval trace recorder (issue #11).
+ *
+ * Records skill activation through four layers:
+ *   1. installed   — skill directories that exist
+ *   2. visible     — skills with allow_implicit_invocation: true
+ *   3. activated   — SKILL.md router bodies actually loaded for a task
+ *   4. referenced  — references/subagent attachments actually selected
+ *
+ * Tracing is enabled ONLY by CODEXCLAW_TRACE_ACTIVATIONS=1 or explicit CLI.
+ * Ordinary sessions receive no additional context or artifacts.
+ */
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export const TRACE_SCHEMA_VERSION = 1;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * Whether tracing is enabled. Checks CODEXCLAW_TRACE_ACTIVATIONS env var.
+ */
+export function isTracingEnabled(
+  env                                     = process.env                                      ,
+)          {
+  return env.CODEXCLAW_TRACE_ACTIVATIONS === "1";
+}
+
+/**
+ * In-memory trace builder. Create one per turn, record events, then emit.
+ */
+export class TraceBuilder {
+           sessionId        ;
+           turnId        ;
+          workClassExpected = "unknown";
+          workClassObserved = "unknown";
+          events                    = [];
+          metadataBytes = 0;
+          routerBytes = 0;
+          referenceBytes = 0;
+          subagentBytes = 0;
+
+  constructor(sessionId        , turnId        ) {
+    this.sessionId = sessionId;
+    this.turnId = turnId;
+  }
+
+  setWorkClass(expected        , observed        )       {
+    this.workClassExpected = expected;
+    this.workClassObserved = observed;
+  }
+
+  recordInstalled(skill        , bytes        )       {
+    this.events.push({ layer: "installed", skill, bytes, timestamp: new Date().toISOString() });
+    this.metadataBytes += bytes;
+  }
+
+  recordVisible(skill        , bytes        )       {
+    this.events.push({ layer: "visible", skill, bytes, timestamp: new Date().toISOString() });
+    this.metadataBytes += bytes;
+  }
+
+  recordActivated(skill        , bytes        )       {
+    this.events.push({ layer: "activated", skill, bytes, timestamp: new Date().toISOString() });
+    this.routerBytes += bytes;
+  }
+
+  recordReferenced(skill        , reference        , bytes        , subagentTask         )       {
+    this.events.push({
+      layer: "referenced",
+      skill,
+      reference,
+      bytes,
+      subagentTask,
+      timestamp: new Date().toISOString(),
+    });
+    if (subagentTask) {
+      this.subagentBytes += bytes;
+    } else {
+      this.referenceBytes += bytes;
+    }
+  }
+
+  build()                  {
+    return {
+      schemaVersion: TRACE_SCHEMA_VERSION,
+      sessionId: this.sessionId,
+      turnId: this.turnId,
+      workClass: { expected: this.workClassExpected, observed: this.workClassObserved },
+      events: [...this.events],
+      tokenEstimates: {
+        metadata: Math.ceil(this.metadataBytes / 4),
+        routerBodies: Math.ceil(this.routerBytes / 4),
+        references: Math.ceil(this.referenceBytes / 4),
+        subagentAttachments: Math.ceil(this.subagentBytes / 4),
+      },
+    };
+  }
+}
+
+/**
+ * Write a trace to the JSONL trace file. Only writes when tracing is enabled.
+ * Appends one JSON line per trace.
+ */
+export function emitTrace(
+  trace                 ,
+  outputDir        ,
+  env                                     = process.env                                      ,
+)                {
+  if (!isTracingEnabled(env)) return null;
+  const dir = join(outputDir, ".codexclaw", "traces");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "activations.jsonl");
+  writeFileSync(path, JSON.stringify(trace) + "\n", { flag: "a" });
+  return path;
+}
+
+/**
+ * Read all traces from the JSONL file. Returns empty array when file is missing.
+ */
+export function readTraces(outputDir        )                    {
+  const path = join(outputDir, ".codexclaw", "traces", "activations.jsonl");
+  if (!existsSync(path)) return [];
+  const lines = readFileSync(path, "utf8").split("\n").filter((l) => l.trim().length > 0);
+  return lines.map((l) => JSON.parse(l)                   );
+}

--- a/plugins/codexclaw/components/cxc-ops/dist/scouting-bundle.js
+++ b/plugins/codexclaw/components/cxc-ops/dist/scouting-bundle.js
@@ -1,0 +1,173 @@
+/**
+ * scouting-bundle.ts — sanitized opt-in support/diagnostics bundle (issue #20).
+ *
+ * Generates an explicitly created, bounded, locally inspectable diagnostic
+ * artifact for field regression diagnosis. Never uploads automatically.
+ */
+import { existsSync, readFileSync, readdirSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { join, basename, relative } from "node:path";
+import { createHash } from "node:crypto";
+import { platform, hostname, release, homedir } from "node:os";
+import { escapeRegExp, homePathVariants } from "./win-paths.js";
+
+/** Schema version for the scouting bundle. */
+export const BUNDLE_SCHEMA_VERSION = 1;
+
+/** Maximum bundle size in bytes (1 MB). */
+export const MAX_BUNDLE_BYTES = 1_048_576;
+
+/** Sentinel patterns that must never appear in the bundle. */
+export const SECRET_SENTINELS = [
+  /ghp_[A-Za-z0-9]{36}/,          // GitHub PAT
+  /gho_[A-Za-z0-9]{36}/,          // GitHub OAuth
+  /sk-[A-Za-z0-9]{48}/,           // OpenAI API key
+  /xoxb-[0-9]+-[A-Za-z0-9]+/,     // Slack bot token
+  /xoxp-[0-9]+-[A-Za-z0-9]+/,     // Slack user token
+  /Bearer\s+[A-Za-z0-9._-]{20,}/, // Generic bearer token
+  /-----BEGIN\s+(RSA|EC|OPENSSH)\s+PRIVATE\s+KEY-----/, // Private keys
+];
+
+/**
+ * Redact every spelling of the home directory.
+ *
+ * win32 needs a case-insensitive match (tools lowercase paths freely) and the
+ * 8.3 short form (`C:\Users\SUPER~1`), neither of which a literal split/join finds.
+ * An empty `homeDir` returns the text untouched - `"".split("")` would explode the
+ * string into characters joined by "~" (defect #1).
+ */
+export function redactPaths(
+  text        ,
+  homeDir        ,
+  platform                  = process.platform,
+)         {
+  const variants = homePathVariants(homeDir, platform);
+  if (variants.length === 0) return text;
+  const pattern = variants.map(escapeRegExp).join("|");
+  return text.replace(new RegExp(pattern, platform === "win32" ? "gi" : "g"), "~");
+}
+
+/** Check text for secret sentinels. Returns matched patterns. */
+export function scanForSecrets(text        )           {
+  const found           = [];
+  for (const pattern of SECRET_SENTINELS) {
+    if (pattern.test(text)) {
+      found.push(pattern.source);
+    }
+  }
+  return found;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/** Generate a scouting bundle from the current environment. */
+export function generateBundle(opts
+
+
+
+
+ )                 {
+  // Windows sets USERPROFILE, not HOME (except under Git Bash), so this used to
+  // resolve to "" and every redactPaths call became split("").join("~") - which
+  // rewrites "plugin" as "p~l~u~g~i~n" and corrupts the whole bundle (defect #1).
+  const home = opts.homeDir ?? homedir();
+  const sections                  = [];
+
+  // 1. Plugin version and manifest shape
+  const manifestPath = join(opts.pluginRoot, ".codex-plugin", "plugin.json");
+  if (existsSync(manifestPath)) {
+    try {
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))                           ;
+      sections.push({
+        name: "plugin-manifest",
+        content: redactPaths(JSON.stringify({
+          name: manifest.name,
+          version: manifest.version,
+          hookCount: Array.isArray(manifest.hooks) ? manifest.hooks.length : 0,
+        }, null, 2), home),
+      });
+    } catch (err) {
+      sections.push({ name: "plugin-manifest", content: "unparseable: " + String(err) });
+    }
+  }
+
+  // 2. Platform info
+  sections.push({
+    name: "platform",
+    content: JSON.stringify({
+      os: platform(),
+      release: release(),
+      node: process.version,
+      arch: process.arch,
+    }, null, 2),
+  });
+
+  // 3. Capability lock status (redacted)
+  const lockPath = join(opts.pluginRoot, "capability-lock.json");
+  if (existsSync(lockPath)) {
+    try {
+      const lock = readFileSync(lockPath, "utf8");
+      sections.push({ name: "capability-lock", content: redactPaths(lock, home) });
+    } catch { /* skip */ }
+  }
+
+  // 4. PABCD session identifiers (no objective/prompt text)
+  if (opts.projectRoot) {
+    const sessDir = join(opts.projectRoot, ".codexclaw", "sessions");
+    if (existsSync(sessDir) && statSync(sessDir).isDirectory()) {
+      const files = readdirSync(sessDir).filter(f => f.endsWith(".json"));
+      const summaries = files.map(f => {
+        try {
+          const data = JSON.parse(readFileSync(join(sessDir, f), "utf8"))                           ;
+          return { file: f, phase: data.phase, session: data.sessionId };
+        } catch {
+          return { file: f, error: "corrupt" };
+        }
+      });
+      sections.push({ name: "pabcd-sessions", content: JSON.stringify(summaries, null, 2) });
+    }
+  }
+
+  // 5. Skill directory listing (names only)
+  const skillsDir = join(opts.pluginRoot, "skills");
+  if (existsSync(skillsDir) && statSync(skillsDir).isDirectory()) {
+    const skills = readdirSync(skillsDir).filter(n => {
+      try { return statSync(join(skillsDir, n)).isDirectory(); } catch { return false; }
+    });
+    sections.push({ name: "installed-skills", content: skills.join("\n") });
+  }
+
+  const bundle                 = {
+    schemaVersion: BUNDLE_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    platform: platform(),
+    nodeVersion: process.version,
+    sections,
+  };
+
+  return bundle;
+}
+
+/** Validate a generated bundle for secrets. Throws if secrets found. */
+export function validateBundleSecurity(bundle                )                                          {
+  const violations           = [];
+  const fullText = JSON.stringify(bundle);
+  const secrets = scanForSecrets(fullText);
+  if (secrets.length > 0) {
+    violations.push("secrets found: " + secrets.join(", "));
+  }
+  if (Buffer.byteLength(fullText) > MAX_BUNDLE_BYTES) {
+    violations.push("bundle exceeds " + MAX_BUNDLE_BYTES + " byte limit");
+  }
+  return { safe: violations.length === 0, violations };
+}

--- a/plugins/codexclaw/components/cxc-ops/dist/win-paths.js
+++ b/plugins/codexclaw/components/cxc-ops/dist/win-paths.js
@@ -1,0 +1,58 @@
+/**
+ * win-paths.ts - platform-parameterized path identity and home redaction.
+ *
+ * Adopted from opencodex `user-identity.ts:447` / `log-guard/path-safety.ts:43-73`:
+ * Windows paths are case-insensitive and `realpathSync.native` expands 8.3 short
+ * components, so "the same directory" has several legal spellings. POSIX paths
+ * have exactly one, and folding case there would merge two real directories.
+ */
+import { realpathSync } from "node:fs";
+
+/** True when two paths name the same location on `platform`. */
+export function samePathIdentity(
+  left        ,
+  right        ,
+  platform                  = process.platform,
+)          {
+  return platform === "win32" ? left.toLowerCase() === right.toLowerCase() : left === right;
+}
+
+/** Escape a literal for embedding in a RegExp. */
+export function escapeRegExp(value        )         {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Every spelling of one directory that could appear in text: both separator
+ * forms, plus the OS-canonical (8.3-expanded) form when it differs.
+ *
+ * `realpathSync.native` is the piece that catches `C:\Users\SUPER~1`, which no amount
+ * of case folding would match (001 1.2).
+ */
+export function homePathVariants(
+  homeDir        ,
+  platform                  = process.platform,
+  realpath                        = (p) => realpathSync.native(p),
+)           {
+  const trimmed = homeDir.trim();
+  if (trimmed.length === 0) return [];
+  const seen = new Set        ();
+  const add = (v        ) => {
+    if (v.length > 0) seen.add(v);
+  };
+  const both = (v        ) => {
+    add(v.split("\\").join("/"));
+    add(v.split("/").join("\\"));
+  };
+  both(trimmed);
+  if (platform === "win32") {
+    try {
+      both(realpath(trimmed));
+    } catch {
+      // An unreadable home is not a redaction failure; the literal forms stand.
+    }
+  }
+  // Longest first, so C:/Users/x/AppData never redacts before C:/Users/x would
+  // have, leaving a dangling suffix.
+  return [...seen].sort((a, b) => b.length - a.length);
+}

--- a/plugins/codexclaw/components/messenger-bridge/dist/token-intake.js
+++ b/plugins/codexclaw/components/messenger-bridge/dist/token-intake.js
@@ -1,0 +1,119 @@
+/**
+ * token-intake.ts -- secret-safe token intake paths (issue #12).
+ *
+ * Provides alternatives to placing raw tokens in agent-authored JSON payloads.
+ * Three intake modes:
+ *   1. stdin   -- read from stdin (non-interactive, pipe-friendly)
+ *   2. file    -- read from a temp file (owner-only 0600), then securely remove
+ *   3. env     -- read from an environment variable, then unset
+ *
+ * The token never appears in argv, process title, or command payloads.
+ * Validation errors are generic and do not include token fragments.
+ */
+import { readFileSync, unlinkSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+
+
+
+
+
+
+
+
+
+/**
+ * Read a token from stdin (one line, trimmed).
+ * Resolves after the first line or EOF.
+ */
+export function readTokenFromStdin(stream                        )                        {
+  const input = stream ?? process.stdin;
+  return new Promise((resolve) => {
+    const rl = createInterface({ input, terminal: false });
+    let token = "";
+    let resolved = false;
+    rl.on("line", (line) => {
+      if (!resolved) {
+        token = line.trim();
+        resolved = true;
+        rl.close();
+      }
+    });
+    rl.on("close", () => {
+      if (!resolved) {
+        resolve({ ok: false, error: "no token provided on stdin", mode: "stdin" });
+        return;
+      }
+      if (token.length === 0) {
+        resolve({ ok: false, error: "empty token", mode: "stdin" });
+        return;
+      }
+      resolve({ ok: true, token, mode: "stdin" });
+    });
+    rl.on("error", () => {
+      if (!resolved) {
+        resolve({ ok: false, error: "failed to read stdin", mode: "stdin" });
+      }
+    });
+  });
+}
+
+/**
+ * Read a token from a file, then securely remove it.
+ * File must be owner-only (mode 0600 or 0400) on Unix.
+ */
+export function readTokenFromFile(path        )               {
+  try {
+    const stat = statSync(path);
+    // On Unix, check permissions (skip on Windows where mode is meaningless)
+    if (process.platform !== "win32") {
+      const mode = stat.mode & 0o777;
+      if (mode & 0o077) {
+        return { ok: false, error: "token file must be owner-only (0600)", mode: "file" };
+      }
+    }
+    const token = readFileSync(path, "utf8").trim();
+    // Securely remove the file
+    try { unlinkSync(path); } catch { /* best-effort */ }
+    if (token.length === 0) {
+      return { ok: false, error: "empty token file", mode: "file" };
+    }
+    return { ok: true, token, mode: "file" };
+  } catch {
+    return { ok: false, error: "failed to read token file", mode: "file" };
+  }
+}
+
+/**
+ * Read a token from an environment variable, then unset it.
+ */
+export function readTokenFromEnv(varName        )               {
+  const token = (process.env[varName] ?? "").trim();
+  // Unset the variable to reduce persistence surface
+  delete process.env[varName];
+  if (token.length === 0) {
+    return { ok: false, error: "environment variable not set or empty", mode: "env" };
+  }
+  return { ok: true, token, mode: "env" };
+}
+
+/**
+ * Write a token to a temp file with owner-only permissions.
+ * Returns the path. The caller or readTokenFromFile will remove it.
+ */
+export function writeTokenFile(dir        , token        )         {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, ".cxc-token-" + Date.now());
+  writeFileSync(path, token, { mode: 0o600 });
+  return path;
+}
+
+/**
+ * Scan a string for token-like values and redact them.
+ * Used to sanitize error messages and logs.
+ */
+export function redactToken(text        , token        )         {
+  if (!token || token.length < 8) return text;
+  return text.split(token).join("[REDACTED]");
+}

--- a/plugins/codexclaw/components/subagent-config/dist/capabilities.js
+++ b/plugins/codexclaw/components/subagent-config/dist/capabilities.js
@@ -1,0 +1,128 @@
+/**
+ * capabilities.ts — runtime capability resolution (issue #7).
+ *
+ * One canonical resolver for non-frontend runtime surfaces. Resolves:
+ *  - hosted discovery availability (web_search tool)
+ *  - browser/proof capabilities
+ *  - V1 vs V2 subagent spawn surface
+ *  - effective concurrency limits
+ *  - available model catalog
+ *
+ * Skills own workflow semantics (search proof ladder, Luna discovery lane,
+ * PABCD dispatch contracts). This module owns exact tool/model/wire identities.
+ */
+
+/** Known tool capabilities the runtime may expose. */
+
+
+
+
+
+
+
+
+/** V1 uses spawn_agent with items[]; V2 uses create_task with task_name. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * Detect spawn surface from environment signals.
+ * V2 is the default for Codex >= 0.1.2025070100 (codex-rs multi_agents_spec v2).
+ * V1 fallback when CODEXCLAW_SPAWN_V1=1 is set.
+ */
+export function detectSpawnSurface(
+  env                                     = process.env                                      ,
+)               {
+  if (env.CODEXCLAW_SPAWN_V1 === "1") return "v1";
+  // Default to v2 — the shipped Codex runtime uses deny_unknown_fields on v2
+  return "v2";
+}
+
+/**
+ * Detect tool availability from a list of tool names the runtime exposes.
+ * When no tool list is available, all tools default to available (fail-open).
+ */
+export function detectToolCapabilities(
+  exposedTools           ,
+)                                          {
+  const allTools                   = [
+    "web_search", "browser", "apply_patch", "exec_command",
+    "spawn_agent", "create_task",
+  ];
+  const result                                  = {};
+  for (const tool of allTools) {
+    if (!exposedTools) {
+      // fail-open: assume available when we cannot detect
+      result[tool] = { available: true, source: null };
+    } else {
+      const found = exposedTools.includes(tool);
+      result[tool] = { available: found, source: found ? "native" : null };
+    }
+  }
+  return result                                           ;
+}
+
+/**
+ * Resolve concurrency limits.
+ * Defaults: 4 concurrent agents, 3 concurrent searches.
+ * Overridable via env: CODEXCLAW_MAX_AGENTS, CODEXCLAW_MAX_SEARCHES.
+ */
+export function resolveConcurrency(
+  env                                     = process.env                                      ,
+)                    {
+  const parseLimit = (val                    , fallback        )         => {
+    if (!val) return fallback;
+    const n = parseInt(val, 10);
+    return Number.isFinite(n) && n >= 0 ? n : fallback;
+  };
+  return {
+    maxConcurrentAgents: parseLimit(env.CODEXCLAW_MAX_AGENTS, 4),
+    maxConcurrentSearches: parseLimit(env.CODEXCLAW_MAX_SEARCHES, 3),
+  };
+}
+
+/**
+ * Build the complete runtime capabilities snapshot.
+ * Pure and deterministic — reads only env vars and optional injected state.
+ */
+export function resolveCapabilities(deps
+
+
+
+
+  = {})                      {
+  const env = deps.env ?? (process.env                                      );
+  return {
+    tools: detectToolCapabilities(deps.exposedTools),
+    spawnSurface: detectSpawnSurface(env),
+    concurrency: resolveConcurrency(env),
+    modelIds: deps.modelIds ?? [],
+    ocxActive: deps.ocxActive ?? false,
+  };
+}

--- a/plugins/codexclaw/components/subagent-config/dist/capability-lock.js
+++ b/plugins/codexclaw/components/subagent-config/dist/capability-lock.js
@@ -1,0 +1,113 @@
+/**
+ * capability-lock.ts — versioned Codex capability lock (issue #16).
+ *
+ * A small fixture describing the native Codex surfaces codexclaw depends on.
+ * Used by doctor and the capability resolver to make drift explicit without
+ * copying runtime identities into skill documents.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+/** Schema version for the capability lock fixture. */
+export const LOCK_SCHEMA_VERSION = 1;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/** Validate a capability lock object. Returns error messages or empty array. */
+export function validateLock(lock         )           {
+  const errors           = [];
+  if (!lock || typeof lock !== "object") {
+    errors.push("lock must be a non-null object");
+    return errors;
+  }
+  const obj = lock                           ;
+  if (obj.schemaVersion !== LOCK_SCHEMA_VERSION) {
+    errors.push("schemaVersion must be " + LOCK_SCHEMA_VERSION + ", got " + String(obj.schemaVersion));
+  }
+  if (!Array.isArray(obj.entries)) {
+    errors.push("entries must be an array");
+    return errors;
+  }
+  for (let i = 0; i < obj.entries.length; i++) {
+    const e = obj.entries[i]                           ;
+    if (typeof e.name !== "string" || !e.name) errors.push("entries[" + i + "].name must be a non-empty string");
+    if (typeof e.required !== "boolean") errors.push("entries[" + i + "].required must be a boolean");
+    if (e.channel !== "stable" && e.channel !== "canary") errors.push("entries[" + i + "].channel must be stable or canary");
+    if (typeof e.usage !== "string" || !e.usage) errors.push("entries[" + i + "].usage must be a non-empty string");
+  }
+  return errors;
+}
+
+/**
+ * Read and validate a capability lock from a JSON file.
+ * Returns the lock or an error description.
+ */
+export function readCapabilityLock(path        )                                               {
+  if (!existsSync(path)) {
+    return { error: "lock file not found: " + path };
+  }
+  try {
+    const data = JSON.parse(readFileSync(path, "utf8"));
+    const errors = validateLock(data);
+    if (errors.length > 0) {
+      return { error: "invalid lock: " + errors.join("; ") };
+    }
+    return { lock: data                   };
+  } catch (err) {
+    return { error: "unparseable lock: " + String(err) };
+  }
+}
+
+/**
+ * Check capabilities against the lock. Returns entries that are required
+ * but not available in the current runtime.
+ */
+export function checkAgainstLock(
+  lock                ,
+  availableCapabilities             ,
+)                                                                  {
+  const missing                                                                  = [];
+  for (const entry of lock.entries) {
+    if (entry.required && !availableCapabilities.has(entry.name)) {
+      missing.push({ name: entry.name, usage: entry.usage, channel: entry.channel });
+    }
+  }
+  return missing;
+}
+
+/** The default stable lock fixture for codexclaw. */
+export const DEFAULT_STABLE_LOCK                 = {
+  schemaVersion: LOCK_SCHEMA_VERSION,
+  generatedAt: "2026-08-15T00:00:00Z",
+  entries: [
+    { name: "exec_command", required: true, channel: "stable", usage: "shell execution for build/test/doctor" },
+    { name: "apply_patch", required: true, channel: "stable", usage: "file editing" },
+    { name: "web_search", required: false, channel: "stable", usage: "search skill discovery" },
+    { name: "spawn_agent", required: false, channel: "stable", usage: "V1 subagent dispatch" },
+    { name: "create_task", required: false, channel: "stable", usage: "V2 subagent dispatch" },
+    { name: "browser", required: false, channel: "stable", usage: "QA and proof browsing" },
+    { name: "plugin_hooks", required: true, channel: "stable", usage: "PABCD state transitions, Stop continuation" },
+    { name: "goal_api", required: false, channel: "canary", usage: "HOTL goal creation and management" },
+  ],
+};
+

--- a/plugins/codexclaw/components/subagent-config/dist/dispatch-contract.js
+++ b/plugins/codexclaw/components/subagent-config/dist/dispatch-contract.js
@@ -1,0 +1,130 @@
+/**
+ * dispatch-contract.ts — typed DispatchPacket and DispatchReceipt (issue #17).
+ *
+ * Expresses PABCD dispatch economy as typed contracts over native Codex spawn,
+ * without adding a scheduler or multiplying permanent agent roles.
+ */
+
+/** Worktree access policy for a dispatched subagent. */
+
+
+/** Terminal status of a dispatched subagent. */
+
+
+/**
+ * DispatchPacket — structured task specification for a subagent.
+ * Contains everything a subagent needs to complete its bounded task.
+ */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * DispatchReceipt — structured result from a dispatched subagent.
+ * Contains the evidence and findings for the main agent to evaluate.
+ */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/** Validate a DispatchPacket. Returns error messages or empty array. */
+export function validatePacket(packet         )           {
+  const errors           = [];
+  if (!packet || typeof packet !== "object") {
+    return ["packet must be a non-null object"];
+  }
+  const p = packet                           ;
+  if (typeof p.id !== "string" || !p.id) errors.push("id must be a non-empty string");
+  if (typeof p.objective !== "string" || !p.objective) errors.push("objective must be a non-empty string");
+  if (!Array.isArray(p.inputAnchors)) errors.push("inputAnchors must be an array");
+  if (typeof p.expectedOutput !== "string") errors.push("expectedOutput must be a string");
+  if (typeof p.decisionBoundary !== "string") errors.push("decisionBoundary must be a string");
+  if (!Array.isArray(p.verifierCommands)) errors.push("verifierCommands must be an array");
+  if (!Array.isArray(p.requiredSkills)) errors.push("requiredSkills must be an array");
+  if (p.worktreePolicy !== "shared-read" && p.worktreePolicy !== "isolated-write") {
+    errors.push("worktreePolicy must be shared-read or isolated-write");
+  }
+  if (p.judgmentOwnership !== "main") errors.push("judgmentOwnership must be main");
+  if (p.role !== "explorer" && p.role !== "reviewer" && p.role !== "executor") {
+    errors.push("role must be explorer, reviewer, or executor");
+  }
+  // Check for oversized skill attachment
+  if (Array.isArray(p.requiredSkills) && p.requiredSkills.length > 10) {
+    errors.push("requiredSkills exceeds maximum of 10");
+  }
+  return errors;
+}
+
+/** Validate a DispatchReceipt. Returns error messages or empty array. */
+export function validateReceipt(receipt         )           {
+  const errors           = [];
+  if (!receipt || typeof receipt !== "object") {
+    return ["receipt must be a non-null object"];
+  }
+  const r = receipt                           ;
+  if (typeof r.packetId !== "string" || !r.packetId) errors.push("packetId must be a non-empty string");
+  if (r.status !== "complete" && r.status !== "blocked" && r.status !== "inconclusive") {
+    errors.push("status must be complete, blocked, or inconclusive");
+  }
+  if (typeof r.findings !== "string") errors.push("findings must be a string");
+  if (!Array.isArray(r.evidenceAnchors)) errors.push("evidenceAnchors must be an array");
+  if (!Array.isArray(r.commandsRun)) errors.push("commandsRun must be an array");
+  if (!Array.isArray(r.unresolvedAssumptions)) errors.push("unresolvedAssumptions must be an array");
+  return errors;
+}
+
+/** Check that a receipt satisfies its packet's verifier requirements. */
+export function receiptSatisfiesPacket(packet                , receipt                 )
+
+
+  {
+  const reasons           = [];
+  if (receipt.packetId !== packet.id) {
+    reasons.push("packetId mismatch: expected " + packet.id + " got " + receipt.packetId);
+  }
+  if (receipt.status !== "complete") {
+    reasons.push("receipt status is " + receipt.status + ", not complete");
+  }
+  if (packet.verifierCommands.length > 0 && !receipt.verifierResult) {
+    reasons.push("packet has verifier commands but receipt has no verifier result");
+  }
+  if (receipt.verifierResult && receipt.verifierResult.exitCode !== 0) {
+    reasons.push("verifier exit code " + receipt.verifierResult.exitCode + " (expected 0)");
+  }
+  return { satisfied: reasons.length === 0, reasons };
+}
+

--- a/plugins/codexclaw/test/packaging.test.mjs
+++ b/plugins/codexclaw/test/packaging.test.mjs
@@ -6,6 +6,8 @@
  * repo IS the install artifact. `.gitignore` ignores dist wholesale and runtime files are
  * force-added; this test fails if any dist file transitively loaded by a runtime
  * entrypoint is NOT git-tracked (i.e. would be missing from a fresh clone).
+ * All compiler outputs must also be tracked: release archives contain the full
+ * post-build directory, including modules outside the current runtime graph.
  *
  * Entrypoint roots (Aquinas A-gate, 2026-06-30): every dist file Codex executes directly.
  *  - the 5 component cli.js entries (bin/codexclaw.mjs spawns these; hooks invoke pabcd-state
@@ -22,6 +24,7 @@ import { createHash } from "node:crypto";
 import { readFileSync, existsSync } from "node:fs";
 import { dirname, join, resolve, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { COMPONENTS, listTsFiles } from "../scripts/build.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pluginRoot = resolve(here, "..");
@@ -121,4 +124,21 @@ test("L19: the runtime graph reaches the known transitive modules (walker sanity
   assert.ok(graph.has("components/pabcd-state/dist/hook.js"), "hook.js must be in the runtime graph");
   assert.ok(graph.has("components/pabcd-state/dist/interview-ledger.js"), "interview-ledger.js must be reached");
   assert.ok(graph.has("components/pabcd-state/dist/orchestrate-cli.js"), "orchestrate-cli.js must be reached");
+});
+
+test("L19: every compiler output is git-tracked for archive/marketplace parity", () => {
+  const tracked = new Set(execFileSync("git", ["ls-files", "-z", "--", "plugins/codexclaw/components"], {
+    cwd: repoRoot, encoding: "utf8", timeout: 10000,
+  }).split("\0"));
+  const missing = [];
+  for (const component of COMPONENTS) {
+    const src = join(pluginRoot, "components", component, "src");
+    const dist = join(pluginRoot, "components", component, "dist");
+    for (const file of listTsFiles(src)) {
+      const output = join(dist, relative(src, file).replace(/\.ts$/, ".js"));
+      const path = relative(repoRoot, output).split(sep).join("/");
+      if (!tracked.has(path)) missing.push(path);
+    }
+  }
+  assert.deepEqual(missing.sort(), [], `compiler outputs absent from Git installations:\n${missing.sort().join("\n")}`);
 });


### PR DESCRIPTION
## Observed release blocker

The isolated native deployment check found918 built payload files versus911 Git-installed files. Seven tracked TypeScript sources compile into ignored/untracked JavaScript outputs. Release archives included them, but Git marketplace installs did not. The failed candidate was automatically rolled back to the exact880-file old payload with trusted hooks; production was not touched.

## Repair

- Track the seven existing compiler outputs, byte-for-byte from the unchanged Node24 build.
- Add one packaging contract asserting all compiler outputs are Git-tracked, using one NUL-delimited Git snapshot.
- Preserve all three existing packaging tests and synchronize README counts to the measured2524 tests.
- Retain deployment plan, failed-run/rollback and RED/GREEN evidence.

## Verification

macmini RED: the new test fails for exactly the seven missing outputs. After building and staging their real output, the same packaging tests pass4/4. Full suite:2524total,2523pass,0fail,0cancelled,1 existing repo-map skip. No source implementation, runtime wiring, dependency or skip changes.

Two generated files retain source-derived terminal blank lines; staged diff-check reports those formatting warnings. They are not hand-edited away from the compiler output. Exact-source build consistency and native installed-file parity remain the operative packaging gates.

This must land before release promotion #66. Exact-head CI and a successful isolated native lifecycle are required; the earlier failed attempt is not relabeled as success.
