### PR TITLE
chore(release): promote v0.2.20 native-stack opt-in policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to codexclaw are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.20] - 2026-09-06
+
+### Changed
+
+- Default to ordinary pull requests and manual branch chains. GitHub native stacks
+  now require a clear, strong request for that feature in the current task; do not
+  proactively suggest or create them. Align the dev/DevOps guidance and the actual
+  SessionStart and compact-recovery hints while preserving existing-stack safety.
+
 ## [0.2.19] - 2026-09-06
 
 ### Changed

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI — status, subagent config, provider toggle, GUI launcher.",

--- a/devlog/_plan/260906_native_stack_opt_in/000_scope.md
+++ b/devlog/_plan/260906_native_stack_opt_in/000_scope.md
@@ -1,0 +1,19 @@
+# Native-stack opt-in correction
+
+User explicitly rejects default GitHub native stacks and authorizes another release
+and deployment. Prior native-stack recommendations are superseded by this request.
+The previous peer-message delivery is complete; this is a new cohesive correction.
+Worktree974c stays in place, original dirty checkout untouched. Previous local
+closeout commits stay on codex/quiet-peer-coordination; this branch starts from
+origin/dev46b2ff53. Latest official release is0.2.19 at27514499.
+
+Source owner: dev/references/stacked-prs.md. The same native-default policy is
+injected by cxc-ops/src/map-affordance.ts, and locked by its runtime-output test.
+Correct the owner, dev and devops entrypoints, emitted hint and committed build.
+Keep ordinary PRs/manual dependency chains, current-head checks, existing-stack
+safety and no unsolicited peer messaging. No stack creation, conversion, extension
+installation, existing-stack dissolution, branch-protection changes or CI shortcuts.
+
+One C4 PABCD cycle covers this single correction and its delivery. No new host goal;
+the local goalplan records the authorized work. Prior Astra/high delegation permission
+continues for bounded independent audits. No new independent app tasks are created.

