### PR TITLE
release: prepare CodexClaw 0.2.18

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI — status, subagent config, provider toggle, GUI launcher.",

--- a/devlog/_plan/260906_release_0_2_18/012_release_preparation.md
+++ b/devlog/_plan/260906_release_0_2_18/012_release_preparation.md
@@ -1,0 +1,40 @@
+# Version preparation and deployment preflight
+
+Prepared3bfc2474c49427c70323d09e42e384128541b51a: root/CLI/GUI/eight components
+0.2.18, matching lock workspace versions, manifest and inventory
+0.2.18+codex.20260906043759. Official plugin cachebuster helper supplied the UTC
+suffix after identifier validation. The dependency graph is structurally unchanged;
+docs-site's independent0.0.1 version is untouched. Independent Grok metadata review GO.
+
+Fresh macmini Node24.20.0 at exact3bfc2474: embedded versions and inventory2579
+pass; full suite2579total/2578pass/0fail/0cancel/1existing skip,74270.194209ms;
+build passes and source remains clean. npm audit reports0 at every severity;
+CycloneDX SBOM has83 components. No signed-provenance claim is made.
+
+Prepared installer is the previous reviewed helper with only its expected-version
+literal changed. SHA256:7ce39f5b698fe2a7c510ba853cc6da67e85760964395bba9fd1cfb223f4e842f.
+Expected-file producer SHA256:9bc768b813d83fb42e06fdc8d2a11eac0934b0684e59345d91512914142541bd.
+Both require the eventual frozen source/published payload; no direct-snapshot
+deployment was authorized in place of a release in this run.
+
+Fresh installed runtime inventory:
+- macmini-cf: Codex0.146.0, operator Node24.20.0, installed0.2.17; local source mode.
+- suji: Codex0.147.0, operator Node22.23.1, installed0.2.17; Git mode.
+- desktop-c795oh4: Codex0.147.0, Node24.19.0, installed0.2.17; Git mode.
+- local: Codex0.153.2; cache0.2.16; local marketplace points at
+  /Users/jun/Developer/new/700_projects/codexclaw. That checkout has unrelated
+  uncommitted ast-grep/diagram/script work and is NOT a clean release source.
+
+Local source/work is preserved. An optional async question asks whether to switch
+only the local install's connection to a fixed released Git source while leaving
+the dirty development checkout intact. Submission is not approval; no response
+means keep the local development connection. SSH deployment continues independently.
+No app restart or forced source reset is allowed. Unreachable aliases are checked
+separately, not treated as absent installations.
+
+Corrected PR69 passed all11 current-head checks before its normal merge to dev;
+the compact-delivery review thread was resolved with the fix evidence. PR70 was
+already merged. The release branch integrates the actual dev merge commit while
+retaining the independently reviewed0.2.18 metadata. A failed local JSON parsing
+attempt during read-only preflight performed no merge; separate structured reads
+then verified the same pinned head and green checks before the successful action.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexclaw",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexclaw",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "license": "MIT",
       "workspaces": [
         "plugins/codexclaw/components/*",
@@ -20,7 +20,7 @@
     },
     "cli": {
       "name": "@codexclaw/cli",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "bin": {
         "codexclaw": "bin/codexclaw.mjs"
       }
@@ -1949,39 +1949,39 @@
     },
     "plugins/codexclaw/components/config-guard": {
       "name": "@codexclaw/config-guard",
-      "version": "0.2.17"
+      "version": "0.2.18"
     },
     "plugins/codexclaw/components/cxc-ops": {
       "name": "@codexclaw/cxc-ops",
-      "version": "0.2.17"
+      "version": "0.2.18"
     },
     "plugins/codexclaw/components/messenger-bridge": {
       "name": "@codexclaw/messenger-bridge",
-      "version": "0.2.17"
+      "version": "0.2.18"
     },
     "plugins/codexclaw/components/pabcd-state": {
       "name": "@codexclaw/pabcd-state",
-      "version": "0.2.17"
+      "version": "0.2.18"
     },
     "plugins/codexclaw/components/provider-bridge": {
       "name": "@codexclaw/provider-bridge",
-      "version": "0.2.17"
+      "version": "0.2.18"
     },
     "plugins/codexclaw/components/recall": {
       "name": "@codexclaw/recall",
-      "version": "0.2.17"
+      "version": "0.2.18"
     },
     "plugins/codexclaw/components/skill-search": {
       "name": "@codexclaw/skill-search",
-      "version": "0.2.17"
+      "version": "0.2.18"
     },
     "plugins/codexclaw/components/subagent-config": {
       "name": "@codexclaw/subagent-config",
-      "version": "0.2.17"
+      "version": "0.2.18"
     },
     "plugins/codexclaw/gui": {
       "name": "@codexclaw/gui",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.17+codex.20260905162606",
+  "version": "0.2.18+codex.20260906043759",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI — doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge — cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) — subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.17+codex.20260905162606",
-    "packageVersion": "0.2.17"
+    "manifestVersion": "0.2.18+codex.20260906043759",
+    "packageVersion": "0.2.18"
   },
   "skills": [
     {
@@ -263,49 +263,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasTests": true
     }
   ]


### PR DESCRIPTION
Prepare0.2.18 after merged PR69/70. Changes are synchronized root/CLI/GUI/component/lock/manifest/inventory versions plus delivery evidence; no dependency graph changes. Cachebuster0.2.18+codex.20260906043759. Remote Node24 full suite2579total/2578pass/0fail/0cancel/1existing optional skip, build and embedded-version/inventory checks pass; npm audit0. Independent version-only review GO. Normal exact-head CI and promotion/release gates remain required. Existing installations receive only the verified release with private backups and normal trust. Local dirty development source is preserved; any install-source switch is separately pending user choice.