### PR TITLE
fix(skills): preserve explicitly requested task notifications

### DIFF
--- a/devlog/_plan/260906_quiet_peer_coordination/020_release.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/020_release.md
@@ -83,3 +83,52 @@ Verifier: independently contrast explicitly requested status/result sends (allow
 subject to host/wake checks) and unsolicited progress/result sends (denied). Rerun
 native21/gate/diff and fresh exact-head PR/dev/main CI. Resolve the existing review
 thread only after the corrective commit is verified and landed; no waiver or dismissal.
+
+### Notification repair root-cause and full route closure
+
+PR76 review PRRT_kwDOTLf_586fp-aw identifies the still-categorical waiting ban.
+Root cause is incomplete propagation of the explicit-request exception through all
+entrypoints, not a broken send implementation. Main reclaims the route inventory;
+search all eight changed guidance files for send/contact/notice/notification/nudge.
+The search also found dev's broad progress-notification phrase and owner's advisory
+wake phrase. These are the same failure class; stop one-location patching and amend
+all reachable wording in this one repair, followed by fresh independent audit.
+Existing user authorization is not weakened and no new outbound trigger is introduced.
+
+MODIFY plugins/codexclaw/skills/loop/references/waiting.md:
+`Do not send\nprogress notices or nudges` -> `Do not send\nunsolicited progress notices or nudges`.
+MODIFY plugins/codexclaw/skills/dev/SKILL.md:
+`progress notifications, or unsolicited follow-ups` ->
+`unsolicited progress notifications or follow-ups`.
+MODIFY plugins/codexclaw/skills/dev/references/peer-collaboration.md:
+`every outbound message: advisory-only notifications must not wake idle/completed` ->
+`every outbound message: unsolicited advisory-only notifications must not wake idle/completed`.
+Before the scenario table add: `Apply explicit user contact instructions first. The
+other rows describe defaults without such a request; host permissions and wake
+checks always apply.` This clarifies all default examples, including ACK/silence.
+
+Fresh reviewer must trace every entrypoint and compare requested progress/result
+contact in normal/waiting/idle states against unsolicited sends. Explicitly stopped,
+unknown eligibility, unsafe runtime wake, host denial and scope limits remain denied.
+Then rerun native21/gate/diff, push a new PR76 head, require all new-head checks, and
+resolve both review threads only after the verified corrective head lands.
+
+Fresh full-route A review (Schrodinger) found two further manifestations of the same
+root cause. Accept both; no conflict with prior amendments. Read-first early exit
+must not substitute a context answer for requested delivery; ACK/nudge body rules
+must also distinguish unsolicited contact. This is a source-guidance repair, not
+runtime enforcement. Add the following exact owner replacements before B:
+
+- Replace the read-first bullet with: `If reading answers a question and no contact
+  was requested, stop there. Otherwise, apply the two outbound-message triggers
+  above and all authority/wake checks. Relevance or a need for fresh judgment alone
+  does not authorize contact. Do not substitute a read-only answer for explicitly
+  requested delivery. Continue independent work where possible.`
+- Replace `Do not reply to every ACK, send repeated nudges, or turn a nonblocking advisory`
+  with `Without an explicit user request, do not reply to ACKs or send repeated nudges.
+  Do not silently turn a nonblocking advisory`.
+
+RCA: prohibitions were reviewed as isolated snippets rather than ordered decision
+paths. The fresh reviewer checks the full contact path (explicit instruction ->
+read -> wake/authority -> send -> follow-up), including early exits and body rules,
+not just the scenario table. Re-audit with that same reviewer after amendment.

--- a/devlog/_plan/260906_quiet_peer_coordination/020_release.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/020_release.md
@@ -58,3 +58,28 @@ through a new commit if necessary. Never overwrite/delete a published version ta
 
 P refresh: wp1 D complete at 15ae4434 with native21/gate/independent PASS.
 Source state is clean apart from this roadmap amendment. Version still0.2.18.
