### PR TITLE
chore(release): promote v0.2.19 quiet peer coordination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to codexclaw are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.19] - 2026-09-06
+
+### Changed
+
+- Keep messages to independent tasks default-off. Contact now requires an explicit
+  user request or necessary coordination of a confirmed blocking CI/merge collision,
+  with host permission and wake checks. Routine progress notices and unsolicited
+  follow-ups stay in the current task; read-only context and authorized subagents
+  remain available.
+
 ## [Unreleased]
 
 ## [0.2.16] — 2026-08-30

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI — status, subagent config, provider toggle, GUI launcher.",

--- a/devlog/_plan/260906_quiet_peer_coordination/000_scope.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/000_scope.md
@@ -1,0 +1,54 @@
+# 000 — Quiet peer coordination
+
+Date: 2026-09-06. Session: 01a07571-80bf-7593-bf15-a51d7ca86acb.
+User requests less interference with other tasks, contact only for explicit requests
+or actual CI collisions, dev integration, release, and official existing installations.
+Unlimited Astra/high subagents are authorized for this assignment.
+
+## Baseline and cause
+
+The active managed worktree is /Users/jun/.codex/worktrees/974c/codexclaw.
+It was clean on main (15b3d44a); local dev belongs to the original checkout.
+Fetched origin, then adopted this worktree in place on codex/quiet-peer-coordination
+at origin/dev c8366fc2. Do not switch or reset the other checkout.
+Canonical owner: plugins/codexclaw/skills/dev/references/peer-collaboration.md.
+Its opening recommended consulting peers for relevant findings/dependencies;
+startup/direction-change discovery and outgoing impacts encouraged needless wakes.
+The same broad trigger appears in dev/search/pabcd and structure 20/60.
+The existing owner already separates peers from children, sender provenance from
+user authority, and transport delivery from actual agreement; preserve these guards.
+
+## Structure and dependency order
+
+- plugins/codexclaw/skills/dev/references/peer-collaboration.md: canonical wording.
+- plugins/codexclaw/skills/{dev,search,pabcd,loop}/: entrypoints and waiting pointer.
+- structure/{20_pabcd_dispatch_doctrine,60_native_capabilities}.md: source-of-truth.
+- .github/workflows/{ci,packed-install,release}.yml: release evidence and builder.
+- devlog/_plan/260906_quiet_peer_coordination/: established numbered unit convention.
+
+wp0 is docs-only roadmap lock. wp1 consumes 010 for guidance correction.
+wp2 consumes 020 for version, dev/main integration and immutable release evidence.
+wp3 consumes 030 for official existing installation updates. One cycle per phase.
+One policy PR; no stack is needed for this bounded correction. Release metadata
+may use a following release PR as required by the repository release flow.
+
+## Authority and acceptance
+
+Source change, necessary push/PR/dev merge, release, and existing target installs
+are authorized by this request. No independent app threads are contacted as part
+of research or validation. No unrelated repo changes, host defaults, or private
+wiki edits. No forced worktree or branch takeover. Preserve live sessions.
+The acceptance scenarios and concrete diffs live in 010. Exact-head release and
+installed payload proof live in 020 and 030. A docs review is not runtime enforcement.
+Prior memory provides procedural leads only; current files and CLI outputs decide.
+
+## Resources and terminal outcomes
+
+Tool/credential scope: local git/cxc/node, authenticated gh for this repository,
+configured SSH solely for established product installation targets, native children.
+No numeric token/cost or delegation cap was given. Observe commands in <=60s units;
+repeated unchanged failures trigger diagnosis, not unbounded retries.
+DONE requires every registered criterion. NOOP still requires requested delivery
+state proof. BLOCKED requires an external obstacle. UNSAFE/NEEDS_HUMAN preserve
+work and identify the missing decision. Context pressure is never budget exhaustion.
+The host's blocked-state threshold remains authoritative.

--- a/devlog/_plan/260906_quiet_peer_coordination/001_audit.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/001_audit.md
@@ -1,0 +1,17 @@
+# 001 — Roadmap audit synthesis
+
+Independent Astra/high reviewer Galileo reviewed the four roadmap docs and eight
+proposed guidance files. Native-execution 21/21 and gate exit0; 14 policy hunks apply
+against c8366fc2. No policy authority/trigger blocker was found.
+
+Round 1 FAIL: (1) default bootstrap-ok could establish first-time hook trust;
+(2) eight-file installed hash requirement included two repo-only structure documents.
+Root causes: reusing a CI first-install command for existing target upgrades, and
+confusing source-of-truth scope with packaged payload scope. No conflict between fixes.
+Accepted both findings. 030 now omits bootstrap-ok, requires existing trust and normal
+review for missing trust; compares six payload docs against the archive and verifies
+two structure docs at the release source SHA. No runtime/source changes made.
+
+Round 2 PASS: reviewer confirmed both amendments, no remaining blockers. Roadmap
+locked; the next phase consumes 010 only. Runtime behavior remains unmeasured until
+future use; this unit claims improved guidance and distribution, not a hard send gate.

