### PR TITLE
release: promote 0.2.22 spawn hook stdout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to codexclaw are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.22] - 2026-09-07
+
+### Fixed
+
+- Let spawn-hook stdout drain before exiting so large piped JSON retains the full
+  message and configured subagent model/effort. Includes source and shipped-CLI
+  regression coverage. Thanks to @thisisjun786 for PR #80.
+
 ## [0.2.21] - 2026-09-07
 
 ### Fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C579_passing-brightgreen" alt="2,579 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C580_passing-brightgreen" alt="2,580 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C579_passing-brightgreen" alt="2,579 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C580_passing-brightgreen" alt="2,580 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C579_passing-brightgreen" alt="2,579 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C580_passing-brightgreen" alt="2,580 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI \u2014 status, subagent config, provider toggle, GUI launcher.",

--- a/devlog/_plan/260907_spawn_stdout_drain/000_review.md
+++ b/devlog/_plan/260907_spawn_stdout_drain/000_review.md
@@ -1,0 +1,31 @@
+# PR80 review and delivery
+
+C2 bounded stdout bug, C4 release. Satisfy-spec following user's 'review this too'
+continuation of completed release. Scope: review/adopt contributor PR80, preserve
+commit attribution, recheck current dev, release0.2.22 on established four hosts.
+No unrelated hooks/roles/schema redesign or dirty-checkout edits. No broad local
+suite. Same source/CI/promotion/release/backup/hash/smoke gates as0.2.21.
+One cohesive work-phase: review+merge conflict resolution+release packaging.
+Verifier: source/dist real spawn-hook pipe test with model/effort/message preservation;
+mutation-red old process.exit, focused80 suite, final exact-head platform/WSL/packed
+CI; installed compiled-pipe smoke on each host. End after release/install proof.
+Artifacts here and .codexclaw/evidence/pr80. No user token/time bound.
+
+Original contributor7f18db0416b186ca83bf72803e21c621e815e3db bythisisjun786.
+Changed code: src/spawn-attach-hook.ts main ends natural exit via exitCode0;
+matching compiled dist and one200KiB real CLI regression. Only other changes are
+three generated README counts. No workflow/credential/policy changes.
+Original checks are action_required, not tested. Current dev causes only README
+badge conflicts. Resolve with newest generated inventory from measured total.
+Hypotheses: H1 forced exit truncates pending pipe writes (toggle tests); H2 payload
+normalization truncates before write (direct runSpawnAttachHook full output); H3
+consumer read cap (maxBuffer2MiB and independently parse output). Node official
+process docs warn process.exit can discard queued stdout; natural exit is intended.
+Review test timeout20s so future leaked handles fail instead of wedging CI.
+
+Delivery: merge original PR ancestry into isolated dev candidate, update contributor
+branch only if maintained-edit authorization and FF preserved. CI for final original
+PR, dev integration and main promotion. Version0.2.22 metadata/cachebuster, count2647
+only after measured new test plus existing2646 proof; full CI must agree. Publish
+normal Release workflow from exact main; verify tag/archive/all files then backed-up
+macmini-cf,suji,Windows,local install. Unrelated config and working copies preserved.

