### PR TITLE
fix(probes): revalidate source and approval provenance after execution

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C548_passing-brightgreen" alt="2,548 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C551_passing-brightgreen" alt="2,551 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C524_passing-brightgreen" alt="2,524 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C548_passing-brightgreen" alt="2,548 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C548_passing-brightgreen" alt="2,548 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C551_passing-brightgreen" alt="2,551 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C524_passing-brightgreen" alt="2,524 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C548_passing-brightgreen" alt="2,548 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C548_passing-brightgreen" alt="2,548 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C551_passing-brightgreen" alt="2,551 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C524_passing-brightgreen" alt="2,524 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C548_passing-brightgreen" alt="2,548 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260905_codex_code_mode_pr_research/090_probe_provenance_revalidation.md
+++ b/devlog/_plan/260905_codex_code_mode_pr_research/090_probe_provenance_revalidation.md
@@ -1,0 +1,57 @@
+# Promotion review repair: immutable provenance at snapshot boundaries
+
+C4 bounded evidence-integrity repair for PR66 review thread
+PRRT_kwDOTLf_586fk9jM. The finding is accepted: unrestricted children can alter
+approval/install files or the source checkout after preflight; current metadata
+hashes some inputs only after execution. Publication remains blocked until fixed.
+
+## Scope and actual boundary
+
+Modify only the recorder and its existing recording fixtures/tests, plus measured
+README count blocks after verification. No model calls, permission/profile changes,
+new runtime, report rewriting or source/worktree reset. Tests run on macmini.
+Directory isolation is not a security sandbox. Before/after snapshots detect drift
+at those boundaries; they do not prove absence of transient write-and-restore or
+provide an OS-level immutable audit trail against an unrestricted process.
+
+## Exact changes
+
+MODIFY plugins/codexclaw/scripts/probe-recorder.mjs:
+- Extend existing cleanSource to fingerprint actual Git-tracked file bytes after
+  checking exact HEAD and clean status. One NUL-delimited git ls-files snapshot;
+  validate canonical contained regular files. This also catches assume-unchanged
+  byte drift that Git status alone misses. Current source tree has no tracked
+  symlinks/submodules; unsupported source entries fail preflight rather than hiding.
+- Carry expected sourceSha in the prepared in-memory context. Every existing
+  snapshot revalidates source HEAD/status/content along with all current paths.
+- Include approval.md, install.json and prompt.txt in the existing contained-file
+  snapshot; include the resolved Codex entrypoint and recorder module bytes too.
+- Persist approval/install/Codex-entrypoint/recorder hashes from the BEFORE
+  snapshot, not a child-rewritten afterimage. Check the actual prompt buffer
+  against its pinned hash before dispatch. Keep all existing after-child and
+  after-doctor comparisons and rejection paths.
+- Preserve schema1 and existing fields. Additional before/after identities strengthen
+  newly recorded attempts; historical records are not retroactively strengthened.
+
+MODIFY plugins/codexclaw/test/probe-fixtures/recorder.mjs: reuse fake dispatcher and
+fake Codex; bind fixture source paths before serializing those scripts. Add scoped
+mutation scenarios for preflight doctor, execution and postflight doctor: approval,
+install, prompt, source bytes, source HEAD, hidden source byte drift and Codex
+entrypoint. All mutations remain inside that fixture's temp root. A separate
+copied-recorder scenario must never modify the real repository recorder.
+
+MODIFY plugins/codexclaw/test/probe-recorder.test.mjs: preserve originals. Show RED
+before the recorder fix, then GREEN for those reachable boundaries; assert no
+inference on preflight drift, postflightError/ok:false for later drift, original
+provenance hashes retained, and analyzer rejection. Include removed-input failure
+and a harmless copied-recorder mutation with retained failed report.
+No test assertions removed, skipped or derived from the modified recorder.
+
+## Verification and review closure
+
+Focused recorder/analyzer tests and full suite on remote Node24, build/gate/
+inventory checks, source-bound independent review, exact-head CI/packed/WSL.
+Capture RED/GREEN and measured test total before updating README badges. Publish
+the focused fix to dev, reply to the actual PR66 review thread with code/test proof,
+and resolve it only after verification. Then revalidate the promoted head; previous
+green CI and the already-passing packaging lifecycle do not waive this finding.