--- a/devlog/_plan/260906_quiet_peer_coordination/010_peer_policy.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/010_peer_policy.md
@@ -1,0 +1,284 @@
+# 010 — Restrict independent peer messaging
+
+Depends on: wp0 roadmap. Work phase: wp1, class C2 guidance correction.
+Loop: spec satisfaction; trigger: excessive unsolicited messages; goal: keep work local.
+Non-goals: runtime tool interception, new settings, child delegation restrictions.
+Scope: eight existing guidance files below, plus this unit's evidence. No transport changes.
+Verifier: existing native-execution tests (21 pass at baseline; route-link checks read dev,
+loop, pabcd and peer owner); gate.mjs (exit 0 baseline; walkSkillMds reads references and
+structure/*.md, checks false enforcement/count drift). Neither proves semantic adherence.
+Semantic verifier: independent review of the eight decision-table scenarios in the
+proposed owner, including allowed and denied conditions; no actual peer messages.
+Stop: all wording consistent, focused gates pass, independent review has no blockers.
+Memory: this unit and .codexclaw/evidence/quiet-peers. Expected result DONE.
+Escalation: reclaim after two failed agent packets; scope changes are P amendments.
+Tools: local docs edits, node checks, read-only subagents. No credential use here.
+Budget: user permits unlimited Astra/high delegation; no numeric token/cost cap.
+Wall clock: bounded command observation <=60s; diagnose repeated nonprogress.
+Layer: agent-followed prose; executing surface is the model; bypass is ignored or
+unloaded guidance; residual is unwanted messaging; final enforcement layer: none.
+No new fields, enums or serialization paths. Do not add mirror-string tests.
+
+## File diffs (MODIFY)
+
+```diff
+--- plugins/codexclaw/skills/dev/references/peer-collaboration.md
++++ plugins/codexclaw/skills/dev/references/peer-collaboration.md
+@@ -1,22 +1,36 @@
+ # Independent peer collaboration
+ 
+-Use an existing task's living context when it could change a decision, resolve a
+-dependency, prevent duplicate investigation, or help another task act on a finding.
+-This applies to coding and research. It is agent-followed guidance, not a scheduler,
+-delivery guarantee, permission grant, or runtime enforcement.
++Keep work in the current task by default. Read another task's existing evidence
++when it resolves a specific uncertainty; sending a message is a separate decision.
++This is agent-followed guidance, not a scheduler, permission grant, delivery
++guarantee, or runtime enforcement.
+ 
+-## Decide whether another task can help
++## Decide whether to contact another task
+ 
+-A peer is an independently user-owned task, not a child assigned by this task.
+-Each keeps its user conversation, goal, worktree, plan, and phase authority.
+-Use a subagent for a bounded slice of your own assignment; consult a peer for
+-context or decisions it already owns. The two patterns can coexist.
++A peer is an independently user-owned task with its own conversation, goal,
++worktree, plan, and phase authority. A subagent explicitly dispatched for this
++assignment follows its scoped packet and native child tools; this peer policy
++does not restrict that authorized delegation.
+ 
+-At the start of substantive work or a material direction change, consider a light
+-look at nearby work. Also look when an unknown decision owner, conflicting contract,
+-or duplicate investigation emerges. Send useful impacts outward when a new finding
+-changes a known peer's premise. Do not require discovery for trivial/self-contained
+-work, poll every turn, broadcast introductions, or promise exhaustive discovery.
++**Outbound messages are default-off.** Send to an existing peer only when:
++
++- The user explicitly requests that contact, within the named recipient and scope; or
++- Current evidence identifies an actual CI/merge collision involving that peer
++  which blocks this assignment, and a minimal coordination message is necessary
++  because read-only evidence or an isolated local action cannot resolve it.
++
++The collision exception is a reason to consider contact, not extra permission:
++obey host permission requirements and the wake checks below. Record the affected
++PR/commit/run or shared resource, the observed collision, and the smallest question
++needed. A red CI run by itself, a shared repo, speculative overlap, an unknown
++owner, or a potentially useful finding does not satisfy this exception.
++
++Do not routinely scan nearby tasks at startup or a direction change. Do not send
++introductions, progress reports, advisory impacts, completion notices, unsolicited
++follow-up work, or requests to keep another task busy. Keep useful nonblocking
++findings in this task's own record. Do not contact peers merely to save research
++or to get general design approval. Both send triggers still preserve each task's
++authority and any explicit no-contact instruction.
+ 
+ ## Discover, read, then decide whether to talk
+ 
+@@ -36,9 +50,9 @@
+   fresh index and refresh a stale recipient/context before acting. Do not repeatedly
+   reload everything. A summary may omit a material exception: request the narrow
+   source or clarification when the missing detail matters.
+-- If reading answers the question, stop there. Talk when current judgment,
+-  negotiation, acceptance, or an actionable impact is needed. A discovered peer
+-  need not be contacted.
++- If reading answers the question, stop there. If it does not, apply the two
++  outbound-message triggers above; relevance or a need for fresh judgment alone
++  does not authorize contact. Continue independent work where possible.
+ 
+ Use [native execution](native-execution.md) for composition and failure handling.
+ Code mode can project tool responses before returning them to the model: keep
+@@ -55,9 +69,11 @@
+ 
+ ## Wake and authority boundaries
+ 
+-A necessary relevant question may wake an idle or previously completed task when
+-within the user's authorized collaboration scope. Idle/completed does not itself
+-mean user-stopped. Check recent user intent or another reliable stop-state source:
++Apply these checks only after an outbound-message trigger is satisfied. Idle or
++completed tasks stay asleep by default; a CI collision alone does not justify
++waking them. Waking one requires explicit user authorization for that contact and
++current evidence that the wake stays within its scope. Idle/completed does not
++itself mean user-stopped. Check recent user intent or a reliable stop-state source:
+ do not wake an explicitly stopped task, and do not infer eligibility from app status
+ alone. If eligibility remains unknown after a narrow read, do not automatically
+ send; use available evidence and continue independent work. Ask the user only when
+@@ -81,7 +97,7 @@
+ Never work around it by changing another task's goal. A warning does not make an
+ unsafe wake permissible.
+ 
+-## Exchange a useful question, impact, or agreement
++## Send the minimum authorized message
+ 
+ Prefer concise natural language: why this recipient, the specific question/impact,
+ source and revision, applicable conditions/exceptions, what is tentative, and whether
+@@ -89,10 +105,11 @@
+ Creating, forking, archiving, or interrupting a user task remains a separate action,
+ not an implicit part of discovering or consulting an existing peer.
+ 
+-For example, ask the API task whether its current cancel contract retains a
+-resumable job before committing a destructive UI action; do not ask it to rebuild
+-your UI. Tell a documentation task which accepted API revision invalidates its
+-example, rather than forwarding your whole conversation.
++For example, when the user asks you to contact a named task, send that bounded
++question. For a confirmed collision between two active release jobs using the same
++resource, include the run IDs and ask which job owns the next step, if host rules
++permit contact. If an API change makes another task's docs stale, record it locally
++unless the user requests contact; relevance alone is not a send trigger.
+ 
+ Delivery success is not acceptance or completion. A promise you depend on needs
+ explicit acceptance of the same issue, revision and scope; silence or an ACK is not
+@@ -100,9 +117,10 @@
+ or devlog. Each party owns its record; do not audit the other's private bookkeeping
+ or invent a globally committed agreement state.
+ 
+-If your user changes direction, distinguish your withdrawn promise, notification
+-delivery, and the peer's still-unconfirmed impact assessment. Do not overwrite its
+-plan. Do not reply to every ACK, send repeated nudges, or turn a nonblocking advisory
++If your user changes direction, re-check authorization before further contact;
++distinguish a withdrawn promise from any delivered message and the peer's still
++unconfirmed impact assessment. Do not automatically send a withdrawal notification
++or overwrite its plan. Do not reply to every ACK, send repeated nudges, or turn a nonblocking advisory
+ into a required wait. For a real dependency use native bounded waits/cursors; a
+ timeout is not proof the peer failed or permission to replace/terminate it.
+ 
+@@ -124,6 +142,18 @@
+ Evaluate relevant and irrelevant peers, stale or contradictory context, absent
+ tools, idle/explicit-stop/unknown intent, incoming questions, silent/ACK replies,
+ and changed user directions. Distinguish simulation from live task delivery.
+-Add runtime machinery only after useful collaboration is established and a concrete
+-activation, delivery, or recovery gap justifies it. CI/merge is one domain example,
+-not the organizing model for all peers.
++Review these cases without sending live probe messages to unrelated tasks:
++
++| Situation | Expected action |
++|---|---|
++| User explicitly requests contact with a named task | Send only that request after authority and wake checks |
++| Confirmed CI/merge collision with an active peer blocks current work | Read first; send the minimum necessary coordination only if permitted |
++| CI fails without evidence of a peer collision | Diagnose within this task; do not contact peers |
++| Related research, stale docs, useful finding, or completion update | Read when needed; keep findings local; no unsolicited message |
++| Idle/completed peer, no explicit contact request | Do not wake it, including for a collision |
++| Explicitly stopped peer or unknown wake eligibility | Do not send automatically; ask only if the dependency blocks progress |
++| Peer acknowledges, stays silent, or send outcome is uncertain | No courtesy reply or nudge; inspect before any justified retry |
++| This task's explicitly dispatched child needs coordination | Use its native subagent tools within the original assignment |
++
++A scenario review proves the wording, not live model compliance. Add runtime
++machinery only for a separately scoped, demonstrated enforcement gap.
+
+--- plugins/codexclaw/skills/dev/SKILL.md
++++ plugins/codexclaw/skills/dev/SKILL.md
+@@ -159,11 +159,13 @@
+ 
+ ### Capability Routing Hub
+ 
+-**Independent peers:** for substantive work, consider whether another existing
+-task owns a relevant decision, dependency, or finding. When that can affect either
+-task, read [peer collaboration](references/peer-collaboration.md): discover and
+-read selectively, consult or notify only for a concrete reason, and preserve each
+-task's user authority. No mandatory lookup for trivial work or per-turn polling.
++**Independent peers:** keep work local and use selective read-only evidence when
++needed. Outbound messages are default-off: contact an existing task only on an
++explicit user request or for necessary coordination of a confirmed blocking
++CI/merge collision, subject to host permissions and wake checks in
++[peer collaboration](references/peer-collaboration.md). No routine discovery,
++progress notifications, or unsolicited follow-ups. Authorized subagent work uses
++its own scoped delegation tools.
+ Use `dev` plus repo tools for local facts; load `search`, `pabcd`, `loop`, `recall`,
+ `cxc-qa`, or the matching `dev-*` owner for their named domains. `skill-hub` is deprecated.
+ 
+
+--- plugins/codexclaw/skills/loop/SKILL.md
++++ plugins/codexclaw/skills/loop/SKILL.md
+@@ -30,7 +30,10 @@
+ Follow the live host tool contracts, including goal creation and blocked-status
+ conditions. A plugin hook accepting a call is not proof that the call is authorized.
+ 
+-An incoming peer question is not a new loop request or permission to resume an old
++Keep this goal's work local; do not send progress or completion notices to other
++tasks. Peer contact is limited to explicit user requests or necessary confirmed
++blocking CI/merge collision coordination, subject to host permissions and wake
++checks. An incoming peer question is not a new loop request or permission to resume an old
+ goal. Follow [peer collaboration](../dev/references/peer-collaboration.md) for
+ question-only wakes and independent task authority; apply this loop only to work
+ the user actually authorized.
+
+--- plugins/codexclaw/skills/pabcd/SKILL.md
++++ plugins/codexclaw/skills/pabcd/SKILL.md
+@@ -125,8 +125,10 @@
+ ## Delegation Model (subagents)
+ 
+ This section governs dispatched children, not independently user-owned peer tasks.
+-For context, contract negotiation, or material cross-task findings, follow
+-[peer collaboration](../dev/references/peer-collaboration.md). Each peer retains
++For necessary read-only context, follow
++[peer collaboration](../dev/references/peer-collaboration.md). Outbound contact
++requires an explicit user request or necessary coordination of a confirmed
++blocking CI/merge collision, plus host permission and wake checks. Each peer retains
+ its own goal, plan and phase authority; a peer message never advances either FSM.
+ 
+ The main session owns the plan, host goal, and transitions. Before authorized
+
+--- plugins/codexclaw/skills/search/SKILL.md
++++ plugins/codexclaw/skills/search/SKILL.md
+@@ -24,10 +24,13 @@
+ 
+ ## Divergence Candidate Grounding
+ 
+-When an existing task owns relevant research, a counterexample, or a live decision,
+-use [peer collaboration](../dev/references/peer-collaboration.md) for selective
+-discovery and consultation. This does not activate a Tier-3 swarm; peer reports are
+-leads, not primary-source proof or independent corroboration.
++Use an existing task's research as read-only context only when needed for a
++specific uncertainty; relevant research does not justify an unsolicited message.
++[Peer collaboration](../dev/references/peer-collaboration.md) limits contact to
++explicit user requests or necessary confirmed blocking CI/merge collision
++coordination, with host permission and wake checks. This does not activate a
++Tier-3 swarm; peer reports are leads, not primary-source proof or independent
++corroboration.
+ 
+ When any PABCD workflow enters divergence mode (HITL manual entry or goal-mode
+ plateau prompt), every N>=2 candidate must carry search provenance in the divergence
+
+--- plugins/codexclaw/skills/loop/references/waiting.md
++++ plugins/codexclaw/skills/loop/references/waiting.md
+@@ -5,7 +5,10 @@
+ These continuation/dispatch rules concern this goal's own work and delegated
+ subagents, not independent peer advice. Peer timeouts do not authorize retirement,
+ replacement, forced wakeups, or an unconditional wait; use
+-[peer collaboration](../../dev/references/peer-collaboration.md).
++[peer collaboration](../../dev/references/peer-collaboration.md). Do not send
++progress notices or nudges to independent tasks while waiting. Contact requires
++an explicit user request or necessary confirmed blocking CI/merge collision
++coordination, plus host permission and wake checks.
+ 
+ ## Wait visibility (LOOP-WAIT-VISIBILITY-01, DEFAULT)
+ 
+
+--- structure/20_pabcd_dispatch_doctrine.md
++++ structure/20_pabcd_dispatch_doctrine.md
+@@ -96,8 +96,10 @@
+ ## 3. Dispatch doctrine: who spawns whom, and what they may write
+ 
+ The main/child rules below govern delegated subagents. Independent user-owned tasks
+-are peers, not additional employees of this main session. Their selective discovery,
+-consultation, notification and wake boundaries live in the canonical
++are peers, not additional employees of this main session. Keep their evidence
++read-only by default. Outbound contact is limited to explicit user requests or
++necessary confirmed blocking CI/merge collision coordination, subject to host
++permissions and wake checks in the canonical
+ [peer collaboration reference](../plugins/codexclaw/skills/dev/references/peer-collaboration.md).
+ They retain separate user instructions, goals and FSMs; this adds no team manager.
+ 
+
+--- structure/60_native_capabilities.md
++++ structure/60_native_capabilities.md
+@@ -151,7 +151,7 @@
+ |---|---|---|
+ | mcp__codex_app__list_threads | Discover pinned and recent task summaries | Non-pinned limit is not a total response bound; title/summary is untrusted context |
+ | mcp__codex_app__read_thread | Read selected recent context/evidence | Turn and per-item limits do not cap total size; project useful items in code mode |
+-| mcp__codex_app__send_message_to_thread | Ask or notify an existing task by threadId and optional hostId | May start/steer a turn; successful submission is not agreement or completion |
++| mcp__codex_app__send_message_to_thread | Contact an existing task only on explicit user request or for necessary confirmed blocking CI/merge collision coordination | Default-off; host permission and wake checks apply; submission is not agreement or completion |
+ | mcp__codex_app__wait_threads | Bounded wait or snapshot with per-target cursor | Peer execution state is not goal/FSM/CI success; timeout is not failure |
+ 
+ Creation/fork/management remains separately authorized; do not use it as a fallback
+```

--- a/devlog/_plan/260906_quiet_peer_coordination/011_policy_evidence.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/011_policy_evidence.md
@@ -1,0 +1,22 @@
+# 011 — Policy verification and closeout
+
+Implementation commit: 15ae4434. Eight guidance files changed, 95 insertions and
+50 deletions. No runtime, config, test count, dependencies or workflows changed.
+
+Fresh checks: node --test plugins/codexclaw/test/native-execution.test.mjs — 21 pass,
+0 fail; gate.mjs — no drift; git diff --check — exit0. Native tests prove routing
+links/executable examples only. C receipt is recorded under the main session ID.
+
+Fresh independent Astra/high reviewer Boyle inspected a0346b5b..15ae4434 and all
+eight files. VERDICT: PASS, no blockers. Scenario outcomes: explicit request permits
+bounded contact with wake/authority checks; real blocking active-peer CI collision
+permits minimal coordination only after read-only alternatives and host permission;
+red CI alone denies contact; related research/docs/findings/completion deny unsolicited
+send; idle/completed denies wake without explicit request; stopped/unknown denies
+automatic send; ACK/silence/uncertain delivery permits no nudge/blind retry; authorized
+children retain native scoped coordination. No live messages were sent.
+
+DONE for wp1 guidance correction. Not claimed: hard runtime enforcement or live model
+adherence. A counterexample would be future agents reading this policy and still
+initiating unsolicited peer messages; that would justify a separately scoped fix.
+Next: wp2 release metadata, exact-head dev/main integration and official publication.

--- a/devlog/_plan/260906_quiet_peer_coordination/020_release.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/020_release.md
@@ -1,0 +1,55 @@
+# 020 — Integrate and release 0.2.19
+
+Depends on: verified wp1. Work phase wp2; class C4, spec satisfaction.
+Trigger/goal: ship the corrected guidance through the existing release train.
+Non-goals: npm publishing, dependency changes, workflow redesign, unrelated dev work.
+Verifier: check-versions.mjs plus explicit CLI/GUI/lockfile reads; inventory --check;
+exact-SHA CI, WSL and Packed install lifecycle; Release workflow's candidate gate;
+downloaded SHA256SUMS and archive, tag ancestry and payload policy hash.
+Stop: all gates pass for the frozen release SHA and v0.2.19 is publicly published.
+Resource/authority/terminal rules: 000; user explicitly authorized merge/release/install.
+Astra/high independent review; reclaim failed packets after two distinct failures;
+new worker scope is a P amendment. No token/cost cap; <=60s command observations.
+
+## MODIFY version surfaces (exact transformation)
+
+For package.json, cli/package.json, plugins/codexclaw/gui/package.json and each
+plugins/codexclaw/components/*/package.json: version 0.2.18 -> 0.2.19.
+For package-lock.json: root version and packages[""] plus the exact corresponding
+workspace entries' version fields 0.2.18 -> 0.2.19; preserve the dependency graph.
+For plugins/codexclaw/.codex-plugin/plugin.json: version
+0.2.18+codex.20260906043759 -> 0.2.19+codex.<fresh UTC timestamp>.
+For plugins/codexclaw/inventory.json: regenerate from the manifest and measured
+existing test total (2579 at baseline) with scripts/inventory.mjs --write --tests.
+README.md, README.ko.md and README.zh.md are generated inventory badge consumers;
+accept only the generator's corresponding changes. docs-site@0.0.1 is independent.
+For CHANGELOG.md: add a 0.2.19 / 2026-09-06 entry describing default-off peer sends,
+explicit user requests and confirmed blocking CI/merge coordination, preserved
+read-only context and authorized child delegation. Do not invent missing older entries.
+No implementation/runtime changes are planned in this phase.
+
+## Integration and publication
+
+1. Review scoped policy diff and current origin/dev; commit and push only this branch.
+   Create a PR to dev with a short behavior description and verification evidence.
+   Require the PR's exact head checks; refresh head/base before normal merge.
+   Never merge unrelated open PRs or modify other local worktrees.
+2. Verify origin/dev contains the policy commit. Apply release metadata on a current
+   dev-based branch (the current branch may be reused if clean); open/merge its
+   scoped release-preparation PR after exact-head checks. No force-push needed.
+3. Verify resulting dev SHA CI, WSL and packed-install. Create dev -> main promotion
+   PR; inspect its complete delta and keep unrelated pending work out of this task.
+   Merge normally after checks and record merge SHA. If dev moved, re-read the delta.
+4. Query actions by the actual main SHA. Only after CI/WSL/packed all pass, run:
+   gh workflow run release.yml --repo lidge-jun/codexclaw --ref main
+   -f version=0.2.19 -f prerelease=false -f dry_run=false.
+   Recheck main identity immediately before dispatch and the returned run headSha.
+5. Observe Release success; download its candidate, payload and SHA256SUMS. Verify
+   sha256sum/shasum, immutable tag commit and payload manifest/policy. Save evidence.
+
+No local repository-wide suite is needed for prose/version changes: existing focused
+checks plus the unmodified CI/release workflows provide the full suite and rebuild.
+Baseline native-execution tests are 21/21 and gate exit0. Full suite measurement comes
+from current-head CI, never a remembered badge. Fix any actual failures before release.
+Rollback: preserve v0.2.18 immutable assets and existing install payloads; revert source
+through a new commit if necessary. Never overwrite/delete a published version tag.

--- a/devlog/_plan/260906_quiet_peer_coordination/020_release.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/020_release.md
@@ -30,13 +30,15 @@ No implementation/runtime changes are planned in this phase.
 
 ## Integration and publication
 
-1. Review scoped policy diff and current origin/dev; commit and push only this branch.
-   Create a PR to dev with a short behavior description and verification evidence.
-   Require the PR's exact head checks; refresh head/base before normal merge.
-   Never merge unrelated open PRs or modify other local worktrees.
-2. Verify origin/dev contains the policy commit. Apply release metadata on a current
-   dev-based branch (the current branch may be reused if clean); open/merge its
-   scoped release-preparation PR after exact-head checks. No force-push needed.
+1. Revalidate wp1 D evidence and origin/dev; prepare the 0.2.19 metadata before
+   publishing the branch. Policy and release metadata use separate local commits in
+   one scoped PR to dev. This P amendment avoids an extra CI/PR round while preserving
+   every exact-head gate; no unrelated PRs or local worktrees are changed.
+2. Review all changes, push only this branch and open its PR to dev. Require exact-head
+   checks; refresh head/base before normal merge and prove dev contains the policy
+   commit. No force-push. The >500-line review includes the required diff-level roadmap;
+   the eight-file production guidance delta is 145 lines, so splitting these same
+   task artifacts into a PR stack would add coordination without isolating behavior.
 3. Verify resulting dev SHA CI, WSL and packed-install. Create dev -> main promotion
    PR; inspect its complete delta and keep unrelated pending work out of this task.
    Merge normally after checks and record merge SHA. If dev moved, re-read the delta.
@@ -53,3 +55,6 @@ Baseline native-execution tests are 21/21 and gate exit0. Full suite measurement
 from current-head CI, never a remembered badge. Fix any actual failures before release.
 Rollback: preserve v0.2.18 immutable assets and existing install payloads; revert source
 through a new commit if necessary. Never overwrite/delete a published version tag.
+
+P refresh: wp1 D complete at 15ae4434 with native21/gate/independent PASS.
+Source state is clean apart from this roadmap amendment. Version still0.2.18.

--- a/devlog/_plan/260906_quiet_peer_coordination/020_release.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/020_release.md
@@ -83,3 +83,52 @@ Verifier: independently contrast explicitly requested status/result sends (allow
 subject to host/wake checks) and unsolicited progress/result sends (denied). Rerun
 native21/gate/diff and fresh exact-head PR/dev/main CI. Resolve the existing review
 thread only after the corrective commit is verified and landed; no waiver or dismissal.
+
+### Notification repair root-cause and full route closure
+
+PR76 review PRRT_kwDOTLf_586fp-aw identifies the still-categorical waiting ban.
+Root cause is incomplete propagation of the explicit-request exception through all
+entrypoints, not a broken send implementation. Main reclaims the route inventory;
+search all eight changed guidance files for send/contact/notice/notification/nudge.
+The search also found dev's broad progress-notification phrase and owner's advisory
+wake phrase. These are the same failure class; stop one-location patching and amend
+all reachable wording in this one repair, followed by fresh independent audit.
+Existing user authorization is not weakened and no new outbound trigger is introduced.
+
+MODIFY plugins/codexclaw/skills/loop/references/waiting.md:
+`Do not send\nprogress notices or nudges` -> `Do not send\nunsolicited progress notices or nudges`.
+MODIFY plugins/codexclaw/skills/dev/SKILL.md:
+`progress notifications, or unsolicited follow-ups` ->
+`unsolicited progress notifications or follow-ups`.
+MODIFY plugins/codexclaw/skills/dev/references/peer-collaboration.md:
+`every outbound message: advisory-only notifications must not wake idle/completed` ->
+`every outbound message: unsolicited advisory-only notifications must not wake idle/completed`.
+Before the scenario table add: `Apply explicit user contact instructions first. The
+other rows describe defaults without such a request; host permissions and wake
+checks always apply.` This clarifies all default examples, including ACK/silence.
+
+Fresh reviewer must trace every entrypoint and compare requested progress/result
+contact in normal/waiting/idle states against unsolicited sends. Explicitly stopped,
+unknown eligibility, unsafe runtime wake, host denial and scope limits remain denied.
+Then rerun native21/gate/diff, push a new PR76 head, require all new-head checks, and
+resolve both review threads only after the verified corrective head lands.
+
+Fresh full-route A review (Schrodinger) found two further manifestations of the same
+root cause. Accept both; no conflict with prior amendments. Read-first early exit
+must not substitute a context answer for requested delivery; ACK/nudge body rules
+must also distinguish unsolicited contact. This is a source-guidance repair, not
+runtime enforcement. Add the following exact owner replacements before B:
+
+- Replace the read-first bullet with: `If reading answers a question and no contact
+  was requested, stop there. Otherwise, apply the two outbound-message triggers
+  above and all authority/wake checks. Relevance or a need for fresh judgment alone
+  does not authorize contact. Do not substitute a read-only answer for explicitly
+  requested delivery. Continue independent work where possible.`
+- Replace `Do not reply to every ACK, send repeated nudges, or turn a nonblocking advisory`
+  with `Without an explicit user request, do not reply to ACKs or send repeated nudges.
+  Do not silently turn a nonblocking advisory`.
+
+RCA: prohibitions were reviewed as isolated snippets rather than ordered decision
+paths. The fresh reviewer checks the full contact path (explicit instruction ->
+read -> wake/authority -> send -> follow-up), including early exits and body rules,
+not just the scenario table. Re-audit with that same reviewer after amendment.

--- a/devlog/_plan/260906_quiet_peer_coordination/020_release.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/020_release.md
@@ -58,3 +58,28 @@ through a new commit if necessary. Never overwrite/delete a published version ta
 
 P refresh: wp1 D complete at 15ae4434 with native21/gate/independent PASS.
 Source state is clean apart from this roadmap amendment. Version still0.2.18.
+
+## Release review repair amendment
+
+PR75 merged at aebead02 after11 green checks. Post-merge review thread
+PRRT_kwDOTLf_586fp6Sp reports P2 ambiguity: categorical notification bans can also
+read as forbidding explicitly requested status/result delivery. Accept the finding;
+two independent reviews missed this wording contradiction. No dependency or phase
+conflict: retain default-off, qualify only unsolicited notification restrictions.
+Reset/re-enter wp2 P before this bounded source repair; version remains0.2.19 and
+nothing has been published. Main owns the patch; same A reviewer verifies amendment.
+
+MODIFY plugins/codexclaw/skills/dev/references/peer-collaboration.md:
+- Before: `introductions, progress reports, advisory impacts, completion notices, unsolicited`
+- After: `unsolicited introductions, progress reports, advisory impacts, completion notices, or`
+- Before: `follow-up work, or requests to keep another task busy.`
+- After: `follow-up work, or requests to keep another task busy.`
+- Add before the list: `The following notification defaults do not prohibit contact explicitly requested by the user.`
+MODIFY plugins/codexclaw/skills/loop/SKILL.md:
+- Before: `Keep this goal's work local; do not send progress or completion notices to other`
+- After: `Keep this goal's work local; do not send unsolicited progress or completion notices to other`
+
+Verifier: independently contrast explicitly requested status/result sends (allowed
+subject to host/wake checks) and unsolicited progress/result sends (denied). Rerun
+native21/gate/diff and fresh exact-head PR/dev/main CI. Resolve the existing review
+thread only after the corrective commit is verified and landed; no waiver or dismissal.

--- a/devlog/_plan/260906_quiet_peer_coordination/030_install.md
+++ b/devlog/_plan/260906_quiet_peer_coordination/030_install.md
@@ -1,0 +1,61 @@
+# 030 — Official installation and verification
+
+Depends on: wp2 published immutable release. Work phase wp3; class C4, spec satisfaction.
+Goal: load the released policy from official complete-copy plugin installs.
+Non-goals: source-checkout rewrites, symlink dogfooding, app termination/restart,
+provider changes, new-host rollout, unrelated plugin updates.
+Authority/resources/escalation/terminal rules: 000; no numeric cost cap, bounded
+commands <=60s per observation. Main owns installation; read-only child validates.
+
+## Existing target inventory and exact intended changes
+
+Re-verify each target before writes. Dated sources:
+260906_release_0_2_18/012_release_preparation.md and
+260905_codex_code_mode_pr_research/072_release_preparation_evidence.md.
+- Local /Users/jun/.codex: enabled codexclaw@codexclaw at 0.2.16; marketplace
+  references dirty /Users/jun/Developer/new/700_projects/codexclaw. Preserve checkout.
+- macmini-cf /Users/junny/.codex: recorded 0.2.17 local-source install.
+- suji /Users/neuralarcadepro/.codex: recorded 0.2.17 Git-source install.
+- desktop-c795oh4 C:\Users\user\.codex: recorded 0.2.17 native Windows Git install.
+Other aliases alone are not installation targets; do not bootstrap unknown hosts.
+
+For each confirmed target: record plugin key/source, version and resolved cache path;
+retain the old payload and nonsecret connection metadata for rollback. Official target
+is codexclaw@codexclaw from https://github.com/lidge-jun/codexclaw at the release SHA.
+For a matching existing Git source, marketplace upgrade then plugin add --json; verify
+its revision, not just version. For a dirty local-source connection or mismatched pin,
+use supported marketplace remove/add for only the codexclaw marketplace, preserving
+other marketplaces/plugins, then add the official Git source with --ref <release SHA>.
+No edit to the original checkout, no cache symlink, no manual payload overlay.
+This source change implements the user's explicit request for the official path.
+If the CLI cannot scope that change without damaging an unrelated connection, stop
+that target and report the concrete issue; continue independent installations.
+
+## Supported commands and evidence
+
+Read codex plugin marketplace/add help on each installed CLI before mutation.
+Expected flow: codex plugin marketplace upgrade codexclaw; codex plugin add
+codexclaw@codexclaw --json. Pinned-source replacement uses marketplace remove
+codexclaw then marketplace add https://github.com/lidge-jun/codexclaw --ref <SHA>.
+Resolve installedPath/path from installer JSON. Invoke its bin/cxc.mjs directly:
+hooks retrust --key codexclaw@codexclaw --codex-home <existing home>
+only when existing trust, fresh hook digest comparison and normal procedure allow it;
+never pass --bootstrap-ok to establish first-time trust under an update request.
+If existing trust is missing, preserve the installed files and report the required
+normal user hook review rather than initializing trust silently;
+then doctor --json. Keep outputs under .codexclaw/evidence/quiet-peers.
+
+Verifier: installed manifest matches released build version, complete non-symlinked
+payload, hashes of the six changed payload guidance files match the published archive;
+verify the two structure/ files against the immutable release source SHA,
+compiled dispatcher loads, doctor manifest/hooks/hook-trust/install-root checks and
+all other failures are inspected. Plugin installation must report the expected key
+and path under the intended home; use native Windows CLI there, never a WSL surrogate.
+A current session can retain old instructions; do not claim it hot-reloaded. Preserve
+live sessions and report that a new task/app reload is needed if current UI is stale.
+
+Stop: all established reachable targets have verified official installs; unreachable
+or externally blocked targets are explicit unmet criteria, never silently dropped.
+Rollback: reinstall the recorded old immutable source or preserved official payload
+through supported CLI, restore only this marketplace connection if needed. Do not
+reset repository branches or kill the running app to make verification pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexclaw",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexclaw",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "license": "MIT",
       "workspaces": [
         "plugins/codexclaw/components/*",
@@ -20,7 +20,7 @@
     },
     "cli": {
       "name": "@codexclaw/cli",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "bin": {
         "codexclaw": "bin/codexclaw.mjs"
       }
@@ -1949,39 +1949,39 @@
     },
     "plugins/codexclaw/components/config-guard": {
       "name": "@codexclaw/config-guard",
-      "version": "0.2.18"
+      "version": "0.2.19"
     },
     "plugins/codexclaw/components/cxc-ops": {
       "name": "@codexclaw/cxc-ops",
-      "version": "0.2.18"
+      "version": "0.2.19"
     },
     "plugins/codexclaw/components/messenger-bridge": {
       "name": "@codexclaw/messenger-bridge",
-      "version": "0.2.18"
+      "version": "0.2.19"
     },
     "plugins/codexclaw/components/pabcd-state": {
       "name": "@codexclaw/pabcd-state",
-      "version": "0.2.18"
+      "version": "0.2.19"
     },
     "plugins/codexclaw/components/provider-bridge": {
       "name": "@codexclaw/provider-bridge",
-      "version": "0.2.18"
+      "version": "0.2.19"
     },
     "plugins/codexclaw/components/recall": {
       "name": "@codexclaw/recall",
-      "version": "0.2.18"
+      "version": "0.2.19"
     },
     "plugins/codexclaw/components/skill-search": {
       "name": "@codexclaw/skill-search",
-      "version": "0.2.18"
+      "version": "0.2.19"
     },
     "plugins/codexclaw/components/subagent-config": {
       "name": "@codexclaw/subagent-config",
-      "version": "0.2.18"
+      "version": "0.2.19"
     },
     "plugins/codexclaw/gui": {
       "name": "@codexclaw/gui",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.18+codex.20260906043759",
+  "version": "0.2.19+codex.20260906065707",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI — doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge — cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) — subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.18+codex.20260906043759",
-    "packageVersion": "0.2.18"
+    "manifestVersion": "0.2.19+codex.20260906065707",
+    "packageVersion": "0.2.19"
   },
   "skills": [
     {
@@ -263,49 +263,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "hasTests": true
     }
   ]