--- a/devlog/_plan/260906_native_stack_opt_in/010_delivery.md
+++ b/devlog/_plan/260906_native_stack_opt_in/010_delivery.md
@@ -1,0 +1,73 @@
+# Explicit-only native-stack delivery
+
+Loop archetype: satisfy-spec. Trigger: user rejects native-stack default.
+Goal: ordinary PRs/manual chains by default; native GitHub stacks only on unmistakable,
+strong, task-specific user request. Non-goals: remove safe inspection, weaken CI,
+modify stack membership or unrelated repositories/settings. Stop: patch released
+and four official installs verified. Memory: this numbered unit plus task evidence.
+Expected outcomes: DONE with all proof, otherwise a concrete external blocker.
+Escalation: main reclaims after two failed packets; added worker scope is a P amendment.
+Tools: git/gh/cxc/node, existing authenticated SSH targets and native Codex plugin CLI.
+No new token/time/cost bound was requested; bounded waits and no blind retries.
+
+## Exact changes
+
+MODIFY plugins/codexclaw/skills/dev/references/stacked-prs.md:
+- Add a prominent native-opt-in policy before the model. Native usage is default-off;
+  do not recommend/prompt to opt in or infer it from generic 'stack', PR splitting,
+  dependency graphs, CI work, release authority, Can Stack or platform availability.
+  One clear strong request naming GitHub native stacks is sufficient; no repeated
+  confirmation or emotional-word/password test. A plain mention/question is insufficient.
+- Replace 'use a registered native stack by default' and mandatory fallback permission
+  with ordinary PR/manual-chain default and native registration only after this opt-in.
+- Scope native tools/async merge instructions to explicitly requested native operations.
+  Existing native membership is not new authorization: read safely, report collateral
+  effects, continue independent work; do not auto-merge/unstack/retarget to escape it.
+- A PABCD dependency map does not itself choose a PR stack or native registration.
+  Keep useful manual-chain ordering and exact-head safety.
+
+MODIFY plugins/codexclaw/skills/dev/SKILL.md stack pointer and
+plugins/codexclaw/skills/dev-devops/SKILL.md stack-CI pointer:
+state ordinary PR/manual-chain default and the strong explicit native opt-in, retain
+owner reference and existing-membership/CI distinction. No proactive upsell.
+
+MODIFY plugins/codexclaw/components/cxc-ops/src/map-affordance.ts renderStackedPrAffordance:
+replace 'Publish GitHub stacks natively' with a bounded (<600 chars) emitted pointer:
+'Use ordinary PRs/manual chains by default. Do not suggest or create native stacks
+unless the user clearly and strongly requests GitHub native stacks for this task.'
+Keep owner DEV-STACK-06/07, existing membership safety and separate CI verification.
+No transport/tool permission enforcement is added; this is emitted guidance.
+
+MODIFY plugins/codexclaw/components/cxc-ops/test/map-affordance.test.ts existing two-event test:
+assert the runtime output's default/opt-in/no-suggestion contract for SessionStart
+and post-compact UserPromptSubmit, reject the removed native-publication directive;
+retain envelope/event/bounded-length tests. No extra test case/count needed.
+REGENERATE plugins/codexclaw/components/cxc-ops/dist/map-affordance.js using shipped build.mjs.
+Source-of-truth sync: owner and injected hint; no other architecture changes.
+
+## Verification and delivery
+
+Baseline: node --test plugins/codexclaw/components/cxc-ops/test/map-affordance.test.ts
+14pass,0fail (reads the changed runtime function and both actual hook envelopes).
+Run it after source/build changes; gate.mjs reads skills/references for drift.
+Independent audit scenarios: ordinary PR; generic stack/manual chain; splitPR/CI;
+strong explicit native request; plain native question; existing native stack without
+new authorization; banned auto-conversion/unstack; no renewed permission prompt when
+already strongly requested. Prose adherence is a review claim, not runtime enforcement.
+
+Bump0.2.19->0.2.20 in11 package surfaces, root lock workspace versions, manifest with
+fresh+codex UTC stamp and generated inventory. Preserve dependency graph/docs-site0.0.1.
+Add changelog entry. Existing test count2579 remains unless observed evidence differs.
+Use one ordinary PR to dev, then dev->main promotion. Opening promotion may overlap
+dev checks, but merge only after both checks pass. Require exact-main CI/WSL/packed,
+then normal release.yml dispatch version0.2.20. Download/verify tag/checksum and all
+published files against frozen Git using the previous reviewed manifest verifier.
+
+Deploy remote macmini-cf, suji, nativeWindows desktop-c795oh4, then local. All were
+verified0.2.19 from officialGit27514499 earlier in this conversation; refresh before
+writes. Reuse reviewed operator1a11ffc8 with only version literal/spec SHA/oldRoot,
+all marketplace keys nowcodexclaw (localpersonal was migrated). Fresh private per-host
+backups outside Codex cache, no bootstrap/restart/checkout edits. Full payload hash,
+actual marketplace Git HEAD, core doctor/trust and unchanged otherconfig checks.
+Use established encoding-aware Windows runner and verified empty-stage recovery only
+if needed. C receipt follows final real delivery report. D archives this unit.