+
+## Release review repair amendment
+
+PR75 merged at aebead02 after11 green checks. Post-merge review thread
+PRRT_kwDOTLf_586fp6Sp reports P2 ambiguity: categorical notification bans can also
+read as forbidding explicitly requested status/result delivery. Accept the finding;
+two independent reviews missed this wording contradiction. No dependency or phase
+conflict: retain default-off, qualify only unsolicited notification restrictions.
+Reset/re-enter wp2 P before this bounded source repair; version remains0.2.19 and
+nothing has been published. Main owns the patch; same A reviewer verifies amendment.
+
+MODIFY plugins/codexclaw/skills/dev/references/peer-collaboration.md:
+- Before: `introductions, progress reports, advisory impacts, completion notices, unsolicited`
+- After: `unsolicited introductions, progress reports, advisory impacts, completion notices, or`
+- Before: `follow-up work, or requests to keep another task busy.`
+- After: `follow-up work, or requests to keep another task busy.`
+- Add before the list: `The following notification defaults do not prohibit contact explicitly requested by the user.`
+MODIFY plugins/codexclaw/skills/loop/SKILL.md:
+- Before: `Keep this goal's work local; do not send progress or completion notices to other`
+- After: `Keep this goal's work local; do not send unsolicited progress or completion notices to other`
+
+Verifier: independently contrast explicitly requested status/result sends (allowed
+subject to host/wake checks) and unsolicited progress/result sends (denied). Rerun
+native21/gate/diff and fresh exact-head PR/dev/main CI. Resolve the existing review
+thread only after the corrective commit is verified and landed; no waiver or dismissal.

--- a/plugins/codexclaw/skills/dev/SKILL.md
+++ b/plugins/codexclaw/skills/dev/SKILL.md
@@ -164,7 +164,7 @@ needed. Outbound messages are default-off: contact an existing task only on an
 explicit user request or for necessary coordination of a confirmed blocking
 CI/merge collision, subject to host permissions and wake checks in
 [peer collaboration](references/peer-collaboration.md). No routine discovery,
-progress notifications, or unsolicited follow-ups. Authorized subagent work uses
+unsolicited progress notifications or follow-ups. Authorized subagent work uses
 its own scoped delegation tools.
 Use `dev` plus repo tools for local facts; load `search`, `pabcd`, `loop`, `recall`,
 `cxc-qa`, or the matching `dev-*` owner for their named domains. `skill-hub` is deprecated.

--- a/plugins/codexclaw/skills/dev/references/peer-collaboration.md
+++ b/plugins/codexclaw/skills/dev/references/peer-collaboration.md
@@ -25,10 +25,11 @@ PR/commit/run or shared resource, the observed collision, and the smallest quest
 needed. A red CI run by itself, a shared repo, speculative overlap, an unknown
 owner, or a potentially useful finding does not satisfy this exception.
 
-Do not routinely scan nearby tasks at startup or a direction change. Do not send
-introductions, progress reports, advisory impacts, completion notices, unsolicited
-follow-up work, or requests to keep another task busy. Keep useful nonblocking
-findings in this task's own record. Do not contact peers merely to save research
+The following notification defaults do not prohibit contact explicitly requested
+by the user. Do not routinely scan nearby tasks at startup or a direction change.
+Do not send unsolicited introductions, progress reports, advisory impacts,
+completion notices, follow-up work, or requests to keep another task busy. Keep
+useful nonblocking findings in this task's own record. Do not contact peers merely to save research
 or to get general design approval. Both send triggers still preserve each task's
 authority and any explicit no-contact instruction.
 

--- a/plugins/codexclaw/skills/dev/references/peer-collaboration.md
+++ b/plugins/codexclaw/skills/dev/references/peer-collaboration.md
@@ -51,9 +51,11 @@ and disclose the limitation; do not emulate delivery by editing rollout files or
   fresh index and refresh a stale recipient/context before acting. Do not repeatedly
   reload everything. A summary may omit a material exception: request the narrow
   source or clarification when the missing detail matters.