--- a/plugins/codexclaw/skills/dev/SKILL.md
+++ b/plugins/codexclaw/skills/dev/SKILL.md
@@ -159,11 +159,13 @@ metadata remains canonical in each skill's `agents/openai.yaml`.
 
 ### Capability Routing Hub
 
-**Independent peers:** for substantive work, consider whether another existing
-task owns a relevant decision, dependency, or finding. When that can affect either
-task, read [peer collaboration](references/peer-collaboration.md): discover and
-read selectively, consult or notify only for a concrete reason, and preserve each
-task's user authority. No mandatory lookup for trivial work or per-turn polling.
+**Independent peers:** keep work local and use selective read-only evidence when
+needed. Outbound messages are default-off: contact an existing task only on an
+explicit user request or for necessary coordination of a confirmed blocking
+CI/merge collision, subject to host permissions and wake checks in
+[peer collaboration](references/peer-collaboration.md). No routine discovery,
+progress notifications, or unsolicited follow-ups. Authorized subagent work uses
+its own scoped delegation tools.
 Use `dev` plus repo tools for local facts; load `search`, `pabcd`, `loop`, `recall`,
 `cxc-qa`, or the matching `dev-*` owner for their named domains. `skill-hub` is deprecated.
 

--- a/plugins/codexclaw/skills/dev/SKILL.md
+++ b/plugins/codexclaw/skills/dev/SKILL.md
@@ -164,7 +164,7 @@ needed. Outbound messages are default-off: contact an existing task only on an
 explicit user request or for necessary coordination of a confirmed blocking
 CI/merge collision, subject to host permissions and wake checks in
 [peer collaboration](references/peer-collaboration.md). No routine discovery,