--- a/devlog/_plan/260905_codex_code_mode_pr_research/091_provenance_repair_evidence.md
+++ b/devlog/_plan/260905_codex_code_mode_pr_research/091_provenance_repair_evidence.md
@@ -1,0 +1,27 @@
+# Provenance repair evidence
+
+090 plan and three-file source interdiff independently reviewed by Gauss: PASS,
+no concrete blockers. Original tests/assertions and schema1 remain intact.
+
+Remote macmini Node24.20.0 proof:
+
+- RED against the unchanged recorder:24 tests,0pass,24fail,0skip/cancelled.
+  The cases expose admitted drift or inability to retain the original failed report.
+- GREEN recorder/analyzer/family selection:240pass,0fail,0skip/cancelled;
+  31,632.965ms. All three stage boundaries and the copied-recorder case execute.
+- Full suite:2548total,2547pass,0fail,0cancelled,1 existing optional repo-map skip;
+  91,909.637ms, exit0. Existing build succeeds; README generator uses measured2548.
+
+Evidence: R/release-provenance-{red,green,build,suite}.log, where R is the session
+remote root already recorded in049_1. Fixture source is R/release-provenance-source.
+No model call, production installation, trust write or real recorder mutation
+occurred in these tests. Test mutations stay within synthetic temporary roots.
+
+New reports bind approval/install, actual prompt, Codex entrypoint and recorder
+hashes to the before snapshot, and compare source HEAD/status/tracked-file bytes
+at each boundary. Missing/deleted later inputs preserve failed-run provenance.
+Historical records and transient write-and-restore remain outside stronger claims.
+
+The PR66 P1 review thread stays unresolved until the verified fix is published and
+its exact-head checks pass; neither the earlier platform green nor prior isolated
+installation proof excuses the identified recording defect.

--- a/devlog/_plan/260905_codex_code_mode_pr_research/092_direct_deployment_authority.md
+++ b/devlog/_plan/260905_codex_code_mode_pr_research/092_direct_deployment_authority.md
@@ -1,0 +1,26 @@
+# User-directed direct deployment
+
+The latest user instruction is: "기다리지말고 그냥 배포해". It supersedes the
+previous requirement to wait for GitHub CI/promotion/publication before installing
+on the established SSH targets. Deploy the exact locally committed, remotely
+verified Git snapshot; label it as a direct candidate deployment, not a completed
+GitHub release. Do not forge CI, bypass branch protection, or claim open PRs merged.
+
+Retain the reviewed installer, exact file-hash comparison, private rollback copy,
+native registration and normal no-bootstrap trust checks. Only the expected-file
+producer gains an explicit direct-snapshot mode; it does not pretend a Git snapshot
+was independently verified against a nonexistent published archive.
+
+The additional PR68 review finding is accepted: status.showUntrackedFiles=no can
+hide new source files from the earlier status check. Force --untracked-files=all
+and cover all three snapshot phases with that local-config override and a new
+untracked file. Targeted remote cases pass3/3; full verification proceeds while
+deployment files are prepared. No new model experiments.
+
+Suji/Windows pre-existing trust failures remain recorded. After exact new-file
+verification, the existing normal retrust command may reconcile missing/drifted
+entries only while its matching-pin safety guard succeeds. No bootstrap override,
+manual config rewrite, app termination, unrelated plugin change or network repair.
+
+Known targets: macmini-cf, suji, desktop-c795oh4. win/oracle/ocx-ci remain unreachable
+after a fresh attempt; their installation state and deployment remain unknown.