--- a/devlog/_plan/260906_native_stack_opt_in/011_verification.md
+++ b/devlog/_plan/260906_native_stack_opt_in/011_verification.md
@@ -1,0 +1,13 @@
+# Initial verification
+
+A auditor Euler: PASS, no blockers; corrected abbreviated component paths.
+Fresh implementation reviewer Dewey: PASS across all6 policy/runtime/test files;
+generic stack/CI/release not opt-in; no upsell/confirmation loop; explicit cleanup
+and existing membership safety preserved. Focused14 tests re-run independently,
+including actual compiled CLI startup/compact envelopes. compileSource/dist byte
+comparison and scoped diff-check pass.
+
+Main build, drift gate,11-package version alignment and lock dependency-graph
+comparison pass. Runtime source/dist pointer exactly468 characters. No new test
+case/count: current total2579 will be remeasured by CI. This is policy guidance,
+not a hard runtime prohibition on native API calls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexclaw",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexclaw",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "license": "MIT",
       "workspaces": [
         "plugins/codexclaw/components/*",
@@ -20,7 +20,7 @@
     },
     "cli": {
       "name": "@codexclaw/cli",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "bin": {
         "codexclaw": "bin/codexclaw.mjs"
       }
@@ -1949,39 +1949,39 @@
     },
     "plugins/codexclaw/components/config-guard": {
       "name": "@codexclaw/config-guard",
-      "version": "0.2.19"
+      "version": "0.2.20"
     },
     "plugins/codexclaw/components/cxc-ops": {
       "name": "@codexclaw/cxc-ops",
-      "version": "0.2.19"
+      "version": "0.2.20"
     },
     "plugins/codexclaw/components/messenger-bridge": {
       "name": "@codexclaw/messenger-bridge",
-      "version": "0.2.19"
+      "version": "0.2.20"
     },
     "plugins/codexclaw/components/pabcd-state": {
       "name": "@codexclaw/pabcd-state",
-      "version": "0.2.19"
+      "version": "0.2.20"
     },
     "plugins/codexclaw/components/provider-bridge": {
       "name": "@codexclaw/provider-bridge",
-      "version": "0.2.19"
+      "version": "0.2.20"
     },
     "plugins/codexclaw/components/recall": {
       "name": "@codexclaw/recall",
-      "version": "0.2.19"
+      "version": "0.2.20"
     },
     "plugins/codexclaw/components/skill-search": {
       "name": "@codexclaw/skill-search",
-      "version": "0.2.19"
+      "version": "0.2.20"
     },
     "plugins/codexclaw/components/subagent-config": {
       "name": "@codexclaw/subagent-config",
-      "version": "0.2.19"
+      "version": "0.2.20"
     },
     "plugins/codexclaw/gui": {
       "name": "@codexclaw/gui",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.19+codex.20260906065707",
+  "version": "0.2.20+codex.20260906101802",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/dist/map-affordance.js
+++ b/plugins/codexclaw/components/cxc-ops/dist/map-affordance.js
@@ -191,12 +191,11 @@ export function renderLoopAffordance()         {
 /** Global discovery only; the agent verifies membership and CI on demand. */
 export function renderStackedPrAffordance()         {
   return [
-    "[codexclaw] For PR creation/review/merge or dependent branches (stacked PR/스택 PR),",
-    "read $codexclaw:cxc-dev references/stacked-prs.md (DEV-STACK-06/07), even without",
-    "a DevOps trigger. A parent base or Can Stack banner is not native stack registration;",
-    "verify GitHub membership and CI separately. Per-PR CI is expected, not proof of a broken stack.",
-    "Publish GitHub stacks natively; verify registration before claiming delivery.",
-    "This is guidance, not authorization to register, restack, cancel CI, or merge.",
+    "[codexclaw] For PR work or dependent branches, read $codexclaw:cxc-dev references/stacked-prs.md (DEV-STACK-06/07).",
+    "Use ordinary PRs/manual chains by default.",
+    "Do not suggest or create GitHub native stacks unless the user clearly and strongly requests them for this task.",
+    "Inspect existing membership and CI separately; a parent base or Can Stack banner is not opt-in.",
+    "Per-PR CI is expected. This is guidance, not authorization to register, restack, cancel CI, or merge.",
   ].join(" ");
 }
 

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI — doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/cxc-ops/src/map-affordance.ts
+++ b/plugins/codexclaw/components/cxc-ops/src/map-affordance.ts
@@ -191,12 +191,11 @@ export function renderLoopAffordance(): string {
 /** Global discovery only; the agent verifies membership and CI on demand. */
 export function renderStackedPrAffordance(): string {
   return [
-    "[codexclaw] For PR creation/review/merge or dependent branches (stacked PR/스택 PR),",
-    "read $codexclaw:cxc-dev references/stacked-prs.md (DEV-STACK-06/07), even without",
-    "a DevOps trigger. A parent base or Can Stack banner is not native stack registration;",
-    "verify GitHub membership and CI separately. Per-PR CI is expected, not proof of a broken stack.",
-    "Publish GitHub stacks natively; verify registration before claiming delivery.",
-    "This is guidance, not authorization to register, restack, cancel CI, or merge.",
+    "[codexclaw] For PR work or dependent branches, read $codexclaw:cxc-dev references/stacked-prs.md (DEV-STACK-06/07).",
+    "Use ordinary PRs/manual chains by default.",
+    "Do not suggest or create GitHub native stacks unless the user clearly and strongly requests them for this task.",
+    "Inspect existing membership and CI separately; a parent base or Can Stack banner is not opt-in.",
+    "Per-PR CI is expected. This is guidance, not authorization to register, restack, cancel CI, or merge.",
   ].join(" ");
 }
 

--- a/plugins/codexclaw/components/cxc-ops/test/map-affordance.test.ts
+++ b/plugins/codexclaw/components/cxc-ops/test/map-affordance.test.ts
@@ -255,10 +255,11 @@ test("stack guidance survives SessionStart and deferred compact recovery without
       const stackLine = ctx.split("\n").find((line: string) => line.includes("DEV-STACK-06/07"));
       assert.ok(stackLine, `${event} must expose stack guidance even in an empty non-Git repo`);
       assert.match(stackLine, /cxc-dev.*references\/stacked-prs\.md/);
-      assert.match(stackLine, /even without a DevOps trigger/);
-      assert.match(stackLine, /not native stack registration/);
+      assert.match(stackLine, /ordinary PRs\/manual chains by default/);
+      assert.match(stackLine, /parent base or Can Stack banner is not opt-in/);
       assert.match(stackLine, /Per-PR CI is expected/);
-      assert.match(stackLine, /Publish GitHub stacks natively; verify registration/);
+      assert.match(stackLine, /Do not suggest or create GitHub native stacks unless the user clearly and strongly requests them for this task/);
+      assert.doesNotMatch(stackLine, /Publish GitHub stacks natively/);
       assert.match(stackLine, /not authorization/);
       assert.ok(stackLine.length < 600, "global guidance must remain a bounded pointer");
       assert.deepEqual(Object.keys(envelope), ["hookSpecificOutput"]);
@@ -322,6 +323,7 @@ test("direct-exec guard fires through a symlinked install path (plugin-cache reg
   assert.match(res.stdout, /additionalContext/, "symlink invocation must emit the envelope");
   assert.match(res.stdout, /cxc map/, "envelope must carry the map pointer");
   assert.match(JSON.parse(res.stdout).hookSpecificOutput.additionalContext, /DEV-STACK-06\/07/);
+  assert.match(JSON.parse(res.stdout).hookSpecificOutput.additionalContext, /native stacks unless the user clearly and strongly requests them for this task/);
   assert.match(JSON.parse(res.stdout).hookSpecificOutput.additionalContext, /User questions:.*request_user_input_async/);
   const compact = spawnSync(process.execPath, [link, "hook", "post-compact"], {
     input: JSON.stringify({ hook_event_name: "PostCompact", cwd: big, session_id: "linked" }), encoding: "utf8" });
@@ -333,5 +335,6 @@ test("direct-exec guard fires through a symlinked install path (plugin-cache reg
   const compactEnvelope = JSON.parse(prompt.stdout).hookSpecificOutput;
   assert.equal(compactEnvelope.hookEventName, "UserPromptSubmit");
   assert.match(compactEnvelope.additionalContext, /DEV-STACK-06\/07/);
+  assert.match(compactEnvelope.additionalContext, /native stacks unless the user clearly and strongly requests them for this task/);
   assert.match(compactEnvelope.additionalContext, /User questions:.*request_user_input_async/);
 });

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge — cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) — subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.19+codex.20260906065707",
-    "packageVersion": "0.2.19"
+    "manifestVersion": "0.2.20+codex.20260906101802",
+    "packageVersion": "0.2.20"
   },
   "skills": [
     {
@@ -263,49 +263,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.19",
+      "version": "0.2.20",
       "hasTests": true
     }
   ]

--- a/plugins/codexclaw/skills/dev-devops/SKILL.md
+++ b/plugins/codexclaw/skills/dev-devops/SKILL.md
@@ -109,7 +109,10 @@ policy.
 checks, follow `DEV-STACK-03/06/07` in
 [`cxc-dev`'s canonical stack reference](../dev/references/stacked-prs.md).
 Stack recognition also applies without this DevOps router; the global `dev` entry
-owns it. Keep membership and CI decisions in that owner, not a second procedure here.
+owns it. Ordinary PRs/manual chains are the default. Do not suggest or adopt GitHub
+native stacks without the user's clear, strong request for that feature in this task
+(DEV-STACK-OPT-IN-01). Existing membership is a safety fact, not new authorization.
+Keep membership and CI decisions in the canonical owner.
 
 ### §2.2 GHA Reusable Workflows (DEFAULT)
 

--- a/plugins/codexclaw/skills/dev/SKILL.md
+++ b/plugins/codexclaw/skills/dev/SKILL.md
@@ -82,8 +82,10 @@ rule is DEFAULT unless violating it has a concrete safety or correctness consequ
 
 For PR creation/review/merge or dependent work-phase delivery, read
 [stacked PRs](references/stacked-prs.md) (DEV-STACK-06/07), even without a DevOps
-trigger. Verify native membership and CI separately; a body map or parent base
-is not registration. Generic CSS/runtime stacks are not PR-stack signals.
+trigger. Default to ordinary PRs/manual chains. Do not suggest or create GitHub
+native stacks unless the user clearly and strongly requests that feature for this
+task (DEV-STACK-OPT-IN-01). Inspect existing membership and CI separately for safety;
+a body map or parent base is not native opt-in. Generic CSS/runtime stacks are unrelated.
 
 Methodologies are conditional, not universal. For an explicit method, repo
 requirement, or a matching strict trigger, read

--- a/plugins/codexclaw/skills/dev/references/stacked-prs.md
+++ b/plugins/codexclaw/skills/dev/references/stacked-prs.md
@@ -4,6 +4,28 @@ Canonical owner: `dev`. Other skills carry pointer stubs only (see
 `references/skill-ownership.md`). Rules here are tool-agnostic: the portable model first,
 CLI recipes second.
 
+## Native stacks are explicit-only (DEV-STACK-OPT-IN-01)
+
+Use ordinary pull requests by default; use a manual branch chain when dependencies
+justify it. GitHub native stacks are default-off. Do not suggest, register, convert
+to, or select a native-stack workflow unless the user clearly and strongly requests
+GitHub native stacks for this specific task.
+
+A generic request to "stack", split PRs, follow a dependency roadmap, improve CI,
+merge, or release is not native opt-in. Neither platform support, a Can Stack banner,
+nor existing membership supplies that intent. Do not ask users to opt in as a routine
+step. One unmistakable request naming the native feature is enough: no repeated
+confirmation, begging, emotional-word test, or special phrase is required. Preserve
+that authorization within its stated task scope and respect later changes of mind.
+
+This selection rule governs every native procedure below. Read-only inspection of
+an existing stack remains allowed for safety; it does not authorize creating one,
+merging its members, restacking, or dissolving it. If an existing stack prevents an
+ordinary authorized operation, explain the concrete blocker and continue independent
+work. Ask for direction only when necessary; do not push the user toward native use.
+Explicit requests to leave or remove an existing stack are separate scoped actions,
+not requests to adopt native stacks. Never change membership merely to avoid an error.
+
 ## The model
 
 A **stack** is an ordered chain of branches. The **bottom** branch is based on trunk
@@ -55,16 +77,15 @@ or restack while you work. GitHub native stacks currently require one repository
 
 `gh pr create --base <parent>`, a body stack map, labels, and the **Can Stack** banner
 do not certify native registration. The banner offers conversion; confirmation is a
-separate operation. **For authorized GitHub stack publication, use a registered native
-stack by default. Base chaining alone is not completed stack delivery.** Inspect
-available tooling (`gh extension list`, installed command help)
-and choose `gh stack submit`, the website's Create stack confirmation, or the
-[documented REST create endpoint](https://docs.github.com/en/rest/pulls/stacks#create-a-pull-request-stack)
-(POST with an ordered `pull_requests` array, bottom to top). Re-read membership after
-the write; completion evidence includes the native stack number, trunk and ordered
-members. Do not install an extension automatically. If native registration is unavailable,
-report the limitation and obtain the user's choice before using a manual-chain fallback.
-When native stacks were explicitly requested, a manual chain never satisfies completion.
+separate operation. **Ordinary PRs and manual chains are the default delivery path;
+native registration requires the clear, strong, task-specific opt-in above.** A
+manual chain satisfies a generic stacked-PR request without a native upgrade prompt.
+Only after native selection and the particular write are authorized, inspect the
+available tooling and use a supported native registration path. Re-read membership
+after the write and record the stack number, trunk and ordered members. Never install
+an extension automatically. If explicitly requested native support is unavailable,
+report that limitation; do not claim a manual chain delivered the requested native
+feature or silently change the user's chosen mode.
 
 **Authority:** inspection is read-only. Registration, branch rewrites, PR retargeting,
 CI changes/cancellation and merging need authority for that operation and those PRs.
@@ -104,10 +125,10 @@ Stack when **all** of these hold:
 - the lower parts are mergeable on their own — they do not need the upper parts to be
   correct or safe.
 
-Codexclaw produces stack-shaped work by construction: a `cxc-pabcd` PHASE-SPLIT-01 phase
-map is dependency-ordered (foundations → core → integration → hardening) and each phase
-must close with something independently verifiable. That map **is** a stack plan; a
-`cxc-loop` chain of work-phases under one goal is the same shape across cycles.
+A `cxc-pabcd` PHASE-SPLIT-01 map orders implementation dependencies, not GitHub
+features. A phase map or `cxc-loop` chain alone selects neither a PR stack nor native
+registration. Decide whether a manual chain is useful using the criteria above;
+the native feature still requires DEV-STACK-OPT-IN-01.
 
 Do **not** stack when:
 
@@ -139,7 +160,7 @@ before asking for review:
   at a commit inside the rebased range. Branches checked out in another worktree are not
   updated. Prefer the per-invocation flag; do not change global Git configuration as
   an incidental step of stack work.
-- `gh stack rebase` fetches origin and cascades from trunk upward; if a layer's PR has
+- Only for an explicitly authorized native workflow, `gh stack rebase` fetches origin and cascades from trunk upward; if a layer's PR has
   already merged it switches to `--onto` mode automatically. Conflicts pause the run;
   resume with `--continue`, unwind everything with `--abort`. Scope with `--downstack` /
   `--upstack` / `--no-trunk`.
@@ -202,6 +223,11 @@ When you are reviewing one layer of a stack:
 
 ## DEV-STACK-04 — Merging and safety (ESCALATE)
 
+Native procedures in this section require DEV-STACK-OPT-IN-01 plus authorization
+for the affected members. Existing membership and a generic merge request do not
+authorize a native merge of lower members. Inspect first and report a real blocker;
+do not auto-convert, dissolve, or issue native writes to complete an ordinary PR.
+
 - **Merge bottom-up.** In a **registered GitHub stack**, merging the top PR brings every PR below it; merging a
   mid-stack PR merges everything below it while the PRs above stay open and re-target the
   stack's base automatically.
@@ -239,11 +265,13 @@ GraphQL: This pull request is part of a stack and must be merged using the async
 ```
 
 That invocation used the unsupported GraphQL path; `--admin` did not change it.
-Do not repeat the same command for every layer, dissolve the stack, or retarget it
-to evade this error. `mergeable_state: blocked` is a separate observation, not proof
+Do not automatically repeat the same command for every layer, dissolve the stack,
+or retarget it to evade this error. An explicit user request to unstack is a
+separately scoped cleanup action, not native adoption. `mergeable_state: blocked` is a separate observation, not proof
 that this transport error was fixed. Inspect membership and the actual merge result.
 
-After verifying the authorized stack prefix and current member heads, target the
+After the required native opt-in and authorization for the stack prefix, verify
+current member heads and target the
 highest PR in that prefix **once**. Recheck installed CLI support; otherwise use the
 [async REST API](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request-asynchronously):
 
@@ -286,7 +314,9 @@ is omitted, `gh` uses the `branch.<current>.gh-merge-base` config and, if that i
 the repository's default branch — so a layer can silently target trunk instead of its
 parent.
 
-GitHub's first-party extension is `gh stack` (`gh extension install github/gh-stack`,
+Only when the user clearly and strongly selected GitHub native stacks for this
+task should these native tools be considered. Do not suggest or install them for
+ordinary PRs or manual chains. GitHub's first-party extension is `gh stack` (`gh extension install github/gh-stack`,
 requires `gh` v2.0+). Core verbs: `init`, `add`, `push`, `view`, `submit`, `rebase`,
 `modify`; `up`/`down` navigate (up = away from trunk). Stack metadata lives in
 `.git/gh-stack` (JSON, uncommitted) and it enables `git rerere` on init so conflict


### PR DESCRIPTION
Promote v0.2.20: GitHub native stacks are explicitly opt-in, with ordinary PR/manual-chain defaults. Updates the canonical guidance, dev/DevOps routes, and actual startup/compact-recovery hint with compiled regression coverage.

PR #78 passed all exact-head checks and independent review. This is an ordinary dev-to-main promotion; no native stack registration. Merge after both exact dev workflows and promotion checks pass, then publish through the existing Release workflow after exact main verification.