-progress notifications, or unsolicited follow-ups. Authorized subagent work uses
+unsolicited progress notifications or follow-ups. Authorized subagent work uses
 its own scoped delegation tools.
 Use `dev` plus repo tools for local facts; load `search`, `pabcd`, `loop`, `recall`,
 `cxc-qa`, or the matching `dev-*` owner for their named domains. `skill-hub` is deprecated.

--- a/plugins/codexclaw/skills/dev/references/peer-collaboration.md
+++ b/plugins/codexclaw/skills/dev/references/peer-collaboration.md
@@ -25,10 +25,11 @@ PR/commit/run or shared resource, the observed collision, and the smallest quest
 needed. A red CI run by itself, a shared repo, speculative overlap, an unknown
 owner, or a potentially useful finding does not satisfy this exception.
 
-Do not routinely scan nearby tasks at startup or a direction change. Do not send
-introductions, progress reports, advisory impacts, completion notices, unsolicited
-follow-up work, or requests to keep another task busy. Keep useful nonblocking
-findings in this task's own record. Do not contact peers merely to save research
+The following notification defaults do not prohibit contact explicitly requested
+by the user. Do not routinely scan nearby tasks at startup or a direction change.
+Do not send unsolicited introductions, progress reports, advisory impacts,
+completion notices, follow-up work, or requests to keep another task busy. Keep
+useful nonblocking findings in this task's own record. Do not contact peers merely to save research
 or to get general design approval. Both send triggers still preserve each task's
 authority and any explicit no-contact instruction.
 