-- If reading answers the question, stop there. If it does not, apply the two
-  outbound-message triggers above; relevance or a need for fresh judgment alone
-  does not authorize contact. Continue independent work where possible.
+- If reading answers a question and no contact was requested, stop there.
+  Otherwise, apply the two outbound-message triggers above and all authority/wake
+  checks. Relevance or a need for fresh judgment alone does not authorize contact.
+  Do not substitute a read-only answer for explicitly requested delivery.
+  Continue independent work where possible.
 
 Use [native execution](native-execution.md) for composition and failure handling.
 Code mode can project tool responses before returning them to the model: keep
@@ -79,7 +81,7 @@ do not wake an explicitly stopped task, and do not infer eligibility from app st
 alone. If eligibility remains unknown after a narrow read, do not automatically
 send; use available evidence and continue independent work. Ask the user only when
 that unanswered dependency actually prevents progress. Apply this wake check to
-every outbound message: advisory-only notifications must not wake idle/completed
+every outbound message: unsolicited advisory-only notifications must not wake idle/completed
 peers. Keep that impact in your own artifact for later authorized contact instead.
 
 Answering a peer question is not permission to resume an old goal, append new work
@@ -121,7 +123,8 @@ or invent a globally committed agreement state.
 If your user changes direction, re-check authorization before further contact;
 distinguish a withdrawn promise from any delivered message and the peer's still
 unconfirmed impact assessment. Do not automatically send a withdrawal notification
-or overwrite its plan. Do not reply to every ACK, send repeated nudges, or turn a nonblocking advisory
+or overwrite its plan. Without an explicit user request, do not reply to ACKs or send repeated nudges.
+Do not silently turn a nonblocking advisory
 into a required wait. For a real dependency use native bounded waits/cursors; a
 timeout is not proof the peer failed or permission to replace/terminate it.
 
@@ -144,6 +147,9 @@ Evaluate relevant and irrelevant peers, stale or contradictory context, absent
 tools, idle/explicit-stop/unknown intent, incoming questions, silent/ACK replies,
 and changed user directions. Distinguish simulation from live task delivery.
 Review these cases without sending live probe messages to unrelated tasks:
+
+Apply explicit user contact instructions first. The other rows describe defaults
+without such a request; host permissions and wake checks always apply.
 
 | Situation | Expected action |
 |---|---|

--- a/plugins/codexclaw/skills/loop/SKILL.md
+++ b/plugins/codexclaw/skills/loop/SKILL.md
@@ -30,8 +30,8 @@ follows its packet; loading loop never authorizes a leaf to start a goal or spaw
 Follow the live host tool contracts, including goal creation and blocked-status
 conditions. A plugin hook accepting a call is not proof that the call is authorized.
 
-Keep this goal's work local; do not send progress or completion notices to other
-tasks. Peer contact is limited to explicit user requests or necessary confirmed
+Keep this goal's work local; do not send unsolicited progress or completion notices
+to other tasks. Peer contact is limited to explicit user requests or necessary confirmed
 blocking CI/merge collision coordination, subject to host permissions and wake
 checks. An incoming peer question is not a new loop request or permission to resume an old
 goal. Follow [peer collaboration](../dev/references/peer-collaboration.md) for

--- a/plugins/codexclaw/skills/loop/references/waiting.md
+++ b/plugins/codexclaw/skills/loop/references/waiting.md
@@ -6,7 +6,7 @@ These continuation/dispatch rules concern this goal's own work and delegated
 subagents, not independent peer advice. Peer timeouts do not authorize retirement,
 replacement, forced wakeups, or an unconditional wait; use
 [peer collaboration](../../dev/references/peer-collaboration.md). Do not send
-progress notices or nudges to independent tasks while waiting. Contact requires
+unsolicited progress notices or nudges to independent tasks while waiting. Contact requires
 an explicit user request or necessary confirmed blocking CI/merge collision
 coordination, plus host permission and wake checks.
 


### PR DESCRIPTION
Clarify that default-off peer notifications do not prohibit contact explicitly requested by the user. Qualify the loop entrypoint's notification restriction as unsolicited, preserving host permissions and wake checks.

Addresses the post-merge P2 review on #75. Native routing tests 21/21 and drift gate pass; exact-head CI and independent scenario review are required before release.