--- a/devlog/_plan/260907_spawn_stdout_drain/010_evidence.md
+++ b/devlog/_plan/260907_spawn_stdout_drain/010_evidence.md
@@ -1,0 +1,12 @@
+# Review and implementation evidence
+
+Baseline0.2.21 plus contributor regression failed: Unterminated string in JSON at
+position65536. Contributor patch passed80focused tests. Actual UTF8 pipe smoke
+produced410029bytes,complete JSON,model+effort+original-message preserved.
+Independent6file review PASS; added timeout20_000 and assert.ifError in spawnSync
+regression per P2 reviewer advice. Role/config/recursion/trust policy unchanged.
+Original7f18db04 is parent of merge4e80d84 with latestdev59307527; only README badge
+conflicts reconciled, new total2647 (existing2646 + measured newcase1).
+Build,gate,version checker and final80tests pass. Version0.2.22 changes only owned
+package versions, no dependency graph changes; freshmanifest metadata and inventory.
+Final GitHub checkout suite must confirm2647. No broad local suite.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexclaw",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexclaw",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "workspaces": [
         "plugins/codexclaw/components/*",
@@ -20,7 +20,7 @@
     },
     "cli": {
       "name": "@codexclaw/cli",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "bin": {
         "codexclaw": "bin/codexclaw.mjs"
       }
@@ -1949,39 +1949,39 @@
     },
     "plugins/codexclaw/components/config-guard": {
       "name": "@codexclaw/config-guard",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     "plugins/codexclaw/components/cxc-ops": {
       "name": "@codexclaw/cxc-ops",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     "plugins/codexclaw/components/messenger-bridge": {
       "name": "@codexclaw/messenger-bridge",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     "plugins/codexclaw/components/pabcd-state": {
       "name": "@codexclaw/pabcd-state",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     "plugins/codexclaw/components/provider-bridge": {
       "name": "@codexclaw/provider-bridge",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     "plugins/codexclaw/components/recall": {
       "name": "@codexclaw/recall",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     "plugins/codexclaw/components/skill-search": {
       "name": "@codexclaw/skill-search",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     "plugins/codexclaw/components/subagent-config": {
       "name": "@codexclaw/subagent-config",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     "plugins/codexclaw/gui": {
       "name": "@codexclaw/gui",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.21+codex.20260906214421",
+  "version": "0.2.22+codex.20260906224615",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI \u2014 doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge \u2014 cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/dist/spawn-attach-hook.js
+++ b/plugins/codexclaw/components/subagent-config/dist/spawn-attach-hook.js
@@ -968,7 +968,8 @@ function main()       {
     ? denyEnvelope("codexclaw spawn policy input exceeded 4 MiB; refusing to bypass the recursion and trust boundary")
     : runSpawnAttachHook(stdin.raw);
   if (out) process.stdout.write(out);
-  process.exit(0);
+  // Piped stdout is asynchronous on POSIX; let pending writes finish before exiting.
+  process.exitCode = 0;
 }
 
 // Only run as a CLI entrypoint, not when imported by tests. Compare via realpath:

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/components/subagent-config/src/spawn-attach-hook.ts
+++ b/plugins/codexclaw/components/subagent-config/src/spawn-attach-hook.ts
@@ -968,7 +968,8 @@ function main(): void {
     ? denyEnvelope("codexclaw spawn policy input exceeded 4 MiB; refusing to bypass the recursion and trust boundary")
     : runSpawnAttachHook(stdin.raw);
   if (out) process.stdout.write(out);
-  process.exit(0);
+  // Piped stdout is asynchronous on POSIX; let pending writes finish before exiting.
+  process.exitCode = 0;
 }
 
 // Only run as a CLI entrypoint, not when imported by tests. Compare via realpath:

--- a/plugins/codexclaw/components/subagent-config/test/spawn-attach-hook.test.ts
+++ b/plugins/codexclaw/components/subagent-config/test/spawn-attach-hook.test.ts
@@ -1049,3 +1049,34 @@ test("concise entrypoint is delivered once without recursively inlining its refs
   const detail = readFileSync(join(SKILLS_DIR, "dev", "references", "development-practice.md"), "utf8").trim();
   assert.ok(!first.includes(detail));
 });
+
+test("BUG-R1: CLI source and dist drain large rewritten spawn JSON over a pipe", () => {
+  const SENTINEL = "CXC-STDOUT-DRAIN-SENTINEL-END";
+  const originalMessage = `${"A".repeat(200 * 1024)}${SENTINEL}`;
+  assert.ok(originalMessage.length < 256 * 1024, "spawn message must stay under the normalization cap");
+  const cwd = workspaceWithConfig({
+    executor: { mode: "model", model: "gpt-5.6-luna", effort: "high", promptOverride: null },
+  });
+  const payload = spawnPayloadAt(cwd, { agent_type: "worker", message: originalMessage });
+  try {
+    for (const [label, cli] of [
+      ["source", resolve(here, "../src/spawn-attach-hook.ts")],
+      ["dist", resolve(here, "../dist/spawn-attach-hook.js")],
+    ] as const) {
+      const result = spawnSync(process.execPath, [cli, "hook", "pre-tool-use"], {
+        input: payload,
+        encoding: "utf8",
+        maxBuffer: 2 * 1024 * 1024,
+      });
+      assert.equal(result.status, 0, `${label} exit status`);
+      const parsed = JSON.parse(result.stdout);
+      const ui = parsed.hookSpecificOutput.updatedInput as Record<string, unknown>;
+      assert.equal(ui.model, "gpt-5.6-luna", `${label} model`);
+      assert.equal(ui.reasoning_effort, "high", `${label} effort`);
+      assert.equal(typeof ui.message, "string", `${label} message type`);
+      assert.ok(String(ui.message).endsWith(originalMessage), `${label} original message retained`);
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/plugins/codexclaw/components/subagent-config/test/spawn-attach-hook.test.ts
+++ b/plugins/codexclaw/components/subagent-config/test/spawn-attach-hook.test.ts
@@ -1067,7 +1067,9 @@ test("BUG-R1: CLI source and dist drain large rewritten spawn JSON over a pipe",
         input: payload,
         encoding: "utf8",
         maxBuffer: 2 * 1024 * 1024,
+        timeout: 20_000,
       });
+      assert.ifError(result.error);
       assert.equal(result.status, 0, `${label} exit status`);
       const parsed = JSON.parse(result.stdout);
       const ui = parsed.hookSpecificOutput.updatedInput as Record<string, unknown>;

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) \u2014 subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.21+codex.20260906214421",
-    "packageVersion": "0.2.21"
+    "manifestVersion": "0.2.22+codex.20260906224615",
+    "packageVersion": "0.2.22"
   },
   "skills": [
     {
@@ -263,49 +263,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasTests": true
     }
   ]


### PR DESCRIPTION
Promote 0.2.22 with PR #80: drain large spawn-hook stdout before natural exit, preserving full JSON, configured model/effort and original message. Original contribution by @thisisjun786 is preserved; the regression subprocess is bounded.

PR #80 passed all 11 checks on 03b0d7d4, including full platform CI (2647 registered tests), WSL drvfs/ext4 and installed lifecycle. The fork-only SHA install failure was resolved by publishing the identical reviewed commit to an upstream ref; unchanged install jobs then passed. Final main checks and the normal Release workflow precede four-host deployment.