--- a/plugins/codexclaw/skills/dev/references/peer-collaboration.md
+++ b/plugins/codexclaw/skills/dev/references/peer-collaboration.md
@@ -51,9 +51,11 @@ and disclose the limitation; do not emulate delivery by editing rollout files or
   fresh index and refresh a stale recipient/context before acting. Do not repeatedly
   reload everything. A summary may omit a material exception: request the narrow
   source or clarification when the missing detail matters.
-- If reading answers the question, stop there. If it does not, apply the two
-  outbound-message triggers above; relevance or a need for fresh judgment alone
-  does not authorize contact. Continue independent work where possible.
+- If reading answers a question and no contact was requested, stop there.
+  Otherwise, apply the two outbound-message triggers above and all authority/wake
+  checks. Relevance or a need for fresh judgment alone does not authorize contact.
+  Do not substitute a read-only answer for explicitly requested delivery.
+  Continue independent work where possible.
 
 Use [native execution](native-execution.md) for composition and failure handling.
 Code mode can project tool responses before returning them to the model: keep
@@ -79,7 +81,7 @@ do not wake an explicitly stopped task, and do not infer eligibility from app st
 alone. If eligibility remains unknown after a narrow read, do not automatically
 send; use available evidence and continue independent work. Ask the user only when
 that unanswered dependency actually prevents progress. Apply this wake check to