--- a/devlog/_plan/260905_codex_code_mode_pr_research/093_direct_deployment_results.md
+++ b/devlog/_plan/260905_codex_code_mode_pr_research/093_direct_deployment_results.md
@@ -1,0 +1,74 @@
+# Direct deployment results
+
+Latest user direction: deploy now without waiting for queued CI (092).
+Deployed snapshot:8267fa99f57a1b5afd714d3e63b9d05706a562b8.
+Version:0.2.17+codex.20260905162606. This is a direct Git deployment,
+not a completed GitHub release/promotion.
+
+## Verification before deployment
+
+The untracked-source override regression passes at all three phases. Full remote
+macmini Node24 suite:2551total,2550pass,0fail,0cancelled,1 existing optional repo-map
+skip;92,106.578ms. Independent narrow review PASS. No local suite/build/typecheck.
+The deployed payload was generated with git archive from the exact commit, not a
+dirty directory.918 expected files; digest of sorted file/hash pairs:
+51fedde3fb43ccc7d371f39626a9e2d7bf9144fa942d84688d37e9dcfb592a05.
+Snapshot tar SHA256:fbc53bfea748a8632e2e1acf8a4feca62cebb396fa3e313f5a89644f1ebf7742.
+
+## Applied hosts
+
+| Host | Applied state | Fresh checks |
+|---|---|---|
+| suji | Native Git install pinned to8267fa99; all918 files match | manifest/hooks/hook-trust/install-root PASS;23 trusted; separate verify PASS |
+| desktop-c795oh4 | Native Windows Git install pinned to8267fa99; all918 files match | same four PASS;23 trusted; separate verify PASS |
+| macmini-cf | Existing source-linked install preserved; clean source checkout fast-forwarded963888e0 ->8267fa99 | all918 required files match;15 links resolve to corresponding verified source paths; same four doctor checks PASS;23 trusted |
+
+Suji/Windows normal no-bootstrap re-trust reconciled their previously recorded
+missing/drifted trust entries. No branch-protection or trust-safety override.
+The native Codex versions were not changed: macmini0.146.0; suji/Windows0.147.0.
+
+## macmini mode change and retained failures
+
+Between read-only inventory and deployment, another actor replaced macmini's old
+0.2.16 cache with a source-linked0.2.17 install from
+/Users/junny/Developer/codexclaw. The original helper's backup/apply attempts
+therefore failed preflight before any write; they are not claimed successful.
+Main re-read the actual installation and kept the new local-source mode.
+
+The clean source checkout's origin and ancestry were verified, its current payload
+and marketplace were archived privately, and only a fast-forward was performed.
+No reset, source overwrite, or application termination was used.
+
+Whole-cache equality then failed because the running GUI had16 existing generated
+Vite cache files under gui/node_modules/.vite/deps. These were preserved, not
+deleted to obtain green. The separate source-linked proof records
+trackedMatch:true and completeTreeMatch:false; it verifies every required file
+and every link target while listing those cache extras. This is not a claim of a
+fully archive-identical filesystem or a restarted/hot-reloaded GUI/session.
+
+## Backups and receipts
+
+Host-local deployment directory:
+- /Users/junny/codexclaw-deploy-20260906-01a0702d
+- /Users/neuralarcadepro/codexclaw-deploy-20260906-01a0702d
+- C:\Users\user\codexclaw-deploy-20260906-01a0702d
+
+Suji/Windows backup subdirectories retain exact old payloads, a private regular
+config preimage, native command receipts and applied.json. Windows backup uses
+restricted user/SYSTEM ACLs. macmini retains source-before.tar, the source-linked
+file proof, native re-trust log/config backup and doctor output. Config bytes were
+not copied off-host. The previously tested isolated copy-install rollback remains
+distinct from macmini's source-linked update; no production rollback was needed.
+
+Local non-secret receipts: .codexclaw/evidence/01a0702d-c493-7510-801f-7d8772a2689c/
+direct-8267fa9/{expected.json,suji-applied.json,windows-applied.json,mac-source-linked-proof.json}.
+
+## Explicitly not completed
+
+win, oracle and ocx-ci still fail SSH connection attempts; installation state and
+deployment there remain unknown. No network/auth repair or new access was attempted.
+PR65 and PR67 merged; PR66/PR68 and formal GitHub publication remain separate.
+The last public release checked was v0.2.16. Queued checks were not marked passed
+and this deployment is not described as a published v0.2.17 release. Existing
+conversations may retain loaded code/skill snapshots; fresh sessions pick up the
+installed plugin. The original research's unmet criteria were not rewritten.