-every outbound message: advisory-only notifications must not wake idle/completed
+every outbound message: unsolicited advisory-only notifications must not wake idle/completed
 peers. Keep that impact in your own artifact for later authorized contact instead.
 
 Answering a peer question is not permission to resume an old goal, append new work
@@ -121,7 +123,8 @@ or invent a globally committed agreement state.
 If your user changes direction, re-check authorization before further contact;
 distinguish a withdrawn promise from any delivered message and the peer's still
 unconfirmed impact assessment. Do not automatically send a withdrawal notification
-or overwrite its plan. Do not reply to every ACK, send repeated nudges, or turn a nonblocking advisory
+or overwrite its plan. Without an explicit user request, do not reply to ACKs or send repeated nudges.
+Do not silently turn a nonblocking advisory
 into a required wait. For a real dependency use native bounded waits/cursors; a
 timeout is not proof the peer failed or permission to replace/terminate it.
 
@@ -144,6 +147,9 @@ Evaluate relevant and irrelevant peers, stale or contradictory context, absent
 tools, idle/explicit-stop/unknown intent, incoming questions, silent/ACK replies,
 and changed user directions. Distinguish simulation from live task delivery.
 Review these cases without sending live probe messages to unrelated tasks:
+
+Apply explicit user contact instructions first. The other rows describe defaults
+without such a request; host permissions and wake checks always apply.
 
 | Situation | Expected action |
 |---|---|

--- a/plugins/codexclaw/skills/dev/references/peer-collaboration.md
+++ b/plugins/codexclaw/skills/dev/references/peer-collaboration.md
@@ -1,22 +1,36 @@
 # Independent peer collaboration
 
-Use an existing task's living context when it could change a decision, resolve a
-dependency, prevent duplicate investigation, or help another task act on a finding.
-This applies to coding and research. It is agent-followed guidance, not a scheduler,
-delivery guarantee, permission grant, or runtime enforcement.
+Keep work in the current task by default. Read another task's existing evidence
+when it resolves a specific uncertainty; sending a message is a separate decision.
+This is agent-followed guidance, not a scheduler, permission grant, delivery
+guarantee, or runtime enforcement.
 
-## Decide whether another task can help
+## Decide whether to contact another task
 
-A peer is an independently user-owned task, not a child assigned by this task.
-Each keeps its user conversation, goal, worktree, plan, and phase authority.
-Use a subagent for a bounded slice of your own assignment; consult a peer for
-context or decisions it already owns. The two patterns can coexist.
+A peer is an independently user-owned task with its own conversation, goal,
+worktree, plan, and phase authority. A subagent explicitly dispatched for this
+assignment follows its scoped packet and native child tools; this peer policy
+does not restrict that authorized delegation.
 
-At the start of substantive work or a material direction change, consider a light
-look at nearby work. Also look when an unknown decision owner, conflicting contract,
-or duplicate investigation emerges. Send useful impacts outward when a new finding
-changes a known peer's premise. Do not require discovery for trivial/self-contained
-work, poll every turn, broadcast introductions, or promise exhaustive discovery.
+**Outbound messages are default-off.** Send to an existing peer only when:
+
+- The user explicitly requests that contact, within the named recipient and scope; or
+- Current evidence identifies an actual CI/merge collision involving that peer
+  which blocks this assignment, and a minimal coordination message is necessary
+  because read-only evidence or an isolated local action cannot resolve it.
+
+The collision exception is a reason to consider contact, not extra permission:
+obey host permission requirements and the wake checks below. Record the affected
+PR/commit/run or shared resource, the observed collision, and the smallest question
+needed. A red CI run by itself, a shared repo, speculative overlap, an unknown
+owner, or a potentially useful finding does not satisfy this exception.
+
+Do not routinely scan nearby tasks at startup or a direction change. Do not send
+introductions, progress reports, advisory impacts, completion notices, unsolicited
+follow-up work, or requests to keep another task busy. Keep useful nonblocking
+findings in this task's own record. Do not contact peers merely to save research
+or to get general design approval. Both send triggers still preserve each task's
+authority and any explicit no-contact instruction.
 
 ## Discover, read, then decide whether to talk
 
@@ -36,9 +50,9 @@ and disclose the limitation; do not emulate delivery by editing rollout files or
   fresh index and refresh a stale recipient/context before acting. Do not repeatedly
   reload everything. A summary may omit a material exception: request the narrow
   source or clarification when the missing detail matters.
-- If reading answers the question, stop there. Talk when current judgment,
-  negotiation, acceptance, or an actionable impact is needed. A discovered peer
-  need not be contacted.
+- If reading answers the question, stop there. If it does not, apply the two
+  outbound-message triggers above; relevance or a need for fresh judgment alone
+  does not authorize contact. Continue independent work where possible.
 
 Use [native execution](native-execution.md) for composition and failure handling.
 Code mode can project tool responses before returning them to the model: keep
@@ -55,9 +69,11 @@ that affects the decision. Character counts are not exact model token/cost count
 
 ## Wake and authority boundaries
 
-A necessary relevant question may wake an idle or previously completed task when
-within the user's authorized collaboration scope. Idle/completed does not itself
-mean user-stopped. Check recent user intent or another reliable stop-state source:
+Apply these checks only after an outbound-message trigger is satisfied. Idle or
+completed tasks stay asleep by default; a CI collision alone does not justify
+waking them. Waking one requires explicit user authorization for that contact and
+current evidence that the wake stays within its scope. Idle/completed does not
+itself mean user-stopped. Check recent user intent or a reliable stop-state source:
 do not wake an explicitly stopped task, and do not infer eligibility from app status
 alone. If eligibility remains unknown after a narrow read, do not automatically
 send; use available evidence and continue independent work. Ask the user only when
@@ -81,7 +97,7 @@ Use read-only evidence or request direction only when blocked; report the limita
 Never work around it by changing another task's goal. A warning does not make an
 unsafe wake permissible.
 
-## Exchange a useful question, impact, or agreement
+## Send the minimum authorized message
 
 Prefer concise natural language: why this recipient, the specific question/impact,
 source and revision, applicable conditions/exceptions, what is tentative, and whether
@@ -89,10 +105,11 @@ a reply is needed. Do not override recipient model/settings just to send context
 Creating, forking, archiving, or interrupting a user task remains a separate action,
 not an implicit part of discovering or consulting an existing peer.
 
-For example, ask the API task whether its current cancel contract retains a
-resumable job before committing a destructive UI action; do not ask it to rebuild
-your UI. Tell a documentation task which accepted API revision invalidates its
-example, rather than forwarding your whole conversation.
+For example, when the user asks you to contact a named task, send that bounded
+question. For a confirmed collision between two active release jobs using the same
+resource, include the run IDs and ask which job owns the next step, if host rules
+permit contact. If an API change makes another task's docs stale, record it locally
+unless the user requests contact; relevance alone is not a send trigger.
 
 Delivery success is not acceptance or completion. A promise you depend on needs
 explicit acceptance of the same issue, revision and scope; silence or an ACK is not
@@ -100,9 +117,10 @@ agreement. Record consequential decisions and their source in your existing plan
 or devlog. Each party owns its record; do not audit the other's private bookkeeping
 or invent a globally committed agreement state.
 
-If your user changes direction, distinguish your withdrawn promise, notification
-delivery, and the peer's still-unconfirmed impact assessment. Do not overwrite its
-plan. Do not reply to every ACK, send repeated nudges, or turn a nonblocking advisory
+If your user changes direction, re-check authorization before further contact;
+distinguish a withdrawn promise from any delivered message and the peer's still
+unconfirmed impact assessment. Do not automatically send a withdrawal notification
+or overwrite its plan. Do not reply to every ACK, send repeated nudges, or turn a nonblocking advisory
 into a required wait. For a real dependency use native bounded waits/cursors; a
 timeout is not proof the peer failed or permission to replace/terminate it.
 
@@ -124,6 +142,18 @@ briefly to the user, not a transcript of all coordination.
 Evaluate relevant and irrelevant peers, stale or contradictory context, absent
 tools, idle/explicit-stop/unknown intent, incoming questions, silent/ACK replies,
 and changed user directions. Distinguish simulation from live task delivery.
-Add runtime machinery only after useful collaboration is established and a concrete
-activation, delivery, or recovery gap justifies it. CI/merge is one domain example,
-not the organizing model for all peers.
+Review these cases without sending live probe messages to unrelated tasks:
+
+| Situation | Expected action |
+|---|---|
+| User explicitly requests contact with a named task | Send only that request after authority and wake checks |
+| Confirmed CI/merge collision with an active peer blocks current work | Read first; send the minimum necessary coordination only if permitted |
+| CI fails without evidence of a peer collision | Diagnose within this task; do not contact peers |
+| Related research, stale docs, useful finding, or completion update | Read when needed; keep findings local; no unsolicited message |
+| Idle/completed peer, no explicit contact request | Do not wake it, including for a collision |
+| Explicitly stopped peer or unknown wake eligibility | Do not send automatically; ask only if the dependency blocks progress |
+| Peer acknowledges, stays silent, or send outcome is uncertain | No courtesy reply or nudge; inspect before any justified retry |
+| This task's explicitly dispatched child needs coordination | Use its native subagent tools within the original assignment |
+
+A scenario review proves the wording, not live model compliance. Add runtime
+machinery only for a separately scoped, demonstrated enforcement gap.