--- a/plugins/codexclaw/scripts/probe-recorder.mjs
+++ b/plugins/codexclaw/scripts/probe-recorder.mjs
@@ -66,7 +66,7 @@ export function execArgs(tier, finalPath) {
 function cleanSource(root, sha) {
   if (!/^[a-f0-9]{40}$/.test(sha)) throw new Error("exact source SHA required");
   for (const [args, expected] of [
-    [["rev-parse", "HEAD"], sha], [["status", "--porcelain"], ""],
+    [["rev-parse", "HEAD"], sha], [["status", "--porcelain", "--untracked-files=all"], ""],
   ]) {
     const r = spawnSync("git", args, {cwd:root, encoding:"utf8", timeout:10000});
     if (r.status !== 0 || r.stdout.trim() !== expected) throw new Error("source identity mismatch or dirty source");

--- a/plugins/codexclaw/scripts/probe-recorder.mjs
+++ b/plugins/codexclaw/scripts/probe-recorder.mjs
@@ -71,6 +71,14 @@ function cleanSource(root, sha) {
     const r = spawnSync("git", args, {cwd:root, encoding:"utf8", timeout:10000});
     if (r.status !== 0 || r.stdout.trim() !== expected) throw new Error("source identity mismatch or dirty source");
   }
+  const listed = spawnSync("git", ["ls-files", "-z"], {cwd:root, encoding:"utf8", timeout:10000, maxBuffer:16 * 1024 * 1024});
+  if (listed.error || listed.signal || listed.status !== 0) throw new Error("source file inventory failed");
+  const files = listed.stdout.split("\0").filter(Boolean).sort().map(name => {
+    const path = real(resolve(root, name));
+    if (!inside(root, path) || !lstatSync(path).isFile()) throw new Error("contained source file required");
+    return [name, fileDigest(path)];
+  });
+  return digest(JSON.stringify([sha, files]));
 }
 
 function prepare(spec) {
@@ -105,7 +113,7 @@ function prepare(spec) {
   const out = join(root, "output");
   mkdirSync(out, {mode:0o700}); // exclusive; a failed run is never overwritten
   mkdirSync(join(home, "tmp"), {recursive:true, mode:0o700});
-  return {root, sourceRoot, home, cwd, codexHome, pluginRoot, codexBin, launchDir, out, timeoutMs, env};
+  return {root, sourceRoot, sourceSha:spec.sourceSha, home, cwd, codexHome, pluginRoot, codexBin, launchDir, out, timeoutMs, env};
 }
 
 function doctor(p, label) {
@@ -137,13 +145,18 @@ function snapshot(p) {
   }
   const hashes = {};
   for (const [key, root, name] of [["config", p.codexHome, "config.toml"],
-    ["cxcLauncher", p.launchDir, "cxc"], ["codexLauncher", p.launchDir, "codex"]]) {
+    ["cxcLauncher", p.launchDir, "cxc"], ["codexLauncher", p.launchDir, "codex"],
+    ["approval", p.root, "approval.md"], ["install", p.root, "install.json"], ["prompt", p.root, "prompt.txt"]]) {
     const path = real(join(root, name));
     if (!inside(root, path) || !lstatSync(path).isFile()) throw new Error("contained identity file required");
     hashes[key] = fileDigest(path);
   }
-  return {config:hashes.config, payload:payloadDigest(p.pluginRoot),
-    cxcLauncher:hashes.cxcLauncher, codexLauncher:hashes.codexLauncher};
+  for (const [key, file] of [["codex", p.codexBin], ["recorder", fileURLToPath(import.meta.url)]]) {
+    const path = real(file);
+    if (!lstatSync(path).isFile()) throw new Error("entrypoint identity file required");
+    hashes[key] = fileDigest(path);
+  }
+  return {...hashes, payload:payloadDigest(p.pluginRoot), source:cleanSource(p.sourceRoot, p.sourceSha)};
 }
 
 export function runOwned({bin, args, cwd, env, prompt, timeoutMs, stdoutFd, stderrFd}) {
@@ -185,6 +198,7 @@ export async function record(spec) {
     throw new Error("identity changed during preflight doctor");
   }
   const prompt = readFileSync(join(p.root, "prompt.txt"));
+  if (digest(prompt) !== before.prompt) throw new Error("prompt identity changed before dispatch");
   const finalPath = join(p.out, "final.txt"), args = execArgs(spec.serviceTier, finalPath);
   const stdoutFd = openSync(join(p.out, "stdout.jsonl"), "wx", 0o600);
   const stderrFd = openSync(join(p.out, "stderr.log"), "wx", 0o600);
@@ -208,13 +222,13 @@ export async function record(spec) {
     if (existsSync(join(p.out, name))) files[name] = fileDigest(join(p.out, name));
   }
   const report = {
-    schemaVersion:1, candidate:spec.candidate, sourceSha:spec.sourceSha,
+    schemaVersion:1, candidate:spec.candidate, sourceSha:p.sourceSha,
     pluginRoot:p.pluginRoot, version:spec.expectedVersion,
-    codexBin:p.codexBin, codexSha256:fileDigest(p.codexBin),
+    codexBin:p.codexBin, codexSha256:before.codex,
     dispatch:{path:p.env.PATH, cxc:p.env.CODEXCLAW_CXC, launcherRoot:p.launchDir},
-    recorderSha256:fileDigest(fileURLToPath(import.meta.url)),
-    approvalSha256:fileDigest(join(p.root, "approval.md")),
-    installSha256:fileDigest(join(p.root, "install.json")), promptSha256:digest(prompt),
+    recorderSha256:before.recorder,
+    approvalSha256:before.approval,
+    installSha256:before.install, promptSha256:digest(prompt),
     requested:{model:"gpt-6-astra", effort:"high", serviceTier:spec.serviceTier},
     args, timeoutMs:p.timeoutMs, before, after, beforeDoctor, afterDoctor, postflightError, outcome, files,
   };

--- a/plugins/codexclaw/test/probe-fixtures/recorder.mjs
+++ b/plugins/codexclaw/test/probe-fixtures/recorder.mjs
@@ -17,6 +17,28 @@ function replaceIdentity(phase) {
   symlinkSync(f.replacement, target);
 }
 
+function mutateProvenance(phase) {
+  const prefix = `${phase}-provenance-`;
+  if (!f.scenario.startsWith(prefix)) return;
+  const key = f.scenario.slice(prefix.length);
+  const git = args => {
+    const r = spawnSync("/usr/bin/git", args, { cwd: f.sourceRoot, encoding: "utf8", timeout: 10000,
+      env: { ...process.env, GIT_CONFIG_NOSYSTEM: "1", GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_AUTHOR_DATE: "2026-01-02T00:00:00Z", GIT_COMMITTER_DATE: "2026-01-02T00:00:00Z" } });
+    if (r.error || r.status !== 0) throw new Error("fixture Git mutation failed");
+  };
+  if (key === "source-head") {
+    git(["-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgsign=false",
+      "-c", "core.hooksPath=/dev/null", "commit", "--allow-empty", "--quiet", "-m", "changed source identity"]);
+  } else if (key.endsWith("-delete")) unlinkSync(f.provenance[key.slice(0, -7)]);
+  else {
+    if (key === "source-hidden") git(["update-index", "--assume-unchanged", "fixture.txt"]);
+    const target = f.provenance[key];
+    if (!target) throw new Error("unknown provenance fixture");
+    appendFileSync(target, "\n");
+  }
+}
+
 // These script bodies are written only under each test's canonical temp root.
 // The fake dispatcher and Codex never read shared settings or invoke a provider.
 function fakeDispatcher() {
@@ -39,6 +61,7 @@ function fakeDispatcher() {
   }
   if (f.scenario === "postdoctor-mutation" && count === 2) appendFileSync(f.config, "# postdoctor drift\n");
   replaceIdentity(count === 1 ? "preflight" : "postdoctor");
+  mutateProvenance(count === 1 ? "preflight" : "postdoctor");
 }
 
 async function fakeCodex() {
@@ -62,6 +85,7 @@ async function fakeCodex() {
     symlinkSync(f.externalDispatcher, f.dispatcher);
   }
   replaceIdentity("execution");
+  mutateProvenance("execution");
   if (f.scenario === "config-drift") appendFileSync(f.config, "# execution drift\n");
   if (f.scenario === "launcher-drift") appendFileSync(f.cxcLauncher, "# execution drift\n");
   writeFileSync(f.final, "SYNTHETIC_FIXTURE_OK\n", { mode: 0o600 });
@@ -74,6 +98,7 @@ function scriptSource(f, fn) {
 import { spawnSync } from "node:child_process";
 const f = ${JSON.stringify(f)};
 ${replaceIdentity.toString()}
+${mutateProvenance.toString()}
 await (${fn.toString()})();\n`;
 }
 
@@ -98,9 +123,14 @@ function cleanGitFixture(root) {
 
 export function recordFixture(t, scenario = "success") {
   const base = tempRoot(t, "cxc-record-");
+  const source = cleanGitFixture(base);
   const root = join(base, "run");
   const home = join(root, "home"), installed = join(home, ".codex/plugins/cache/codexclaw/fixture");
-  const f = { scenario, root, installed, home, dispatcher: join(installed, "bin/cxc.mjs"),
+  const f = { scenario, root, installed, home, sourceRoot: source.sourceRoot,
+    provenance: { approval: join(root, "approval.md"), install: join(root, "install.json"), prompt: join(root, "prompt.txt"),
+      source: join(source.sourceRoot, "fixture.txt"), "source-hidden": join(source.sourceRoot, "fixture.txt"),
+      codex: join(base, "fake-codex.mjs"), recorder: join(base, "recorder-copy.mjs") },
+    dispatcher: join(installed, "bin/cxc.mjs"),
     dist: join(installed, "components/fixture/dist/cli.js"), config: join(home, ".codex/config.toml"),
     cxcLauncher: join(home, "probe-bin/cxc"), final: join(root, "output/final.txt"),
     execMarker: join(base, "exec.marker"), doctorLog: join(base, "doctor.log"),
@@ -124,7 +154,7 @@ writeFileSync(${JSON.stringify(f.linkedMarker)}, "executed");
 process.stdout.write(${JSON.stringify(JSON.stringify(doctorReport()))});\n`);
   const codexBin = put(base, "fake-codex.mjs", scriptSource(f, fakeCodex), 0o700);
   putJson(root, "install.json", { installedPath: installed });
-  const spec = { schemaVersion: 1, candidate: "fixture", root, ...cleanGitFixture(base),
+  const spec = { schemaVersion: 1, candidate: "fixture", root, ...source,
     codexBin, expectedVersion: version, serviceTier: "priority" };
   return { ...f, base, spec };
 }

--- a/plugins/codexclaw/test/probe-fixtures/recorder.mjs
+++ b/plugins/codexclaw/test/probe-fixtures/recorder.mjs
@@ -30,6 +30,9 @@ function mutateProvenance(phase) {
   if (key === "source-head") {
     git(["-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgsign=false",
       "-c", "core.hooksPath=/dev/null", "commit", "--allow-empty", "--quiet", "-m", "changed source identity"]);
+  } else if (key === "source-untracked") {
+    git(["config", "status.showUntrackedFiles", "no"]);
+    writeFileSync(join(f.sourceRoot, "untracked.txt"), "untracked source drift\n");
   } else if (key.endsWith("-delete")) unlinkSync(f.provenance[key.slice(0, -7)]);
   else {
     if (key === "source-hidden") git(["update-index", "--assume-unchanged", "fixture.txt"]);
@@ -96,6 +99,7 @@ async function fakeCodex() {
 function scriptSource(f, fn) {
   return `#!${process.execPath}\nimport { appendFileSync, existsSync, readFileSync, writeFileSync, unlinkSync, symlinkSync, renameSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { join } from "node:path";
 const f = ${JSON.stringify(f)};
 ${replaceIdentity.toString()}
 ${mutateProvenance.toString()}

--- a/plugins/codexclaw/test/probe-recorder.test.mjs
+++ b/plugins/codexclaw/test/probe-recorder.test.mjs
@@ -286,7 +286,7 @@ for (const phase of ["preflight", "execution", "postdoctor"]) {
 }
 
 for (const phase of ["preflight", "execution", "postdoctor"]) {
-  for (const identity of ["approval", "install", "prompt", "source", "source-head", "source-hidden", "codex"]) {
+  for (const identity of ["approval", "install", "prompt", "source", "source-head", "source-hidden", "source-untracked", "codex"]) {
     test(`record rejects ${phase} provenance ${identity} drift`, darwinOnly, async t => {
       const f = recordFixture(t, `${phase}-provenance-${identity}`);
       const original = Object.fromEntries(["approval", "install", "prompt", "codex"].map(k => [k, sha(readFileSync(f.provenance[k]))]));

--- a/plugins/codexclaw/test/probe-recorder.test.mjs
+++ b/plugins/codexclaw/test/probe-recorder.test.mjs
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { closeSync, cpSync, existsSync, lstatSync, openSync, readFileSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { analyzeRun } from "../scripts/probe-evidence.mjs";
 import { execArgs, probeEnv, payloadDigest, record, runOwned } from "../scripts/probe-recorder.mjs";
 import { sha, readJson, tempRoot, put, putJson, isolatedEnv, recorderUrl, darwinOnly } from "./probe-fixtures/filesystem.mjs";
@@ -64,6 +65,12 @@ test("record accepts a clean isolated fixture exactly once and persists private 
   assert.equal(run.pluginRoot, f.installed);
   assert.equal(run.before.config, sha(readFileSync(f.config)));
   assert.equal(run.codexSha256, sha(readFileSync(f.spec.codexBin)));
+  assert.equal(run.approvalSha256, run.before.approval);
+  assert.equal(run.installSha256, run.before.install);
+  assert.equal(run.promptSha256, run.before.prompt);
+  assert.equal(run.codexSha256, run.before.codex);
+  assert.equal(run.recorderSha256, run.before.recorder);
+  assert.equal(run.before.source, sha(JSON.stringify([f.spec.sourceSha, [["fixture.txt", sha("synthetic source identity\n")]]])));
   assert.deepEqual(run.beforeDoctor, { rc: 0, selectedChecks: "PASS" });
   assert.deepEqual(run.afterDoctor, { rc: 0, selectedChecks: "PASS" });
   assert.deepEqual(run.before, run.after);
@@ -277,3 +284,58 @@ for (const phase of ["preflight", "execution", "postdoctor"]) {
     });
   }
 }
+
+for (const phase of ["preflight", "execution", "postdoctor"]) {
+  for (const identity of ["approval", "install", "prompt", "source", "source-head", "source-hidden", "codex"]) {
+    test(`record rejects ${phase} provenance ${identity} drift`, darwinOnly, async t => {
+      const f = recordFixture(t, `${phase}-provenance-${identity}`);
+      const original = Object.fromEntries(["approval", "install", "prompt", "codex"].map(k => [k, sha(readFileSync(f.provenance[k]))]));
+      if (phase === "preflight") {
+        await assert.rejects(() => record(f.spec), /identity|source/);
+        assertNoExec(f);
+      } else {
+        const result = await record(f.spec), run = recordReport(f);
+        assert.equal(run.outcome.rc, 0, "mutation must reach the postflight boundary");
+        assert.equal(result.ok, false);
+        assert.equal(run.postflightError, true);
+        assert.equal(run.sourceSha, f.spec.sourceSha);
+        assert.equal(run.approvalSha256, original.approval);
+        assert.equal(run.installSha256, original.install);
+        assert.equal(run.promptSha256, original.prompt);
+        assert.equal(run.codexSha256, original.codex);
+        assert.equal(existsSync(join(result.out, "doctor-after.json")), phase === "postdoctor");
+        if (identity === "source-hidden") assert.notEqual(run.before.source, run.after.source);
+        assertVerdict(() => analyzeRun(result.out), 1);
+      }
+    });
+  }
+}
+
+for (const identity of ["approval", "install"]) {
+  test(`record retains original provenance and failed report after ${identity} deletion`, darwinOnly, async t => {
+    const f = recordFixture(t, `execution-provenance-${identity}-delete`);
+    const original = sha(readFileSync(f.provenance[identity]));
+    const result = await record(f.spec), run = recordReport(f);
+    assert.equal(result.ok, false);
+    assert.equal(run.outcome.rc, 0);
+    assert.equal(run.postflightError, true);
+    assert.equal(run[`${identity}Sha256`], original);
+    assert.equal(existsSync(f.provenance[identity]), false);
+    assertVerdict(() => analyzeRun(result.out), 1);
+  });
+}
+
+test("record pins its own module bytes before a child mutates an isolated copy", darwinOnly, async t => {
+  const f = recordFixture(t, "execution-provenance-recorder");
+  const bytes = readFileSync(new URL(recorderUrl));
+  put(f.base, "recorder-copy.mjs", bytes);
+  const { record: copiedRecord } = await import(pathToFileURL(f.provenance.recorder).href);
+  const result = await copiedRecord(f.spec), run = recordReport(f);
+  assert.equal(result.ok, false);
+  assert.equal(run.outcome.rc, 0);
+  assert.equal(run.postflightError, true);
+  assert.equal(run.recorderSha256, sha(bytes));
+  assert.notEqual(sha(readFileSync(f.provenance.recorder)), sha(bytes));
+  assert.deepEqual(readFileSync(new URL(recorderUrl)), bytes, "real recorder must remain untouched");
+  assertVerdict(() => analyzeRun(result.out), 1);
+});


### PR DESCRIPTION
## Accepted promotion-review finding

Addresses PR #66's P1 provenance finding: an unrestricted child could change approval/install files or the source checkout after preflight, while the recorder accepted the run or recorded a rewritten afterimage.

## Repair

- Revalidate source HEAD, clean status and actual tracked-file bytes at every snapshot, including drift hidden from Git status.
- Snapshot approval/install/prompt and Codex-entrypoint/recorder bytes before execution and compare them afterward.
- Persist original provenance hashes even when a later input is changed or deleted; verify the actual prompt buffer before dispatch.
- Preserve schema1 and all existing tests. Historical records and transient write-and-restore gain no new assurance.

## Verification

macmini Node24: the 24 new negative cases all fail against the original recorder, then the recorder/analyzer/family selection passes240/240 with the fix. Full suite:2548total,2547pass,0fail,0cancelled,1 existing optional repo-map skip. Build succeeds; README counts use the measured total. Independent plan and source reviews returned PASS.

No model calls, production writes, permission changes or real-repository recorder mutation occurred in the tests. The copied-recorder case uses a temporary module copy. Exact-head CI remains a pre-merge requirement, and promotion #66 stays blocked on verified review closure.