--- a/plugins/codexclaw/skills/loop/SKILL.md
+++ b/plugins/codexclaw/skills/loop/SKILL.md
@@ -30,7 +30,10 @@ follows its packet; loading loop never authorizes a leaf to start a goal or spaw
 Follow the live host tool contracts, including goal creation and blocked-status
 conditions. A plugin hook accepting a call is not proof that the call is authorized.
 
-An incoming peer question is not a new loop request or permission to resume an old
+Keep this goal's work local; do not send progress or completion notices to other
+tasks. Peer contact is limited to explicit user requests or necessary confirmed
+blocking CI/merge collision coordination, subject to host permissions and wake
+checks. An incoming peer question is not a new loop request or permission to resume an old
 goal. Follow [peer collaboration](../dev/references/peer-collaboration.md) for
 question-only wakes and independent task authority; apply this loop only to work
 the user actually authorized.

--- a/plugins/codexclaw/skills/loop/SKILL.md
+++ b/plugins/codexclaw/skills/loop/SKILL.md
@@ -30,8 +30,8 @@ follows its packet; loading loop never authorizes a leaf to start a goal or spaw
 Follow the live host tool contracts, including goal creation and blocked-status
 conditions. A plugin hook accepting a call is not proof that the call is authorized.
 
-Keep this goal's work local; do not send progress or completion notices to other
-tasks. Peer contact is limited to explicit user requests or necessary confirmed
+Keep this goal's work local; do not send unsolicited progress or completion notices
+to other tasks. Peer contact is limited to explicit user requests or necessary confirmed
 blocking CI/merge collision coordination, subject to host permissions and wake
 checks. An incoming peer question is not a new loop request or permission to resume an old
 goal. Follow [peer collaboration](../dev/references/peer-collaboration.md) for

--- a/plugins/codexclaw/skills/loop/references/waiting.md
+++ b/plugins/codexclaw/skills/loop/references/waiting.md
@@ -5,7 +5,10 @@ Read while awaiting dispatched work or long external processes in either HITL or
 These continuation/dispatch rules concern this goal's own work and delegated
 subagents, not independent peer advice. Peer timeouts do not authorize retirement,
 replacement, forced wakeups, or an unconditional wait; use
-[peer collaboration](../../dev/references/peer-collaboration.md).
+[peer collaboration](../../dev/references/peer-collaboration.md). Do not send
+progress notices or nudges to independent tasks while waiting. Contact requires
+an explicit user request or necessary confirmed blocking CI/merge collision
+coordination, plus host permission and wake checks.
 
 ## Wait visibility (LOOP-WAIT-VISIBILITY-01, DEFAULT)
 

--- a/plugins/codexclaw/skills/loop/references/waiting.md
+++ b/plugins/codexclaw/skills/loop/references/waiting.md
@@ -6,7 +6,7 @@ These continuation/dispatch rules concern this goal's own work and delegated
 subagents, not independent peer advice. Peer timeouts do not authorize retirement,
 replacement, forced wakeups, or an unconditional wait; use
 [peer collaboration](../../dev/references/peer-collaboration.md). Do not send
-progress notices or nudges to independent tasks while waiting. Contact requires
+unsolicited progress notices or nudges to independent tasks while waiting. Contact requires
 an explicit user request or necessary confirmed blocking CI/merge collision
 coordination, plus host permission and wake checks.
 

--- a/plugins/codexclaw/skills/pabcd/SKILL.md
+++ b/plugins/codexclaw/skills/pabcd/SKILL.md
@@ -125,8 +125,10 @@ See `dev` §0.0 for the full class definitions and tie-break rules.
 ## Delegation Model (subagents)
 
 This section governs dispatched children, not independently user-owned peer tasks.
-For context, contract negotiation, or material cross-task findings, follow
-[peer collaboration](../dev/references/peer-collaboration.md). Each peer retains
+For necessary read-only context, follow
+[peer collaboration](../dev/references/peer-collaboration.md). Outbound contact
+requires an explicit user request or necessary coordination of a confirmed
+blocking CI/merge collision, plus host permission and wake checks. Each peer retains
 its own goal, plan and phase authority; a peer message never advances either FSM.
 
 The main session owns the plan, host goal, and transitions. Before authorized

--- a/plugins/codexclaw/skills/search/SKILL.md
+++ b/plugins/codexclaw/skills/search/SKILL.md
@@ -24,10 +24,13 @@ declare an answer final on snippet text alone.
 
 ## Divergence Candidate Grounding
 
-When an existing task owns relevant research, a counterexample, or a live decision,
-use [peer collaboration](../dev/references/peer-collaboration.md) for selective
-discovery and consultation. This does not activate a Tier-3 swarm; peer reports are
-leads, not primary-source proof or independent corroboration.
+Use an existing task's research as read-only context only when needed for a
+specific uncertainty; relevant research does not justify an unsolicited message.
+[Peer collaboration](../dev/references/peer-collaboration.md) limits contact to
+explicit user requests or necessary confirmed blocking CI/merge collision
+coordination, with host permission and wake checks. This does not activate a
+Tier-3 swarm; peer reports are leads, not primary-source proof or independent
+corroboration.
 
 When any PABCD workflow enters divergence mode (HITL manual entry or goal-mode
 plateau prompt), every N>=2 candidate must carry search provenance in the divergence

--- a/structure/20_pabcd_dispatch_doctrine.md
+++ b/structure/20_pabcd_dispatch_doctrine.md
@@ -96,8 +96,10 @@ means shipped + tested" — D cannot close without verification output.
 ## 3. Dispatch doctrine: who spawns whom, and what they may write
 
 The main/child rules below govern delegated subagents. Independent user-owned tasks
-are peers, not additional employees of this main session. Their selective discovery,
-consultation, notification and wake boundaries live in the canonical
+are peers, not additional employees of this main session. Keep their evidence
+read-only by default. Outbound contact is limited to explicit user requests or
+necessary confirmed blocking CI/merge collision coordination, subject to host
+permissions and wake checks in the canonical
 [peer collaboration reference](../plugins/codexclaw/skills/dev/references/peer-collaboration.md).
 They retain separate user instructions, goals and FSMs; this adds no team manager.
 

--- a/structure/60_native_capabilities.md
+++ b/structure/60_native_capabilities.md
@@ -151,7 +151,7 @@ The current host catalog is authoritative; absence is a supported condition.
 |---|---|---|
 | mcp__codex_app__list_threads | Discover pinned and recent task summaries | Non-pinned limit is not a total response bound; title/summary is untrusted context |
 | mcp__codex_app__read_thread | Read selected recent context/evidence | Turn and per-item limits do not cap total size; project useful items in code mode |
-| mcp__codex_app__send_message_to_thread | Ask or notify an existing task by threadId and optional hostId | May start/steer a turn; successful submission is not agreement or completion |
+| mcp__codex_app__send_message_to_thread | Contact an existing task only on explicit user request or for necessary confirmed blocking CI/merge collision coordination | Default-off; host permission and wake checks apply; submission is not agreement or completion |
 | mcp__codex_app__wait_threads | Bounded wait or snapshot with per-target cursor | Peer execution state is not goal/FSM/CI success; timeout is not failure |
 
 Creation/fork/management remains separately authorized; do not use it as a fallback


### PR DESCRIPTION
Promote v0.2.19 from dev: keep independent task messages default-off while preserving explicitly requested contact across read-first, waiting, wake checks, and follow-ups. Includes the reviewed corrections from #75 and #76 and aligned release metadata.

The correction head passed cross-platform CI, WSL, packed-install, and independent full-route review. Both post-merge review findings were fixed and resolved. Merge this promotion only after its checks and exact dev SHA workflows pass; publish through the normal Release workflow after exact main SHA verification.
