### PR TITLE
fix: bind workflow source checks to session worktrees

### DIFF
--- a/.github/workflows/packed-install.yml
+++ b/.github/workflows/packed-install.yml
@@ -117,6 +117,9 @@ jobs:
       # payload rather than this checkout.
       - name: Install, retrust, upgrade, and remove against an immutable ref
         shell: bash
+        env:
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          HEAD_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
           if command -v cxc >/dev/null 2>&1; then echo "unexpected cxc on PATH"; exit 1; fi
@@ -146,8 +149,8 @@ jobs:
             echo "payload[$1]: $PLUGIN_ROOT version=$PLUGIN_VERSION"
           }
 
-          PR_SHA=${{ github.event.pull_request.head.sha }}
-          codex plugin marketplace add "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" --ref "${PR_SHA:-$GITHUB_SHA}"
+          # Fork commits must be resolved in the repository that owns the head.
+          codex plugin marketplace add "${GITHUB_SERVER_URL}/${HEAD_REPOSITORY}" --ref "$HEAD_REVISION"
           install_and_resolve head
           HEAD_VERSION="$PLUGIN_VERSION"
 
@@ -179,7 +182,7 @@ jobs:
           OLD_VERSION="$PLUGIN_VERSION"
 
           codex plugin marketplace remove codexclaw
-          codex plugin marketplace add "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" --ref "${PR_SHA:-$GITHUB_SHA}"
+          codex plugin marketplace add "${GITHUB_SERVER_URL}/${HEAD_REPOSITORY}" --ref "$HEAD_REVISION"
           install_and_resolve head-again
 
           # The upgrade must be OBSERVABLE. An unchanged version means it silently kept

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to codexclaw are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Bind a native session to a same-repository source worktree with `cxc session
+  source <path>`. Phase delta checks, test commands, receipts and final validation
+  follow that tree while native session identity and evidence storage stay put.
+  `session current --json` exposes a bound source snapshot for QA/review producers.
+  Refuse missing/switched source roots instead of accepting them as implementation.
+
 ## [0.2.22] - 2026-09-07
 
 ### Fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C647_passing-brightgreen" alt="2,647 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C668_passing-brightgreen" alt="2,668 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C668_passing-brightgreen" alt="2,668 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C670_passing-brightgreen" alt="2,670 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C647_passing-brightgreen" alt="2,647 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C668_passing-brightgreen" alt="2,668 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C668_passing-brightgreen" alt="2,668 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C670_passing-brightgreen" alt="2,670 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C647_passing-brightgreen" alt="2,647 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C668_passing-brightgreen" alt="2,668 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C668_passing-brightgreen" alt="2,668 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C670_passing-brightgreen" alt="2,670 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260907_worktree_source_binding/000_plan.md
+++ b/devlog/_plan/260907_worktree_source_binding/000_plan.md
@@ -1,0 +1,17 @@
+# Worktree source binding
+
+Satisfy-spec repair requested by the user: reproduce the worktree false-negative, patch the installed plugin and publish an ordinary PR to dev. Stop after a reviewed patch, regression evidence, local installation and PR. No merge, release, native database edits or mutation of the reported Lina session. Evidence lives in this unit and task-local temporary logs. Main owns integration and publication; worker owns the source-binding module/CLI/tests. Escalate only a scope-changing or irreversible requirement; reclaim a failed delegation locally.
+
+## Cause and competing hypotheses
+
+H1: no implementation occurred; falsified by a real linked-worktree commit while native HEAD is unchanged. H2: CXC captures the wrong source root; test with identical temp repository state except explicit source binding, expecting B-to-C and Check to observe the linked worktree. H3: native identity is wrong; native SQLite fixture resolves the expected ID and native root, while the source-root mismatch persists.
+
+## Boundary decision
+
+Keep native identity, state, goalplans, review metadata and receipt storage at the original cwd. Add immutable session-specific source binding to a linked Git worktree in the same common Git directory. Preserve exact native cwd corroboration. Do not infer source from branch names, newest files, sibling sessions or arbitrary command cwd. Removing SOURCE-DELTA-01 or moving native DB state would erase useful checks and is rejected.
+
+Assets: session ownership, B baseline and check receipts. CLI/file input crosses the boundary; accidental cross-session commands and corrupt/redirected files are in scope. Hostile same-user edits of all evidence/native DB are outside existing CXC trust model. Bind before B, fail closed for damaged/removed/replaced worktrees, and preserve existing evidence. A bind must never make a new source count as implementation by itself.
+
+One cohesive module repair; details in 010_implementation.md. No new dependencies or UI. Existing session/source/receipt owners are reused. Source metadata is an additive optional sourceRoot in identities produced for explicitly bound sessions. Creation: captureSessionSourceIdentity; serialization: existing JSON writes; parsing: state, source-receipt, goalplan revivers; consumers: CLI/chat B gate, receipt producer, Check gate, final goal validation. Legacy unbound identities remain unchanged.
+
+Enforcement: local runtime CLI/chat/check/goal validation, not hostile-user authentication. A user can manually forge local state/receipts or edit the plugin; no claim of tamper-proof provenance. Native identity checks remain intact.

--- a/devlog/_plan/260907_worktree_source_binding/010_implementation.md
+++ b/devlog/_plan/260907_worktree_source_binding/010_implementation.md
@@ -1,0 +1,60 @@
+# Implementation and acceptance
+
+## Source and state boundary
+
+`session-source.ts` owns an immutable `.codexclaw/sources/<session>.json` binding:
+version, ownerSessionId, nativeCwd, sourceRoot, commonDir and gitDir. Creation is
+`session source <absolute-worktree>`, after exact native identity and state checks.
+Canonical realpaths must describe another worktree in the same Git common dir.
+Atomic exclusive publication preserves a concurrent winner. Binding is pre-B;
+repeating the same binding or restoring a previously pinned root is idempotent.
+Malformed, nonregular, redirected, foreign or missing bound sources refuse.
+
+`session-source-identity.ts` captures the resolved source using the existing
+source-identity implementation. Explicit bindings add `sourceRoot`; unbound
+captures retain the old shape. JSON receipt writers retain the field; state,
+source-receipt and goalplan revivers validate/preserve it. Comparison rejects
+unequal or missing roots. CLI and chat B-to-C have a separate root equality
+refusal BEFORE comparing content: root changes are never implementation.
+
+At B entry, CLI/chat persist optional `State.boundSourceRoot` alongside the B
+snapshot. State reconstruction and subsequent transitions retain it. Resolution
+checks this pin, including after B when the phaseEntrySource is cleared. Deleting
+a binding during Check therefore cannot certify the native tree. No pin is
+invented for legacy sessions. The source command may restore exactly the pinned
+root without rewriting phase, baseline or receipts.
+
+## Consumers
+
+- CLI/chat B entry and B-to-C capture the bound tree. Missing bound baselines refuse.
+- `receipt test` executes in the bound tree, checks before/after identities and
+  stores its result in the native evidence directory. Failed/mutating checks
+  cannot leave a passing receipt. Check verifies the same session/root/epoch.
+- Goal completion and `loop validate --session` use the same source capture.
+  Absolute worktree plan paths remain supported; plan/state paths stay native.
+- `session current --json` exposes `sourceCwd` and a bound `sourceIdentity` snapshot.
+  QA verdict, reviewer lane and final-gate producers use this at observation time.
+  A snapshot is not proof that QA/review ran. Rootless receipts are not wildcards.
+- QA validate-evidence validates and compares sourceRoot across scenarios and
+  preserves it in emitted receipts. Goalplan read/write must retain the QA,
+  final-gate and reviewer identities through final validation.
+- Final-review spawn prerequisites load the shipped sibling pabcd-state dist
+  source resolver with createRequire. This reuses canonical binding validation
+  and dirty-content hashing instead of duplicating a weaker metadata-only hash.
+  src and dist are at identical relative depth; both new dist files must ship.
+
+## Verification and delivery
+
+The existing Node test harness uses real temporary Git worktrees/native SQLite.
+Acceptance covers source-only edits, native-only edits, CLI/chat parity, correct
+check cwd/native receipt location, stale/foreign roots, binding deletion in B/C,
+late/foreign/corrupt source commands, QA mixed roots, final validation roundtrip,
+and clean/dirty final-review sources. Run source-identity, session-binding,
+worktree-source-integration and QA tests, then build, full suite, gate and smoke.
+Type diagnostics are compared against an untouched base; existing failures must
+not be described as a passing typecheck. Outcomes live in 020_verification.md.
+
+Only reviewed changed plugin src/dist/help/skill files are installed after a
+hash-checked backup. Installed dist is tested with isolated state, without
+advancing an existing user session. Publish one ordinary PR to dev; no merge or
+release. Phase-control and visual-QA docs document capture/recovery semantics.

--- a/devlog/_plan/260907_worktree_source_binding/020_verification.md
+++ b/devlog/_plan/260907_worktree_source_binding/020_verification.md
@@ -68,3 +68,16 @@ A real `session current --json` call shows the new sourceCwd field while retaini
 the actual native session identity/cwd. Existing blocked sessions were not
 advanced or rebound by this patch. Plugin update/reinstall can overwrite a local
 cache patch; upstream delivery remains a separate PR, not a release.
+
+## PR CI follow-up
+
+The remote Ubuntu suite ran all 2,668 tests with zero failures (2,597 passed,
+71 conditional skips). Its count gate exposed stale published test badges;
+`inventory.mjs --write --tests 2668` updates them and the measured-count check passes.
+
+Packed install used the upstream repository with a fork-only head SHA and failed
+before installation (`unable to read tree`). The workflow now passes the matching
+head repository/SHA via environment variables for head installs, retaining the
+upstream release source for the downgrade. YAML and shell syntax checks pass.
+An isolated probe with the workflow's exact Codex 0.147.0 successfully resolves
+the fork marketplace at the immutable head SHA. No runtime payload file changed.

--- a/devlog/_plan/260907_worktree_source_binding/020_verification.md
+++ b/devlog/_plan/260907_worktree_source_binding/020_verification.md
@@ -1,0 +1,70 @@
+# Verification
+
+Base: d811701 (dev). No existing user session, native database, branch or live
+worktree was migrated during verification. Fixtures use temporary Git worktrees
+and native SQLite databases. The implementation worker was reclaimed before any
+worker changes; the main agent implemented the patch. Independent plan review
+failed on root-mismatch polarity and QA identity propagation; both amendments
+were re-reviewed PASS before integration.
+
+## Reproduction and correction
+
+- A correct native ID/cwd plus changes only in a linked worktree reproduces
+  SOURCE-DELTA-01 on the unbound path.
+- In an isolated copy, disabling only session source routing reproduces the same
+  SOURCE-DELTA-01 failure in the new end-to-end regression. Restoring routing in
+  the patched tree passes it.
+- Bound/unbound root comparison and QA mixed-root regressions failed before the
+  identity changes and pass after them.
+- Deleting a binding during C initially allowed a native receipt. The regression
+  now refuses it; restoring exactly the pinned root preserves state and succeeds.
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Full `npm test`, with task-owned TMPDIR outside a Git ancestor | 2,668 tests: 2,598 pass, 0 fail, 70 existing conditional skips |
+| worktree-source-integration.test.ts | 17 pass, including shipped CLI subprocess, native storage, root loss in B/C, restoration, same-size dirty content, final review and v1 loop validation |
+| QA evidence contracts | 19 pass, including bound QA receipt through final goalplan validation and rootless/mixed-root refusal |
+| `npm run build` | 160 modules compiled; layout validated |
+| `npm run gate` | PASS |
+| `npm run smoke` | PASS on Linux |
+| Packaging regression | 4 pass; both new compiled files are tracked |
+| `git diff --check` | PASS |
+| Scoped strict TypeScript check | exit 2: same seven diagnostics as untouched base; no added diagnostic in the selected dependency closure |
+
+The host has an unrelated `/tmp/.git`, which breaks four pre-existing GUI
+project-root fixtures. Running those unchanged tests with a task-owned TMPDIR
+outside that ancestor passes 8/8; the full suite uses that isolation. No host
+marker was removed and no test was weakened. Initial packaging failures exposed
+the two new dist files being untracked; they are now included.
+
+Strict TypeScript diagnostics are existing interview cast/export errors and an
+untyped cxc-resolve dist import. The project build uses Node type stripping, not
+a whole-repository typecheck. This patch does not claim those errors are fixed.
+
+Windows/macOS execution is left to upstream CI. Tests and local smoke are Linux
+evidence; no merge or release is implied by these results.
+
+## Independent implementation review
+
+PASS, no blockers; reviewer independently ran four affected files (71 assertions
+at that review snapshot). Main's later full-suite and 17-case integration run
+cover the final code. Residuals: the pre-existing final-review generatedPaths
+exclusion mismatch remains; immutable bindings require a new session or restoring
+the same path after worktree removal; atomic publication needs hard links. These
+are documented limits, not claims of broader platform verification.
+
+## Local installed payload
+
+32 changed runtime/help/skill files were backed up and atomically replaced after
+matching each installed preimage to the Git base. Every installed postimage was
+hash-verified. The integration and QA contract harnesses were retargeted to the
+installed dist/CLI paths: 36 tests pass, 0 fail. One initial harness failure was
+an unretargeted QA script-relative path; correcting that test path exercised the
+installed validator's real usage exit. No production change was needed.
+
+A real `session current --json` call shows the new sourceCwd field while retaining
+the actual native session identity/cwd. Existing blocked sessions were not
+advanced or rebound by this patch. Plugin update/reinstall can overwrite a local
+cache patch; upstream delivery remains a separate PR, not a release.

--- a/plugins/codexclaw/bin/cxc.mjs
+++ b/plugins/codexclaw/bin/cxc.mjs
@@ -71,7 +71,7 @@ const HELP = [
   '  node "<payloadRoot>/bin/cxc.mjs" <command> [args]',
   "",
   "PABCD / loop:",
-  "  session current|bind          verify native identity / recover missing FSM state",
+  "  session current|bind|source   verify native identity / bind a source worktree",
   "  orchestrate <verb>             drive IPABCD state (try: orchestrate --help)",
   "  freeze | metric | divergence   interview freeze / metrics / divergence state",
   "  loop init|show|validate        manage the project-local goalplan substrate",

--- a/plugins/codexclaw/components/pabcd-state/dist/check-gate.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/check-gate.js
@@ -11,7 +11,8 @@
  * edge that needs them.
  */
 import { parseSourceBoundReceipt, isReceiptError } from "./source-receipt.js";
-import { captureSourceIdentity, compareSource } from "./source-identity.js";
+import { compareSource } from "./source-identity.js";
+import { captureSessionSourceIdentity } from "./session-source-identity.js";
 
 
 
@@ -65,10 +66,15 @@ export function validateCheckReceipt(
   // #49 wiring: re-capture with the SAME exclusions the receipt was captured with.
   // Dropping generatedPaths here compared an exclusive hash against an inclusive one,
   // which no amount of re-running could reconcile while a declared path kept moving.
-  const now = captureSourceIdentity(cwd, {
-    excludeCodexclawArtifacts: true,
-    ...(parsed.generatedPaths ? { generatedPaths: parsed.generatedPaths } : {}),
-  });
+  let now;
+  try {
+    now = captureSessionSourceIdentity(cwd, sessionId, {
+      excludeCodexclawArtifacts: true,
+      ...(parsed.generatedPaths ? { generatedPaths: parsed.generatedPaths } : {}),
+    });
+  } catch (err) {
+    return refuse(`SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}`);
+  }
   const cmp = compareSource(parsed.sourceIdentity, now);
   if (cmp.kind === "different") {
     return refuse(`the source changed after the check ran (${cmp.detail})`);

--- a/plugins/codexclaw/components/pabcd-state/dist/goal-gate.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/goal-gate.js
@@ -34,7 +34,9 @@ const CREATE_GOAL_WARNING =
 import { getGoalActiveStatus, suppressesInterview,                                            } from "./goal-active.js";
 import { readStateStrict } from "./state.js";
 import { readGoalplan, validateGoalplan } from "./goalplan.js";
-import { captureSourceIdentity, compareSource } from "./source-identity.js";
+import { compareSource } from "./source-identity.js";
+import { captureSessionSourceIdentity } from "./session-source-identity.js";
+import { resolveSessionSource } from "./session-source.js";
 import { parseSourceBoundReceipt } from "./source-receipt.js";
 import { hasSpentBudget, unrecordableVerdictStatus } from "./subagent-evidence.js";
 // Cross-component dist import (precedent: messenger-bridge/src/api-compat.ts:17).
@@ -268,6 +270,8 @@ export function applyGoalCompleteGuard(payload                   )         {
       );
     }
     if (state.slug) {
+      try { resolveSessionSource(payload.cwd, payload.session_id); }
+      catch (err) { return goalCompleteDenyEnvelope(`SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}`); }
       const plan = readGoalplan(payload.cwd, state.slug);
       if (plan) {
         // Completion must use the same marker/source/receipt-aware validation as
@@ -275,14 +279,14 @@ export function applyGoalCompleteGuard(payload                   )         {
         // field into a downgrade path around the v2 final gate.
         const verdict = validateGoalplan(plan, {
           cwd: payload.cwd,
-          captureSourceIdentity,
+          captureSourceIdentity: (cwd) => captureSessionSourceIdentity(cwd, payload.session_id),
           compareSource,
           readReceipt: (path, expectedKind) => parseSourceBoundReceipt(path, payload.cwd, expectedKind),
         });
         if (!verdict.ok) {
           const reasons = verdict.reasons.slice(0, 4).join("; ");
           return goalCompleteDenyEnvelope(
-            `GOAL-COMPLETE-GATE-01: the session-bound goalplan '${state.slug}' fails the E8 quality/integrity gate: ${reasons}. Repair invalid dependency, outcome, and criteria references first; then finish remaining work and record fresh capturedEvidence in .codexclaw/goalplans/${state.slug}/goalplan.json (check with \`cxc loop validate --slug "${state.slug}"\`), or use update_goal status "blocked" if an external blocker prevents completion. Do not shrink the objective to escape the gate (LOOP-CONTINUE-01).`,
+            `GOAL-COMPLETE-GATE-01: the session-bound goalplan '${state.slug}' fails the E8 quality/integrity gate: ${reasons}. Repair invalid dependency, outcome, and criteria references first; then finish remaining work and record fresh capturedEvidence in .codexclaw/goalplans/${state.slug}/goalplan.json (check with \`cxc loop validate --session ${payload.session_id} --slug "${state.slug}"\`), or use update_goal status "blocked" if an external blocker prevents completion. Do not shrink the objective to escape the gate (LOOP-CONTINUE-01).`,
           );
         }
       } else {

--- a/plugins/codexclaw/components/pabcd-state/dist/goalplan-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/goalplan-cli.js
@@ -42,6 +42,8 @@ import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { isCanonicalSessionId, readState, writeState } from "./state.js";
 import { captureSourceIdentity, compareSource } from "./source-identity.js";
+import { captureSessionSourceIdentity } from "./session-source-identity.js";
+import { resolveSessionSource } from "./session-source.js";
 import { parseSourceBoundReceipt } from "./source-receipt.js";
 import { applySteeringBatch } from "./steering.js";
 
@@ -665,9 +667,15 @@ export function runGoalplanCli(args                 )                    {
   // A read-only context, so `loop validate` can report on a schemaVersion 2 plan
   // instead of refusing every one of them for a missing context. Nothing here
   // mutates state; the enforcing consumer (goal-gate) is wired separately.
+  if (args.session) {
+    try { resolveSessionSource(args.cwd, args.session); }
+    catch (err) { return { code: 1, output: `loop validate: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}` }; }
+  } else if (plan.finalGate?.sourceIdentity?.sourceRoot) {
+    return { code: 1, output: "loop validate: SOURCE-ROOT: pass --session <id> to validate a bound source worktree." };
+  }
   const ctx                        = {
     cwd: args.cwd,
-    captureSourceIdentity,
+    captureSourceIdentity: (cwd) => args.session ? captureSessionSourceIdentity(cwd, args.session) : captureSourceIdentity(cwd),
     compareSource,
     readReceipt: (path, expectedKind) => parseSourceBoundReceipt(path, args.cwd, expectedKind),
   };

--- a/plugins/codexclaw/components/pabcd-state/dist/goalplan.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/goalplan.js
@@ -31,7 +31,7 @@ import {
   rmSync,
   writeSync,
 } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { isAbsolute, join, resolve, sep } from "node:path";
 import { renameWithRetry } from "./atomic-write.js";
 import { STATE_DIR } from "./state.js";
 import { deriveSlug,                   } from "./freeze.js";
@@ -404,6 +404,10 @@ function reviveSourceIdentity(raw         )                             {
     capturedAt: typeof s.capturedAt === "string" ? s.capturedAt : new Date(0).toISOString(),
   };
   if (typeof s.treeHash === "string") id.treeHash = s.treeHash;
+  if (s.sourceRoot !== undefined) {
+    if (typeof s.sourceRoot !== "string" || !isAbsolute(s.sourceRoot)) return undefined;
+    id.sourceRoot = s.sourceRoot;
+  }
   return id;
 }
 

--- a/plugins/codexclaw/components/pabcd-state/dist/hook.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/hook.js
@@ -82,7 +82,9 @@ import {
 
 
 } from "./goalplan.js";
- import { captureSourceIdentity, compareSource, describeSource } from "./source-identity.js";
+ import { compareSource, describeSource } from "./source-identity.js";
+import { resolveSessionSource } from "./session-source.js";
+import { captureSessionSourceIdentity } from "./session-source-identity.js";
 import { validateCheckReceipt } from "./check-gate.js";
 import { validatePlanArtifacts } from "./plan-gate.js";
 import { validateWorkPhaseBinding,                  } from "./attest.js";
@@ -806,6 +808,11 @@ function handleOrchestrateCommand(
     return null;
   }
 
+  if (command.verb !== "status" && command.verb !== "reset") {
+    try { resolveSessionSource(payload.cwd, payload.session_id); }
+    catch (err) { return buildContextOutput("UserPromptSubmit", `[codexclaw — refused: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}]`); }
+  }
+
   const closePhaseId = command.verb === "D" ? command.attest?.workPhaseId?.trim() ?? "" : "";
   const recoveringDclose = command.verb === "D" && matchesDcloseRecovery(state, closePhaseId);
   let closedWorkPhaseId                = closePhaseId || null;
@@ -834,8 +841,15 @@ function handleOrchestrateCommand(
   // SOURCE-DELTA-01 (050): the chat path gets the same B>C check as the CLI. Wiring
   // only one of them would leave a phrasing that bypasses the gate entirely, which
   // is the class of hole this unit exists to close.
+  if (state.phase === "B" && command.verb === "C" && !state.phaseEntrySource
+      && resolveSessionSource(payload.cwd, payload.session_id) !== payload.cwd) {
+    return buildContextOutput("UserPromptSubmit", "[codexclaw — refused: SOURCE-ROOT: bound source has no valid B baseline. Re-plan before continuing.]");
+  }
   if (state.phase === "B" && command.verb === "C" && state.phaseEntrySource) {
-    const now = captureSourceIdentity(payload.cwd, { excludeCodexclawArtifacts: true });
+    const now = captureSessionSourceIdentity(payload.cwd, payload.session_id, { excludeCodexclawArtifacts: true });
+    if (state.phaseEntrySource.sourceRoot !== now.sourceRoot) {
+      return buildContextOutput("UserPromptSubmit", "[codexclaw — refused: SOURCE-ROOT: source binding changed since B began. Re-plan and capture a new baseline; nothing was written.]");
+    }
     if (compareSource(state.phaseEntrySource, now).kind === "same") {
       return buildContextOutput(
         "UserPromptSubmit",
@@ -1212,7 +1226,7 @@ function handleOrchestrateCommand(
   // ordinary forward-edge write, so they are computed once here instead of inside one
   // branch. The values are unchanged from the pre-wp5 block.
   const entrySource = result.state && result.state.phase === "B"
-    ? captureSourceIdentity(payload.cwd, { excludeCodexclawArtifacts: true })
+    ? captureSessionSourceIdentity(payload.cwd, payload.session_id, { excludeCodexclawArtifacts: true })
     : null;
   const planBinding = state.phase === "P" && result.state?.phase === "A"
     ? chatPlanBinding(payload.cwd, state.slug, command.attest)
@@ -1290,6 +1304,7 @@ function handleOrchestrateCommand(
     writeState(payload.cwd, {
       ...result.state,
       phaseEntrySource: entrySource,
+      ...(entrySource?.sourceRoot ? { boundSourceRoot: entrySource.sourceRoot } : {}),
       planUnit: planBinding ? planBinding.unit : keepBinding ? state.planUnit : null,
       planEpoch: planBinding ? planBinding.epoch : keepBinding ? state.planEpoch : null,
       // 075: same rule as the CLI — C mints, staying in C keeps, elsewhere drops.

--- a/plugins/codexclaw/components/pabcd-state/dist/orchestrate-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/orchestrate-cli.js
@@ -20,7 +20,9 @@ import { resolveNativeSession } from "./session-binding.js";
 import { coerceAttest, validateWorkPhaseBinding, GATED_TRANSITIONS,                  } from "./attest.js";
 import { canEnter, transition, isLegalEdge, VALID_TRANSITIONS } from "./fsm.js";
 import { validatePlanArtifacts } from "./plan-gate.js";
-import { captureSourceIdentity, compareSource, describeSource } from "./source-identity.js";
+import { compareSource, describeSource } from "./source-identity.js";
+import { resolveSessionSource } from "./session-source.js";
+import { captureSessionSourceIdentity } from "./session-source-identity.js";
 import { randomBytes } from "node:crypto";
 
 
@@ -554,6 +556,9 @@ export function runOrchestrateCli(args                                          
 
   // phase verb: AGENT-GATED via the un-weakened transition().
   const to = args.verb         ;
+  // Validate before any phase/goalplan writes; identity and artifact cwd stay native.
+  try { resolveSessionSource(args.cwd, sessionId); }
+  catch (err) { return { code: 1, output: `orchestrate ${args.verb}: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}` }; }
   // P>A plan-artifact gate (260714 wp2, DIFFLEVEL-ROADMAP-01): the plan must
   // exist as numbered on-disk docs before Audit. Runs even when attest is null
   // so the FIRST error names planUnit. Fail-closed on this edge only.
@@ -663,8 +668,15 @@ export function runOrchestrateCli(args                                          
   // Advisory limits, stated plainly: committing work made in P also changes HEAD
   // and passes, a shared worktree attributes another session's edits to this one,
   // and no git means no opinion. It is a supporting signal, not the main defence.
+  if (state.phase === "B" && to === "C" && !state.phaseEntrySource
+      && resolveSessionSource(args.cwd, sessionId) !== args.cwd) {
+    return { code: 1, output: "orchestrate C: SOURCE-ROOT: bound source has no valid B baseline. Re-plan before continuing." };
+  }
   if (state.phase === "B" && to === "C" && state.phaseEntrySource) {
-    const now = captureSourceIdentity(args.cwd, { excludeCodexclawArtifacts: true });
+    const now = captureSessionSourceIdentity(args.cwd, sessionId, { excludeCodexclawArtifacts: true });
+    if (state.phaseEntrySource.sourceRoot !== now.sourceRoot) {
+      return { code: 1, output: "orchestrate C: SOURCE-ROOT: source binding changed since B began. Re-plan and capture a new baseline; nothing was written." };
+    }
     const cmp = compareSource(state.phaseEntrySource, now);
     if (cmp.kind === "same") {
       return {
@@ -1025,7 +1037,7 @@ export function runOrchestrateCli(args                                          
   // SOURCE-DELTA-01 (050): snapshot the source on entry to B, and clear it on every
   // other edge so a stale snapshot cannot outlive its phase. applyHumanTransition()
   // takes no cwd, so the capture belongs here at the call site rather than inside it.
-  const entrySource = result.state.phase === "B" ? captureSourceIdentity(args.cwd, { excludeCodexclawArtifacts: true }) : null;
+  const entrySource = result.state.phase === "B" ? captureSessionSourceIdentity(args.cwd, sessionId, { excludeCodexclawArtifacts: true }) : null;
   // 060: A carries the binding this edge just minted; entering P or I drops it, so
   // re-planning cannot leave an old approval looking current.
   const nextUnit = planBinding ? planBinding.unit : result.state.phase === "A" ? state.planUnit : null;
@@ -1074,7 +1086,7 @@ export function runOrchestrateCli(args                                          
       // Housekeeping is fail-open. The P-to-A edge continues.
     }
   }
-  writeState(args.cwd, { ...result.state, orchestrationActive: result.state.phase !== "IDLE", lastInjectedPhase: result.state.phase, stopBlockPhase: null, stopBlockCount: 0, phaseEntrySource: entrySource, planUnit: nextUnit, planEpoch: nextEpoch, checkEpoch: nextCheckEpoch });
+  writeState(args.cwd, { ...result.state, orchestrationActive: result.state.phase !== "IDLE", lastInjectedPhase: result.state.phase, stopBlockPhase: null, stopBlockCount: 0, phaseEntrySource: entrySource, ...(entrySource?.sourceRoot ? { boundSourceRoot: entrySource.sourceRoot } : {}), planUnit: nextUnit, planEpoch: nextEpoch, checkEpoch: nextCheckEpoch });
   // C-RENDER-GROUNDING-01: a new cycle starts at P — clear the render ledger so the
   // Stop advisory judges THIS cycle's rows only (stale rows both suppress and misfire).
   if (result.state.phase === "P") resetRenderLedger(args.cwd);

--- a/plugins/codexclaw/components/pabcd-state/dist/receipt-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/receipt-cli.js
@@ -16,7 +16,9 @@ import { commandInvocation } from "./win-exec.js";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { readState } from "./state.js";
-import { captureSourceIdentity, compareSource } from "./source-identity.js";
+import { compareSource } from "./source-identity.js";
+import { resolveSessionSource } from "./session-source.js";
+import { captureSessionSourceIdentity } from "./session-source-identity.js";
 import { STATE_DIR, sanitizeKey } from "./state.js";
 
 
@@ -113,11 +115,15 @@ export function runReceiptCli(args                )                   {
   // Clear first: a stale success must not survive a failing re-run.
   rmSync(path, { force: true });
 
+  let sourceCwd        ;
+  try { sourceCwd = resolveSessionSource(args.cwd, session); }
+  catch (err) { return { code: 1, output: `receipt test: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}` }; }
+
   const capture = {
     excludeCodexclawArtifacts: true,
     ...(args.generated && args.generated.length > 0 ? { generatedPaths: args.generated } : {}),
   };
-  const before = captureSourceIdentity(args.cwd, capture);
+  const before = captureSessionSourceIdentity(args.cwd, session, capture);
   const [bin, ...rest] = args.command;
   // Issue #40: `npm` is the command people actually pass here, and a bare
   // shell-less spawn of it cannot work on Windows - the name alone skips PATHEXT
@@ -126,12 +132,14 @@ export function runReceiptCli(args                )                   {
   // shell:false still holds and the recorded command stays the argv the user gave.
   const invocation = commandInvocation(bin, rest);
   const run = spawnSync(invocation.file, invocation.args, {
-    cwd: args.cwd,
+    cwd: sourceCwd,
     stdio: "inherit",
     shell: false,
     ...invocation.options,
   });
-  const after = captureSourceIdentity(args.cwd, capture);
+  let after;
+  try { after = captureSessionSourceIdentity(args.cwd, session, capture); }
+  catch (err) { return { code: 1, output: `receipt test: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}; no receipt written` }; }
 
   if (run.error || typeof run.status !== "number") {
     return { output: `receipt test: the command did not run to completion (${run.error?.message ?? "terminated by signal"}); no receipt written`, code: 1 };

--- a/plugins/codexclaw/components/pabcd-state/dist/receipt-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/receipt-cli.js
@@ -16,7 +16,7 @@ import { commandInvocation } from "./win-exec.js";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { readState } from "./state.js";
-import { compareSource } from "./source-identity.js";
+import { compareSource, gitEnv } from "./source-identity.js";
 import { resolveSessionSource } from "./session-source.js";
 import { captureSessionSourceIdentity } from "./session-source-identity.js";
 import { STATE_DIR, sanitizeKey } from "./state.js";
@@ -131,11 +131,15 @@ export function runReceiptCli(args                )                   {
   // through win-exec routes only .cmd/.bat via a caret-escaped ComSpec line, so
   // shell:false still holds and the recorded command stays the argv the user gave.
   const invocation = commandInvocation(bin, rest);
+  // The check command runs in the bound source tree, so Git inside it must resolve that
+  // tree from cwd alone: inherited GIT_DIR/GIT_WORK_TREE would let a clean native checkout
+  // certify a dirty bound worktree (reviewer probe, wp4 round 2).
   const run = spawnSync(invocation.file, invocation.args, {
     cwd: sourceCwd,
     stdio: "inherit",
     shell: false,
     ...invocation.options,
+    env: gitEnv(),
   });
   let after;
   try { after = captureSessionSourceIdentity(args.cwd, session, capture); }

--- a/plugins/codexclaw/components/pabcd-state/dist/session-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/session-cli.js
@@ -1,5 +1,7 @@
 import { closeSync, constants, fstatSync, lstatSync, openSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { bindSessionSource, resolveSessionSource } from "./session-source.js";
+import { captureSessionSourceIdentity } from "./session-source-identity.js";
 import { resolveNativeSession } from "./session-binding.js";
 import { ALL_PHASES, ensureState, SESSIONS_SUBDIR, STATE_DIR,            } from "./state.js";
 
@@ -64,8 +66,12 @@ export function runSessionCli(argv          , cwd        , env                  
     output: json ? JSON.stringify({ ok: false, error, hooksVerified: false }) : `${error}\nhooksVerified: false`,
   });
   const [command, ...flags] = argv;
-  if ((command !== "current" && command !== "bind") || flags.length > 1 || (flags.length === 1 && flags[0] !== "--json")) {
-    return fail("Usage: cxc session current [--json] | cxc session bind [--json]");
+  const sourceCommand = command === "source";
+  const validFlags = sourceCommand
+    ? (flags.length === 1 || (flags.length === 2 && flags[1] === "--json")) && !flags[0].startsWith("--")
+    : flags.length === 0 || (flags.length === 1 && flags[0] === "--json");
+  if (!["current", "bind", "source"].includes(command) || !validFlags) {
+    return fail("Usage: cxc session current [--json] | cxc session bind [--json] | cxc session source <absolute-worktree> [--json]");
   }
   const identity = resolveNativeSession(cwd, env);
   if (!identity.ok) return fail(identity.error);
@@ -84,10 +90,21 @@ export function runSessionCli(argv          , cwd        , env                  
     if (!state.ok) return fail(state.error);
     if (!state.stateExists) return fail("Session state disappeared during bind. Retry after the concurrent operation finishes.");
   }
+  let sourceCwd        ;
+  let sourceIdentity;
+  try {
+    if (sourceCommand && !state.stateExists) return fail("Bind session state before binding a source worktree.");
+    sourceCwd = sourceCommand
+      ? bindSessionSource(identity.cwd, identity.sessionId, flags[0])
+      : resolveSessionSource(identity.cwd, identity.sessionId);
+    if (sourceCwd !== identity.cwd) sourceIdentity = captureSessionSourceIdentity(identity.cwd, identity.sessionId);
+  } catch (err) { return fail(`SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}`); }
   const output = {
     ok: true,
     sessionId: identity.sessionId,
     cwd: identity.cwd,
+    sourceCwd,
+    ...(sourceIdentity ? { sourceIdentity } : {}),
     source: "CODEX_THREAD_ID",
     dbPath: identity.dbPath,
     statePath: join(identity.cwd, STATE_DIR, SESSIONS_SUBDIR, `${identity.sessionId}.json`),

--- a/plugins/codexclaw/components/pabcd-state/dist/session-source-identity.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/session-source-identity.js
@@ -1,0 +1,9 @@
+/** Session state/evidence stay native; only source capture follows the worktree. */
+import { resolveSessionSource } from "./session-source.js";
+import { captureSourceIdentity,                                          } from "./source-identity.js";
+
+export function captureSessionSourceIdentity(cwd        , sessionId        , options                 = {})                 {
+  const sourceCwd = resolveSessionSource(cwd, sessionId);
+  const identity = captureSourceIdentity(sourceCwd, sourceCwd === cwd ? options : { excludeCodexclawArtifacts: true, ...options });
+  return sourceCwd === cwd ? identity : { ...identity, sourceRoot: sourceCwd };
+}

--- a/plugins/codexclaw/components/pabcd-state/dist/session-source.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/session-source.js
@@ -1,0 +1,118 @@
+/** Immutable per-session source binding; native state/identity never moves. */
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { closeSync, constants, fstatSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { isCanonicalSessionId, readState } from "./state.js";
+
+
+
+
+
+
+
+
+
+
+function gitIdentity(cwd        )                                                      {
+  const env = { ...process.env };
+  for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) delete env[name];
+  const git = (...args          ) => execFileSync("git", args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  try {
+    return {
+      root: realpathSync(git("rev-parse", "--show-toplevel")),
+      commonDir: realpathSync(git("rev-parse", "--path-format=absolute", "--git-common-dir")),
+      gitDir: realpathSync(git("rev-parse", "--absolute-git-dir")),
+    };
+  } catch { throw new Error("Cannot resolve source Git worktree identity."); }
+}
+
+function bindingPath(cwd        , sessionId        )         {
+  if (!isCanonicalSessionId(sessionId)) throw new Error("Invalid source-binding session ID.");
+  for (const path of [join(cwd, ".codexclaw"), join(cwd, ".codexclaw", "sources")]) {
+    try {
+      const stat = lstatSync(path);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Source-binding directories must be real directories.");
+    } catch (err) {
+      if ((err                         ).code !== "ENOENT") throw err;
+    }
+  }
+  return join(cwd, ".codexclaw", "sources", `${sessionId}.json`);
+}
+
+function readBinding(cwd        , sessionId        )                       {
+  const path = bindingPath(cwd, sessionId);
+  let fd        ;
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("Source binding must be a regular file.");
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+  } catch (err) {
+    if ((err                         ).code === "ENOENT") return null;
+    throw err;
+  }
+  let raw         ;
+  try {
+    if (!fstatSync(fd).isFile()) throw new Error("Source binding must be a regular file.");
+    raw = JSON.parse(readFileSync(fd, "utf8"));
+  } catch { throw new Error("Source binding is unreadable or corrupt; existing bytes were preserved."); }
+  finally { closeSync(fd); }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("Invalid source binding.");
+  const b = raw                           ;
+  if (b.version !== 1 || b.ownerSessionId !== sessionId || b.nativeCwd !== realpathSync(cwd)
+      || ![b.sourceRoot, b.commonDir, b.gitDir].every(p => typeof p === "string" && isAbsolute(p))) {
+    throw new Error("Source binding has invalid identity or paths.");
+  }
+  return b                            ;
+}
+
+/** No binding keeps legacy behavior; a broken binding never falls back to cwd. */
+export function resolveSessionSource(cwd        , sessionId        )         {
+  const binding = readBinding(cwd, sessionId);
+  const pinned = readState(cwd, sessionId).boundSourceRoot;
+  if (!binding) {
+    if (pinned) throw new Error("Source binding is missing for the pinned worktree; restore the same binding before continuing.");
+    return cwd;
+  }
+  if (pinned && binding.sourceRoot !== pinned) throw new Error("Source binding differs from the session's pinned worktree.");
+  const native = gitIdentity(cwd);
+  const source = gitIdentity(binding.sourceRoot);
+  if (source.root !== binding.sourceRoot || source.commonDir !== binding.commonDir
+      || source.gitDir !== binding.gitDir || native.commonDir !== binding.commonDir) {
+    throw new Error("Bound source worktree moved or its repository identity changed.");
+  }
+  return binding.sourceRoot;
+}
+
+/** Caller must corroborate native identity and inspect the existing state first. */
+export function bindSessionSource(cwd        , sessionId        , target        )         {
+  if (!isAbsolute(target)) throw new Error("Source worktree path must be absolute.");
+  const nativeCwd = realpathSync(cwd);
+  const sourceRoot = realpathSync(target);
+  const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
+  if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
+    throw new Error("Source must be a linked worktree root in the native session's repository.");
+  }
+  const previous = readBinding(cwd, sessionId);
+  if (previous) {
+    if (resolveSessionSource(cwd, sessionId) !== sourceRoot) throw new Error("Source binding is immutable; use a new session for a different worktree.");
+    return sourceRoot;
+  }
+  const state = readState(cwd, sessionId);
+  if (state.boundSourceRoot && state.boundSourceRoot !== sourceRoot) throw new Error("Cannot replace the session's pinned source worktree.");
+  if (!state.boundSourceRoot && !["IDLE", "I", "P", "A"].includes(state.phase)) {
+    throw new Error("Bind the source before B. Preserve the old baseline and re-plan before binding.");
+  }
+  const binding                = { version: 1, ownerSessionId: sessionId, nativeCwd, sourceRoot, commonDir: source.commonDir, gitDir: source.gitDir };
+  const path = bindingPath(cwd, sessionId);
+  mkdirSync(join(cwd, ".codexclaw", "sources"), { recursive: true });
+  bindingPath(cwd, sessionId);
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(binding, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+  try {
+    try { linkSync(tmp, path); }
+    catch (err) { if ((err                         ).code !== "EEXIST") throw err; }
+  } finally { unlinkSync(tmp); }
+  if (resolveSessionSource(cwd, sessionId) !== sourceRoot) throw new Error("Another source binding won publication; existing binding preserved.");
+  return sourceRoot;
+}

--- a/plugins/codexclaw/components/pabcd-state/dist/session-source.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/session-source.js
@@ -14,15 +14,25 @@ import { isCanonicalSessionId, readState } from "./state.js";
 
 
 
+/**
+ * Canonical absolute path. `realpathSync.native` expands Windows 8.3 short names
+ * (`RUNNER~1`) that the JS implementation leaves intact; Git always reports the long
+ * form, so comparing a short-name cwd against `rev-parse` output would refuse a
+ * valid worktree (observed on windows-latest CI where TEMP is a short path).
+ */
+function canonical(path        )         {
+  return realpathSync.native(path);
+}
+
 function gitIdentity(cwd        )                                                      {
   const env = { ...process.env };
   for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) delete env[name];
   const git = (...args          ) => execFileSync("git", args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
   try {
     return {
-      root: realpathSync(git("rev-parse", "--show-toplevel")),
-      commonDir: realpathSync(git("rev-parse", "--path-format=absolute", "--git-common-dir")),
-      gitDir: realpathSync(git("rev-parse", "--absolute-git-dir")),
+      root: canonical(git("rev-parse", "--show-toplevel")),
+      commonDir: canonical(git("rev-parse", "--path-format=absolute", "--git-common-dir")),
+      gitDir: canonical(git("rev-parse", "--absolute-git-dir")),
     };
   } catch { throw new Error("Cannot resolve source Git worktree identity."); }
 }
@@ -59,7 +69,7 @@ function readBinding(cwd        , sessionId        )                       {
   finally { closeSync(fd); }
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("Invalid source binding.");
   const b = raw                           ;
-  if (b.version !== 1 || b.ownerSessionId !== sessionId || b.nativeCwd !== realpathSync(cwd)
+  if (b.version !== 1 || b.ownerSessionId !== sessionId || b.nativeCwd !== canonical(cwd)
       || ![b.sourceRoot, b.commonDir, b.gitDir].every(p => typeof p === "string" && isAbsolute(p))) {
     throw new Error("Source binding has invalid identity or paths.");
   }
@@ -87,8 +97,8 @@ export function resolveSessionSource(cwd        , sessionId        )         {
 /** Caller must corroborate native identity and inspect the existing state first. */
 export function bindSessionSource(cwd        , sessionId        , target        )         {
   if (!isAbsolute(target)) throw new Error("Source worktree path must be absolute.");
-  const nativeCwd = realpathSync(cwd);
-  const sourceRoot = realpathSync(target);
+  const nativeCwd = canonical(cwd);
+  const sourceRoot = canonical(target);
   const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
   if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
     throw new Error("Source must be a linked worktree root in the native session's repository.");

--- a/plugins/codexclaw/components/pabcd-state/dist/source-identity.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/source-identity.js
@@ -23,6 +23,8 @@ import { join } from "node:path";
 
 
 
+
+
 /**
  * discriminated result. A boolean|string union would let "unavailable" pass as
  * truthy and read as "same". Naming all three cases forces the consumer to
@@ -195,6 +197,9 @@ export function captureSourceIdentity(cwd        , options                 = {})
 export function compareSource(a                , b                )                   {
   if (a.kind === "unavailable" || b.kind === "unavailable") {
     return { kind: "unavailable", reason: "git could not resolve the source identity on at least one side" };
+  }
+  if (a.sourceRoot !== b.sourceRoot) {
+    return { kind: "different", detail: "source root changed or binding is missing" };
   }
   if (a.commitSha !== b.commitSha) {
     return { kind: "different", detail: `commit ${a.commitSha.slice(0, 7)} -> ${b.commitSha.slice(0, 7)}` };

--- a/plugins/codexclaw/components/pabcd-state/dist/source-identity.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/source-identity.js
@@ -60,8 +60,8 @@ export function assertNever(value       )        {
  */
 const GIT_ROUTING_VARS = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"];
 
-function gitEnv()                    {
-  const env = { ...process.env };
+export function gitEnv(base                    = process.env)                    {
+  const env = { ...base };
   for (const name of GIT_ROUTING_VARS) delete env[name];
   return env;
 }

--- a/plugins/codexclaw/components/pabcd-state/dist/source-identity.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/source-identity.js
@@ -52,8 +52,22 @@ export function assertNever(value       )        {
 
 
 
+/**
+ * Git must resolve the repository from `cwd` alone. Inherited GIT_DIR / GIT_WORK_TREE
+ * (and friends) would silently redirect status/rev-parse to another tree, so a receipt
+ * captured "for" a bound source worktree could describe the native checkout instead.
+ * Same sanitization as session-source.ts.
+ */
+const GIT_ROUTING_VARS = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"];
+
+function gitEnv()                    {
+  const env = { ...process.env };
+  for (const name of GIT_ROUTING_VARS) delete env[name];
+  return env;
+}
+
 function git(cwd        , args          )         {
-  return execFileSync("git", args, { cwd, maxBuffer: 64 * 1024 * 1024 });
+  return execFileSync("git", args, { cwd, env: gitEnv(), maxBuffer: 64 * 1024 * 1024 });
 }
 
 /**

--- a/plugins/codexclaw/components/pabcd-state/dist/source-receipt.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/source-receipt.js
@@ -74,6 +74,10 @@ function parseIdentity(raw         )                        {
     capturedAt: typeof s.capturedAt === "string" ? s.capturedAt : new Date(0).toISOString(),
   };
   if (typeof s.treeHash === "string") id.treeHash = s.treeHash;
+  if (s.sourceRoot !== undefined) {
+    if (typeof s.sourceRoot !== "string" || !isAbsolute(s.sourceRoot)) return null;
+    id.sourceRoot = s.sourceRoot;
+  }
   return id;
 }
 

--- a/plugins/codexclaw/components/pabcd-state/dist/state.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/state.js
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, linkSync, rmSync, statSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { renameWithRetry } from "./atomic-write.js";
 import {                        reconstructInterview, normalizeInterview, isInterviewReady } from "./interview.js";
 
@@ -215,6 +215,8 @@ export function reconstructUnverified(raw         )                             
 
 
 
+
+
 export const STATE_DIR = ".codexclaw";
 export const SESSIONS_SUBDIR = "sessions";
 export const LEDGER_FILE = "ledger.jsonl";
@@ -259,6 +261,10 @@ function reconstructSourceIdentity(raw         )                        {
     capturedAt: o.capturedAt,
   };
   if (typeof o.treeHash === "string") id.treeHash = o.treeHash;
+  if (o.sourceRoot !== undefined) {
+    if (typeof o.sourceRoot !== "string" || !isAbsolute(o.sourceRoot)) return null;
+    id.sourceRoot = o.sourceRoot;
+  }
   return id;
 }
 
@@ -550,6 +556,7 @@ export function readStateStrict(cwd        , sessionId        )                 
       // found on any other phase is stale by definition and reading it back would
       // keep the invariant true only by accident.
       phaseEntrySource: parsed.phase === "B" ? reconstructSourceIdentity(parsed.phaseEntrySource) : null,
+      ...(typeof parsed.boundSourceRoot === "string" && isAbsolute(parsed.boundSourceRoot) ? { boundSourceRoot: parsed.boundSourceRoot } : {}),
       // 060: only A can hold a plan binding — minted at P>A, consumed at A>B.
       planUnit: parsed.phase === "A" && typeof parsed.planUnit === "string" && parsed.planUnit.length > 0 ? parsed.planUnit : null,
       planEpoch: parsed.phase === "A" && typeof parsed.planEpoch === "string" && parsed.planEpoch.length > 0 ? parsed.planEpoch : null,

--- a/plugins/codexclaw/components/pabcd-state/src/check-gate.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/check-gate.ts
@@ -11,7 +11,8 @@
  * edge that needs them.
  */
 import { parseSourceBoundReceipt, isReceiptError } from "./source-receipt.ts";
-import { captureSourceIdentity, compareSource } from "./source-identity.ts";
+import { compareSource } from "./source-identity.ts";
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
 import type { State } from "./state.ts";
 
 export type CheckGateResult = { ok: true } | { ok: false; reason: string };
@@ -65,10 +66,15 @@ export function validateCheckReceipt(
   // #49 wiring: re-capture with the SAME exclusions the receipt was captured with.
   // Dropping generatedPaths here compared an exclusive hash against an inclusive one,
   // which no amount of re-running could reconcile while a declared path kept moving.
-  const now = captureSourceIdentity(cwd, {
-    excludeCodexclawArtifacts: true,
-    ...(parsed.generatedPaths ? { generatedPaths: parsed.generatedPaths } : {}),
-  });
+  let now;
+  try {
+    now = captureSessionSourceIdentity(cwd, sessionId, {
+      excludeCodexclawArtifacts: true,
+      ...(parsed.generatedPaths ? { generatedPaths: parsed.generatedPaths } : {}),
+    });
+  } catch (err) {
+    return refuse(`SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}`);
+  }
   const cmp = compareSource(parsed.sourceIdentity, now);
   if (cmp.kind === "different") {
     return refuse(`the source changed after the check ran (${cmp.detail})`);

--- a/plugins/codexclaw/components/pabcd-state/src/goal-gate.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/goal-gate.ts
@@ -34,7 +34,9 @@ const CREATE_GOAL_WARNING =
 import { getGoalActiveStatus, suppressesInterview, type GoalActiveDeps, type GoalActiveStatus } from "./goal-active.ts";
 import { readStateStrict } from "./state.ts";
 import { readGoalplan, validateGoalplan } from "./goalplan.ts";
-import { captureSourceIdentity, compareSource } from "./source-identity.ts";
+import { compareSource } from "./source-identity.ts";
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
+import { resolveSessionSource } from "./session-source.ts";
 import { parseSourceBoundReceipt } from "./source-receipt.ts";
 import { hasSpentBudget, unrecordableVerdictStatus } from "./subagent-evidence.ts";
 // Cross-component dist import (precedent: messenger-bridge/src/api-compat.ts:17).
@@ -268,6 +270,8 @@ export function applyGoalCompleteGuard(payload: PreToolUsePayload): string {
       );
     }
     if (state.slug) {
+      try { resolveSessionSource(payload.cwd, payload.session_id); }
+      catch (err) { return goalCompleteDenyEnvelope(`SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}`); }
       const plan = readGoalplan(payload.cwd, state.slug);
       if (plan) {
         // Completion must use the same marker/source/receipt-aware validation as
@@ -275,14 +279,14 @@ export function applyGoalCompleteGuard(payload: PreToolUsePayload): string {
         // field into a downgrade path around the v2 final gate.
         const verdict = validateGoalplan(plan, {
           cwd: payload.cwd,
-          captureSourceIdentity,
+          captureSourceIdentity: (cwd) => captureSessionSourceIdentity(cwd, payload.session_id),
           compareSource,
           readReceipt: (path, expectedKind) => parseSourceBoundReceipt(path, payload.cwd, expectedKind),
         });
         if (!verdict.ok) {
           const reasons = verdict.reasons.slice(0, 4).join("; ");
           return goalCompleteDenyEnvelope(
-            `GOAL-COMPLETE-GATE-01: the session-bound goalplan '${state.slug}' fails the E8 quality/integrity gate: ${reasons}. Repair invalid dependency, outcome, and criteria references first; then finish remaining work and record fresh capturedEvidence in .codexclaw/goalplans/${state.slug}/goalplan.json (check with \`cxc loop validate --slug "${state.slug}"\`), or use update_goal status "blocked" if an external blocker prevents completion. Do not shrink the objective to escape the gate (LOOP-CONTINUE-01).`,
+            `GOAL-COMPLETE-GATE-01: the session-bound goalplan '${state.slug}' fails the E8 quality/integrity gate: ${reasons}. Repair invalid dependency, outcome, and criteria references first; then finish remaining work and record fresh capturedEvidence in .codexclaw/goalplans/${state.slug}/goalplan.json (check with \`cxc loop validate --session ${payload.session_id} --slug "${state.slug}"\`), or use update_goal status "blocked" if an external blocker prevents completion. Do not shrink the objective to escape the gate (LOOP-CONTINUE-01).`,
           );
         }
       } else {

--- a/plugins/codexclaw/components/pabcd-state/src/goalplan-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/goalplan-cli.ts
@@ -42,6 +42,8 @@ import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { isCanonicalSessionId, readState, writeState } from "./state.ts";
 import { captureSourceIdentity, compareSource } from "./source-identity.ts";
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
+import { resolveSessionSource } from "./session-source.ts";
 import { parseSourceBoundReceipt } from "./source-receipt.ts";
 import { applySteeringBatch } from "./steering.ts";
 
@@ -665,9 +667,15 @@ export function runGoalplanCli(args: GoalplanCliArgs): GoalplanCliResult {
   // A read-only context, so `loop validate` can report on a schemaVersion 2 plan
   // instead of refusing every one of them for a missing context. Nothing here
   // mutates state; the enforcing consumer (goal-gate) is wired separately.
+  if (args.session) {
+    try { resolveSessionSource(args.cwd, args.session); }
+    catch (err) { return { code: 1, output: `loop validate: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}` }; }
+  } else if (plan.finalGate?.sourceIdentity?.sourceRoot) {
+    return { code: 1, output: "loop validate: SOURCE-ROOT: pass --session <id> to validate a bound source worktree." };
+  }
   const ctx: GoalplanValidationCtx = {
     cwd: args.cwd,
-    captureSourceIdentity,
+    captureSourceIdentity: (cwd) => args.session ? captureSessionSourceIdentity(cwd, args.session) : captureSourceIdentity(cwd),
     compareSource,
     readReceipt: (path, expectedKind) => parseSourceBoundReceipt(path, args.cwd, expectedKind),
   };

--- a/plugins/codexclaw/components/pabcd-state/src/goalplan.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/goalplan.ts
@@ -31,7 +31,7 @@ import {
   rmSync,
   writeSync,
 } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { isAbsolute, join, resolve, sep } from "node:path";
 import { renameWithRetry } from "./atomic-write.ts";
 import { STATE_DIR } from "./state.ts";
 import { deriveSlug, type PlanFileHash } from "./freeze.ts";
@@ -404,6 +404,10 @@ function reviveSourceIdentity(raw: unknown): SourceIdentity | undefined {
     capturedAt: typeof s.capturedAt === "string" ? s.capturedAt : new Date(0).toISOString(),
   };
   if (typeof s.treeHash === "string") id.treeHash = s.treeHash;
+  if (s.sourceRoot !== undefined) {
+    if (typeof s.sourceRoot !== "string" || !isAbsolute(s.sourceRoot)) return undefined;
+    id.sourceRoot = s.sourceRoot;
+  }
   return id;
 }
 

--- a/plugins/codexclaw/components/pabcd-state/src/hook.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/hook.ts
@@ -82,7 +82,9 @@ import {
   type AdvanceResult,
   type Goalplan,
 } from "./goalplan.ts";
- import { captureSourceIdentity, compareSource, describeSource } from "./source-identity.ts";
+ import { compareSource, describeSource } from "./source-identity.ts";
+import { resolveSessionSource } from "./session-source.ts";
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
 import { validateCheckReceipt } from "./check-gate.ts";
 import { validatePlanArtifacts } from "./plan-gate.ts";
 import { validateWorkPhaseBinding, type Attestation } from "./attest.ts";
@@ -806,6 +808,11 @@ function handleOrchestrateCommand(
     return null;
   }
 
+  if (command.verb !== "status" && command.verb !== "reset") {
+    try { resolveSessionSource(payload.cwd, payload.session_id); }
+    catch (err) { return buildContextOutput("UserPromptSubmit", `[codexclaw — refused: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}]`); }
+  }
+
   const closePhaseId = command.verb === "D" ? command.attest?.workPhaseId?.trim() ?? "" : "";
   const recoveringDclose = command.verb === "D" && matchesDcloseRecovery(state, closePhaseId);
   let closedWorkPhaseId: string | null = closePhaseId || null;
@@ -834,8 +841,15 @@ function handleOrchestrateCommand(
   // SOURCE-DELTA-01 (050): the chat path gets the same B>C check as the CLI. Wiring
   // only one of them would leave a phrasing that bypasses the gate entirely, which
   // is the class of hole this unit exists to close.
+  if (state.phase === "B" && command.verb === "C" && !state.phaseEntrySource
+      && resolveSessionSource(payload.cwd, payload.session_id) !== payload.cwd) {
+    return buildContextOutput("UserPromptSubmit", "[codexclaw — refused: SOURCE-ROOT: bound source has no valid B baseline. Re-plan before continuing.]");
+  }
   if (state.phase === "B" && command.verb === "C" && state.phaseEntrySource) {
-    const now = captureSourceIdentity(payload.cwd, { excludeCodexclawArtifacts: true });
+    const now = captureSessionSourceIdentity(payload.cwd, payload.session_id, { excludeCodexclawArtifacts: true });
+    if (state.phaseEntrySource.sourceRoot !== now.sourceRoot) {
+      return buildContextOutput("UserPromptSubmit", "[codexclaw — refused: SOURCE-ROOT: source binding changed since B began. Re-plan and capture a new baseline; nothing was written.]");
+    }
     if (compareSource(state.phaseEntrySource, now).kind === "same") {
       return buildContextOutput(
         "UserPromptSubmit",
@@ -1212,7 +1226,7 @@ function handleOrchestrateCommand(
   // ordinary forward-edge write, so they are computed once here instead of inside one
   // branch. The values are unchanged from the pre-wp5 block.
   const entrySource = result.state && result.state.phase === "B"
-    ? captureSourceIdentity(payload.cwd, { excludeCodexclawArtifacts: true })
+    ? captureSessionSourceIdentity(payload.cwd, payload.session_id, { excludeCodexclawArtifacts: true })
     : null;
   const planBinding = state.phase === "P" && result.state?.phase === "A"
     ? chatPlanBinding(payload.cwd, state.slug, command.attest)
@@ -1290,6 +1304,7 @@ function handleOrchestrateCommand(
     writeState(payload.cwd, {
       ...result.state,
       phaseEntrySource: entrySource,
+      ...(entrySource?.sourceRoot ? { boundSourceRoot: entrySource.sourceRoot } : {}),
       planUnit: planBinding ? planBinding.unit : keepBinding ? state.planUnit : null,
       planEpoch: planBinding ? planBinding.epoch : keepBinding ? state.planEpoch : null,
       // 075: same rule as the CLI — C mints, staying in C keeps, elsewhere drops.

--- a/plugins/codexclaw/components/pabcd-state/src/orchestrate-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/orchestrate-cli.ts
@@ -20,7 +20,9 @@ import { resolveNativeSession } from "./session-binding.ts";
 import { coerceAttest, validateWorkPhaseBinding, GATED_TRANSITIONS, type Attestation } from "./attest.ts";
 import { canEnter, transition, isLegalEdge, VALID_TRANSITIONS } from "./fsm.ts";
 import { validatePlanArtifacts } from "./plan-gate.ts";
-import { captureSourceIdentity, compareSource, describeSource } from "./source-identity.ts";
+import { compareSource, describeSource } from "./source-identity.ts";
+import { resolveSessionSource } from "./session-source.ts";
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
 import { randomBytes } from "node:crypto";
 
 
@@ -554,6 +556,9 @@ export function runOrchestrateCli(args: OrchestrateCliArgs | OrchestrateCliHelpA
 
   // phase verb: AGENT-GATED via the un-weakened transition().
   const to = args.verb as Phase;
+  // Validate before any phase/goalplan writes; identity and artifact cwd stay native.
+  try { resolveSessionSource(args.cwd, sessionId); }
+  catch (err) { return { code: 1, output: `orchestrate ${args.verb}: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}` }; }
   // P>A plan-artifact gate (260714 wp2, DIFFLEVEL-ROADMAP-01): the plan must
   // exist as numbered on-disk docs before Audit. Runs even when attest is null
   // so the FIRST error names planUnit. Fail-closed on this edge only.
@@ -663,8 +668,15 @@ export function runOrchestrateCli(args: OrchestrateCliArgs | OrchestrateCliHelpA
   // Advisory limits, stated plainly: committing work made in P also changes HEAD
   // and passes, a shared worktree attributes another session's edits to this one,
   // and no git means no opinion. It is a supporting signal, not the main defence.
+  if (state.phase === "B" && to === "C" && !state.phaseEntrySource
+      && resolveSessionSource(args.cwd, sessionId) !== args.cwd) {
+    return { code: 1, output: "orchestrate C: SOURCE-ROOT: bound source has no valid B baseline. Re-plan before continuing." };
+  }
   if (state.phase === "B" && to === "C" && state.phaseEntrySource) {
-    const now = captureSourceIdentity(args.cwd, { excludeCodexclawArtifacts: true });
+    const now = captureSessionSourceIdentity(args.cwd, sessionId, { excludeCodexclawArtifacts: true });
+    if (state.phaseEntrySource.sourceRoot !== now.sourceRoot) {
+      return { code: 1, output: "orchestrate C: SOURCE-ROOT: source binding changed since B began. Re-plan and capture a new baseline; nothing was written." };
+    }
     const cmp = compareSource(state.phaseEntrySource, now);
     if (cmp.kind === "same") {
       return {
@@ -1025,7 +1037,7 @@ export function runOrchestrateCli(args: OrchestrateCliArgs | OrchestrateCliHelpA
   // SOURCE-DELTA-01 (050): snapshot the source on entry to B, and clear it on every
   // other edge so a stale snapshot cannot outlive its phase. applyHumanTransition()
   // takes no cwd, so the capture belongs here at the call site rather than inside it.
-  const entrySource = result.state.phase === "B" ? captureSourceIdentity(args.cwd, { excludeCodexclawArtifacts: true }) : null;
+  const entrySource = result.state.phase === "B" ? captureSessionSourceIdentity(args.cwd, sessionId, { excludeCodexclawArtifacts: true }) : null;
   // 060: A carries the binding this edge just minted; entering P or I drops it, so
   // re-planning cannot leave an old approval looking current.
   const nextUnit = planBinding ? planBinding.unit : result.state.phase === "A" ? state.planUnit : null;
@@ -1074,7 +1086,7 @@ export function runOrchestrateCli(args: OrchestrateCliArgs | OrchestrateCliHelpA
       // Housekeeping is fail-open. The P-to-A edge continues.
     }
   }
-  writeState(args.cwd, { ...result.state, orchestrationActive: result.state.phase !== "IDLE", lastInjectedPhase: result.state.phase, stopBlockPhase: null, stopBlockCount: 0, phaseEntrySource: entrySource, planUnit: nextUnit, planEpoch: nextEpoch, checkEpoch: nextCheckEpoch });
+  writeState(args.cwd, { ...result.state, orchestrationActive: result.state.phase !== "IDLE", lastInjectedPhase: result.state.phase, stopBlockPhase: null, stopBlockCount: 0, phaseEntrySource: entrySource, ...(entrySource?.sourceRoot ? { boundSourceRoot: entrySource.sourceRoot } : {}), planUnit: nextUnit, planEpoch: nextEpoch, checkEpoch: nextCheckEpoch });
   // C-RENDER-GROUNDING-01: a new cycle starts at P — clear the render ledger so the
   // Stop advisory judges THIS cycle's rows only (stale rows both suppress and misfire).
   if (result.state.phase === "P") resetRenderLedger(args.cwd);

--- a/plugins/codexclaw/components/pabcd-state/src/receipt-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/receipt-cli.ts
@@ -16,7 +16,7 @@ import { commandInvocation } from "./win-exec.ts";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { readState } from "./state.ts";
-import { compareSource } from "./source-identity.ts";
+import { compareSource, gitEnv } from "./source-identity.ts";
 import { resolveSessionSource } from "./session-source.ts";
 import { captureSessionSourceIdentity } from "./session-source-identity.ts";
 import { STATE_DIR, sanitizeKey } from "./state.ts";
@@ -131,11 +131,15 @@ export function runReceiptCli(args: ReceiptCliArgs): ReceiptCliResult {
   // through win-exec routes only .cmd/.bat via a caret-escaped ComSpec line, so
   // shell:false still holds and the recorded command stays the argv the user gave.
   const invocation = commandInvocation(bin, rest);
+  // The check command runs in the bound source tree, so Git inside it must resolve that
+  // tree from cwd alone: inherited GIT_DIR/GIT_WORK_TREE would let a clean native checkout
+  // certify a dirty bound worktree (reviewer probe, wp4 round 2).
   const run = spawnSync(invocation.file, invocation.args, {
     cwd: sourceCwd,
     stdio: "inherit",
     shell: false,
     ...invocation.options,
+    env: gitEnv(),
   });
   let after;
   try { after = captureSessionSourceIdentity(args.cwd, session, capture); }

--- a/plugins/codexclaw/components/pabcd-state/src/receipt-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/receipt-cli.ts
@@ -16,7 +16,9 @@ import { commandInvocation } from "./win-exec.ts";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { readState } from "./state.ts";
-import { captureSourceIdentity, compareSource } from "./source-identity.ts";
+import { compareSource } from "./source-identity.ts";
+import { resolveSessionSource } from "./session-source.ts";
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
 import { STATE_DIR, sanitizeKey } from "./state.ts";
 
 export interface ReceiptCliArgs {
@@ -113,11 +115,15 @@ export function runReceiptCli(args: ReceiptCliArgs): ReceiptCliResult {
   // Clear first: a stale success must not survive a failing re-run.
   rmSync(path, { force: true });
 
+  let sourceCwd: string;
+  try { sourceCwd = resolveSessionSource(args.cwd, session); }
+  catch (err) { return { code: 1, output: `receipt test: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}` }; }
+
   const capture = {
     excludeCodexclawArtifacts: true,
     ...(args.generated && args.generated.length > 0 ? { generatedPaths: args.generated } : {}),
   };
-  const before = captureSourceIdentity(args.cwd, capture);
+  const before = captureSessionSourceIdentity(args.cwd, session, capture);
   const [bin, ...rest] = args.command;
   // Issue #40: `npm` is the command people actually pass here, and a bare
   // shell-less spawn of it cannot work on Windows - the name alone skips PATHEXT
@@ -126,12 +132,14 @@ export function runReceiptCli(args: ReceiptCliArgs): ReceiptCliResult {
   // shell:false still holds and the recorded command stays the argv the user gave.
   const invocation = commandInvocation(bin, rest);
   const run = spawnSync(invocation.file, invocation.args, {
-    cwd: args.cwd,
+    cwd: sourceCwd,
     stdio: "inherit",
     shell: false,
     ...invocation.options,
   });
-  const after = captureSourceIdentity(args.cwd, capture);
+  let after;
+  try { after = captureSessionSourceIdentity(args.cwd, session, capture); }
+  catch (err) { return { code: 1, output: `receipt test: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}; no receipt written` }; }
 
   if (run.error || typeof run.status !== "number") {
     return { output: `receipt test: the command did not run to completion (${run.error?.message ?? "terminated by signal"}); no receipt written`, code: 1 };

--- a/plugins/codexclaw/components/pabcd-state/src/session-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/session-cli.ts
@@ -1,5 +1,7 @@
 import { closeSync, constants, fstatSync, lstatSync, openSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { bindSessionSource, resolveSessionSource } from "./session-source.ts";
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
 import { resolveNativeSession } from "./session-binding.ts";
 import { ALL_PHASES, ensureState, SESSIONS_SUBDIR, STATE_DIR, type Phase } from "./state.ts";
 
@@ -64,8 +66,12 @@ export function runSessionCli(argv: string[], cwd: string, env: NodeJS.ProcessEn
     output: json ? JSON.stringify({ ok: false, error, hooksVerified: false }) : `${error}\nhooksVerified: false`,
   });
   const [command, ...flags] = argv;
-  if ((command !== "current" && command !== "bind") || flags.length > 1 || (flags.length === 1 && flags[0] !== "--json")) {
-    return fail("Usage: cxc session current [--json] | cxc session bind [--json]");
+  const sourceCommand = command === "source";
+  const validFlags = sourceCommand
+    ? (flags.length === 1 || (flags.length === 2 && flags[1] === "--json")) && !flags[0].startsWith("--")
+    : flags.length === 0 || (flags.length === 1 && flags[0] === "--json");
+  if (!["current", "bind", "source"].includes(command) || !validFlags) {
+    return fail("Usage: cxc session current [--json] | cxc session bind [--json] | cxc session source <absolute-worktree> [--json]");
   }
   const identity = resolveNativeSession(cwd, env);
   if (!identity.ok) return fail(identity.error);
@@ -84,10 +90,21 @@ export function runSessionCli(argv: string[], cwd: string, env: NodeJS.ProcessEn
     if (!state.ok) return fail(state.error);
     if (!state.stateExists) return fail("Session state disappeared during bind. Retry after the concurrent operation finishes.");
   }
+  let sourceCwd: string;
+  let sourceIdentity;
+  try {
+    if (sourceCommand && !state.stateExists) return fail("Bind session state before binding a source worktree.");
+    sourceCwd = sourceCommand
+      ? bindSessionSource(identity.cwd, identity.sessionId, flags[0])
+      : resolveSessionSource(identity.cwd, identity.sessionId);
+    if (sourceCwd !== identity.cwd) sourceIdentity = captureSessionSourceIdentity(identity.cwd, identity.sessionId);
+  } catch (err) { return fail(`SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}`); }
   const output = {
     ok: true,
     sessionId: identity.sessionId,
     cwd: identity.cwd,
+    sourceCwd,
+    ...(sourceIdentity ? { sourceIdentity } : {}),
     source: "CODEX_THREAD_ID",
     dbPath: identity.dbPath,
     statePath: join(identity.cwd, STATE_DIR, SESSIONS_SUBDIR, `${identity.sessionId}.json`),

--- a/plugins/codexclaw/components/pabcd-state/src/session-source-identity.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/session-source-identity.ts
@@ -1,0 +1,9 @@
+/** Session state/evidence stay native; only source capture follows the worktree. */
+import { resolveSessionSource } from "./session-source.ts";
+import { captureSourceIdentity, type CaptureOptions, type SourceIdentity } from "./source-identity.ts";
+
+export function captureSessionSourceIdentity(cwd: string, sessionId: string, options: CaptureOptions = {}): SourceIdentity {
+  const sourceCwd = resolveSessionSource(cwd, sessionId);
+  const identity = captureSourceIdentity(sourceCwd, sourceCwd === cwd ? options : { excludeCodexclawArtifacts: true, ...options });
+  return sourceCwd === cwd ? identity : { ...identity, sourceRoot: sourceCwd };
+}

--- a/plugins/codexclaw/components/pabcd-state/src/session-source.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/session-source.ts
@@ -1,0 +1,118 @@
+/** Immutable per-session source binding; native state/identity never moves. */
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { closeSync, constants, fstatSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { isCanonicalSessionId, readState } from "./state.ts";
+
+interface SourceBinding {
+  version: 1;
+  ownerSessionId: string;
+  nativeCwd: string;
+  sourceRoot: string;
+  commonDir: string;
+  gitDir: string;
+}
+
+function gitIdentity(cwd: string): { root: string; commonDir: string; gitDir: string } {
+  const env = { ...process.env };
+  for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) delete env[name];
+  const git = (...args: string[]) => execFileSync("git", args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  try {
+    return {
+      root: realpathSync(git("rev-parse", "--show-toplevel")),
+      commonDir: realpathSync(git("rev-parse", "--path-format=absolute", "--git-common-dir")),
+      gitDir: realpathSync(git("rev-parse", "--absolute-git-dir")),
+    };
+  } catch { throw new Error("Cannot resolve source Git worktree identity."); }
+}
+
+function bindingPath(cwd: string, sessionId: string): string {
+  if (!isCanonicalSessionId(sessionId)) throw new Error("Invalid source-binding session ID.");
+  for (const path of [join(cwd, ".codexclaw"), join(cwd, ".codexclaw", "sources")]) {
+    try {
+      const stat = lstatSync(path);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("Source-binding directories must be real directories.");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+  return join(cwd, ".codexclaw", "sources", `${sessionId}.json`);
+}
+
+function readBinding(cwd: string, sessionId: string): SourceBinding | null {
+  const path = bindingPath(cwd, sessionId);
+  let fd: number;
+  try {
+    const stat = lstatSync(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error("Source binding must be a regular file.");
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  let raw: unknown;
+  try {
+    if (!fstatSync(fd).isFile()) throw new Error("Source binding must be a regular file.");
+    raw = JSON.parse(readFileSync(fd, "utf8"));
+  } catch { throw new Error("Source binding is unreadable or corrupt; existing bytes were preserved."); }
+  finally { closeSync(fd); }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("Invalid source binding.");
+  const b = raw as Record<string, unknown>;
+  if (b.version !== 1 || b.ownerSessionId !== sessionId || b.nativeCwd !== realpathSync(cwd)
+      || ![b.sourceRoot, b.commonDir, b.gitDir].every(p => typeof p === "string" && isAbsolute(p))) {
+    throw new Error("Source binding has invalid identity or paths.");
+  }
+  return b as unknown as SourceBinding;
+}
+
+/** No binding keeps legacy behavior; a broken binding never falls back to cwd. */
+export function resolveSessionSource(cwd: string, sessionId: string): string {
+  const binding = readBinding(cwd, sessionId);
+  const pinned = readState(cwd, sessionId).boundSourceRoot;
+  if (!binding) {
+    if (pinned) throw new Error("Source binding is missing for the pinned worktree; restore the same binding before continuing.");
+    return cwd;
+  }
+  if (pinned && binding.sourceRoot !== pinned) throw new Error("Source binding differs from the session's pinned worktree.");
+  const native = gitIdentity(cwd);
+  const source = gitIdentity(binding.sourceRoot);
+  if (source.root !== binding.sourceRoot || source.commonDir !== binding.commonDir
+      || source.gitDir !== binding.gitDir || native.commonDir !== binding.commonDir) {
+    throw new Error("Bound source worktree moved or its repository identity changed.");
+  }
+  return binding.sourceRoot;
+}
+
+/** Caller must corroborate native identity and inspect the existing state first. */
+export function bindSessionSource(cwd: string, sessionId: string, target: string): string {
+  if (!isAbsolute(target)) throw new Error("Source worktree path must be absolute.");
+  const nativeCwd = realpathSync(cwd);
+  const sourceRoot = realpathSync(target);
+  const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
+  if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
+    throw new Error("Source must be a linked worktree root in the native session's repository.");
+  }
+  const previous = readBinding(cwd, sessionId);
+  if (previous) {
+    if (resolveSessionSource(cwd, sessionId) !== sourceRoot) throw new Error("Source binding is immutable; use a new session for a different worktree.");
+    return sourceRoot;
+  }
+  const state = readState(cwd, sessionId);
+  if (state.boundSourceRoot && state.boundSourceRoot !== sourceRoot) throw new Error("Cannot replace the session's pinned source worktree.");
+  if (!state.boundSourceRoot && !["IDLE", "I", "P", "A"].includes(state.phase)) {
+    throw new Error("Bind the source before B. Preserve the old baseline and re-plan before binding.");
+  }
+  const binding: SourceBinding = { version: 1, ownerSessionId: sessionId, nativeCwd, sourceRoot, commonDir: source.commonDir, gitDir: source.gitDir };
+  const path = bindingPath(cwd, sessionId);
+  mkdirSync(join(cwd, ".codexclaw", "sources"), { recursive: true });
+  bindingPath(cwd, sessionId);
+  const tmp = `${path}.${randomUUID()}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(binding, null, 2)}\n`, { flag: "wx", mode: 0o600 });
+  try {
+    try { linkSync(tmp, path); }
+    catch (err) { if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err; }
+  } finally { unlinkSync(tmp); }
+  if (resolveSessionSource(cwd, sessionId) !== sourceRoot) throw new Error("Another source binding won publication; existing binding preserved.");
+  return sourceRoot;
+}

--- a/plugins/codexclaw/components/pabcd-state/src/session-source.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/session-source.ts
@@ -14,15 +14,25 @@ interface SourceBinding {
   gitDir: string;
 }
 
+/**
+ * Canonical absolute path. `realpathSync.native` expands Windows 8.3 short names
+ * (`RUNNER~1`) that the JS implementation leaves intact; Git always reports the long
+ * form, so comparing a short-name cwd against `rev-parse` output would refuse a
+ * valid worktree (observed on windows-latest CI where TEMP is a short path).
+ */
+function canonical(path: string): string {
+  return realpathSync.native(path);
+}
+
 function gitIdentity(cwd: string): { root: string; commonDir: string; gitDir: string } {
   const env = { ...process.env };
   for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) delete env[name];
   const git = (...args: string[]) => execFileSync("git", args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
   try {
     return {
-      root: realpathSync(git("rev-parse", "--show-toplevel")),
-      commonDir: realpathSync(git("rev-parse", "--path-format=absolute", "--git-common-dir")),
-      gitDir: realpathSync(git("rev-parse", "--absolute-git-dir")),
+      root: canonical(git("rev-parse", "--show-toplevel")),
+      commonDir: canonical(git("rev-parse", "--path-format=absolute", "--git-common-dir")),
+      gitDir: canonical(git("rev-parse", "--absolute-git-dir")),
     };
   } catch { throw new Error("Cannot resolve source Git worktree identity."); }
 }
@@ -59,7 +69,7 @@ function readBinding(cwd: string, sessionId: string): SourceBinding | null {
   finally { closeSync(fd); }
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("Invalid source binding.");
   const b = raw as Record<string, unknown>;
-  if (b.version !== 1 || b.ownerSessionId !== sessionId || b.nativeCwd !== realpathSync(cwd)
+  if (b.version !== 1 || b.ownerSessionId !== sessionId || b.nativeCwd !== canonical(cwd)
       || ![b.sourceRoot, b.commonDir, b.gitDir].every(p => typeof p === "string" && isAbsolute(p))) {
     throw new Error("Source binding has invalid identity or paths.");
   }
@@ -87,8 +97,8 @@ export function resolveSessionSource(cwd: string, sessionId: string): string {
 /** Caller must corroborate native identity and inspect the existing state first. */
 export function bindSessionSource(cwd: string, sessionId: string, target: string): string {
   if (!isAbsolute(target)) throw new Error("Source worktree path must be absolute.");
-  const nativeCwd = realpathSync(cwd);
-  const sourceRoot = realpathSync(target);
+  const nativeCwd = canonical(cwd);
+  const sourceRoot = canonical(target);
   const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
   if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
     throw new Error("Source must be a linked worktree root in the native session's repository.");

--- a/plugins/codexclaw/components/pabcd-state/src/source-identity.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/source-identity.ts
@@ -60,8 +60,8 @@ interface StatusRecord {
  */
 const GIT_ROUTING_VARS = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"];
 
-function gitEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
+export function gitEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...base };
   for (const name of GIT_ROUTING_VARS) delete env[name];
   return env;
 }

--- a/plugins/codexclaw/components/pabcd-state/src/source-identity.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/source-identity.ts
@@ -52,8 +52,22 @@ interface StatusRecord {
   origPath?: string;
 }
 
+/**
+ * Git must resolve the repository from `cwd` alone. Inherited GIT_DIR / GIT_WORK_TREE
+ * (and friends) would silently redirect status/rev-parse to another tree, so a receipt
+ * captured "for" a bound source worktree could describe the native checkout instead.
+ * Same sanitization as session-source.ts.
+ */
+const GIT_ROUTING_VARS = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES"];
+
+function gitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const name of GIT_ROUTING_VARS) delete env[name];
+  return env;
+}
+
 function git(cwd: string, args: string[]): Buffer {
-  return execFileSync("git", args, { cwd, maxBuffer: 64 * 1024 * 1024 });
+  return execFileSync("git", args, { cwd, env: gitEnv(), maxBuffer: 64 * 1024 * 1024 });
 }
 
 /**

--- a/plugins/codexclaw/components/pabcd-state/src/source-identity.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/source-identity.ts
@@ -21,6 +21,8 @@ export interface SourceIdentity {
   /** hash of every non-clean entry; absent on a clean tree. */
   treeHash?: string;
   capturedAt: string;
+  /** Canonical worktree root for an explicitly bound session; absent on legacy captures. */
+  sourceRoot?: string;
 }
 
 /**
@@ -195,6 +197,9 @@ export function captureSourceIdentity(cwd: string, options: CaptureOptions = {})
 export function compareSource(a: SourceIdentity, b: SourceIdentity): SourceComparison {
   if (a.kind === "unavailable" || b.kind === "unavailable") {
     return { kind: "unavailable", reason: "git could not resolve the source identity on at least one side" };
+  }
+  if (a.sourceRoot !== b.sourceRoot) {
+    return { kind: "different", detail: "source root changed or binding is missing" };
   }
   if (a.commitSha !== b.commitSha) {
     return { kind: "different", detail: `commit ${a.commitSha.slice(0, 7)} -> ${b.commitSha.slice(0, 7)}` };

--- a/plugins/codexclaw/components/pabcd-state/src/source-receipt.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/source-receipt.ts
@@ -74,6 +74,10 @@ function parseIdentity(raw: unknown): SourceIdentity | null {
     capturedAt: typeof s.capturedAt === "string" ? s.capturedAt : new Date(0).toISOString(),
   };
   if (typeof s.treeHash === "string") id.treeHash = s.treeHash;
+  if (s.sourceRoot !== undefined) {
+    if (typeof s.sourceRoot !== "string" || !isAbsolute(s.sourceRoot)) return null;
+    id.sourceRoot = s.sourceRoot;
+  }
   return id;
 }
 

--- a/plugins/codexclaw/components/pabcd-state/src/state.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/state.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, linkSync, rmSync, statSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { renameWithRetry } from "./atomic-write.ts";
 import { type InterviewTracker, reconstructInterview, normalizeInterview, isInterviewReady } from "./interview.ts";
 import type { SourceIdentity } from "./source-identity.ts";
@@ -162,6 +162,8 @@ export interface State {
    * other edge has a question to ask of it.
    */
   phaseEntrySource: SourceIdentity | null;
+  /** Source root pinned at B entry; retained so deleting a binding cannot switch Check to native. */
+  boundSourceRoot?: string;
   /**
    * REVIEW-BINDING-01 (060): the plan unit P>A validated for this cycle, stored
    * relative to cwd, plus a nonce minted on the same edge.
@@ -259,6 +261,10 @@ function reconstructSourceIdentity(raw: unknown): SourceIdentity | null {
     capturedAt: o.capturedAt,
   };
   if (typeof o.treeHash === "string") id.treeHash = o.treeHash;
+  if (o.sourceRoot !== undefined) {
+    if (typeof o.sourceRoot !== "string" || !isAbsolute(o.sourceRoot)) return null;
+    id.sourceRoot = o.sourceRoot;
+  }
   return id;
 }
 
@@ -550,6 +556,7 @@ export function readStateStrict(cwd: string, sessionId: string): { state: State;
       // found on any other phase is stale by definition and reading it back would
       // keep the invariant true only by accident.
       phaseEntrySource: parsed.phase === "B" ? reconstructSourceIdentity(parsed.phaseEntrySource) : null,
+      ...(typeof parsed.boundSourceRoot === "string" && isAbsolute(parsed.boundSourceRoot) ? { boundSourceRoot: parsed.boundSourceRoot } : {}),
       // 060: only A can hold a plan binding — minted at P>A, consumed at A>B.
       planUnit: parsed.phase === "A" && typeof parsed.planUnit === "string" && parsed.planUnit.length > 0 ? parsed.planUnit : null,
       planEpoch: parsed.phase === "A" && typeof parsed.planEpoch === "string" && parsed.planEpoch.length > 0 ? parsed.planEpoch : null,

--- a/plugins/codexclaw/components/pabcd-state/test/source-identity.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/source-identity.test.ts
@@ -297,4 +297,3 @@ test("capture ignores inherited GIT_DIR/GIT_WORK_TREE and describes cwd's own tr
     rmSync(decoy, { recursive: true, force: true });
   }
 });
-

--- a/plugins/codexclaw/components/pabcd-state/test/source-identity.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/source-identity.test.ts
@@ -270,3 +270,31 @@ test("bound identities do not equate different worktrees with identical commits"
   assert.equal(compareSource(a, identity).kind, "different");
   assert.equal(compareSource(a, { ...a }).kind, "same");
 });
+
+test("capture ignores inherited GIT_DIR/GIT_WORK_TREE and describes cwd's own tree", () => {
+  // Reviewer-found blocker: a receipt captured "for" a bound worktree must never be
+  // computed from another repository that the environment happens to route Git to.
+  const target = repo();
+  const decoy = repo();
+  writeFileSync(join(target, "only-in-target"), "x");
+  const saved = { GIT_DIR: process.env.GIT_DIR, GIT_WORK_TREE: process.env.GIT_WORK_TREE };
+  process.env.GIT_DIR = join(decoy, ".git");
+  process.env.GIT_WORK_TREE = decoy;
+  try {
+    const id = captureSourceIdentity(target);
+    assert.equal(id.kind, "resolved");
+    if (id.kind !== "resolved") throw new Error("unreachable");
+    assert.equal(id.dirty, true, "target's untracked file must be seen");
+    // The decoy is clean, so a capture routed there by the environment would read clean.
+    const decoyId = captureSourceIdentity(decoy);
+    assert.equal(decoyId.kind, "resolved");
+    if (decoyId.kind !== "resolved") throw new Error("unreachable");
+    assert.equal(decoyId.dirty, false);
+    assert.notEqual(id.treeHash, decoyId.treeHash, "must not have described the decoy repo");
+  } finally {
+    for (const [k, v] of Object.entries(saved)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+    rmSync(target, { recursive: true, force: true });
+    rmSync(decoy, { recursive: true, force: true });
+  }
+});
+

--- a/plugins/codexclaw/components/pabcd-state/test/source-identity.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/source-identity.test.ts
@@ -262,3 +262,11 @@ test("T21: MD and AD statuses are recorded through the fallback rule", () => {
   assert.match(status, /AD added\.ts/);
   assert.equal(compareSource(before, captureSourceIdentity(root)).kind, "different");
 });
+
+test("bound identities do not equate different worktrees with identical commits", () => {
+  const identity = { kind: "resolved" as const, commitSha: "same", dirty: false, capturedAt: "2026-09-07" };
+  const a = { ...identity, sourceRoot: "/worktree-a" };
+  assert.equal(compareSource(a, { ...identity, sourceRoot: "/worktree-b" }).kind, "different");
+  assert.equal(compareSource(a, identity).kind, "different");
+  assert.equal(compareSource(a, { ...a }).kind, "same");
+});

--- a/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
@@ -1,0 +1,257 @@
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { DatabaseSync } from "node:sqlite";
+import { runSessionCli } from "../src/session-cli.ts";
+import { defaultState, writeState, readState } from "../src/state.ts";
+import { runOrchestrateCli, parseOrchestrateCliArgs } from "../src/orchestrate-cli.ts";
+import { runReceiptCli } from "../src/receipt-cli.ts";
+import { validateCheckReceipt } from "../src/check-gate.ts";
+import { buildGoalplan, writeGoalplan } from "../src/goalplan.ts";
+import { runGoalplanCli } from "../src/goalplan-cli.ts";
+import { captureSessionSourceIdentity } from "../src/session-source-identity.ts";
+import { checkFinalGatePrereqs } from "../../subagent-config/src/final-gate-guard.ts";
+import { handleUserPromptSubmit } from "../src/hook.ts";
+
+const id = "019a0000-0000-7000-8000-000000000123";
+function fixture(t: TestContext) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "cxc-source-flow-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const cwd = join(root, "native"), source = join(root, "source"), home = join(root, "home");
+  mkdirSync(cwd); mkdirSync(home);
+  const git = (...args: string[]) => execFileSync("git", args, { cwd, stdio: "pipe" });
+  git("init", "-q"); git("config", "user.name", "test"); git("config", "user.email", "test@example.invalid");
+  writeFileSync(join(cwd, "seed"), "seed"); git("add", "."); git("commit", "-qm", "seed");
+  git("worktree", "add", "-qb", "work", source);
+  const db = new DatabaseSync(join(home, "state_5.sqlite"));
+  db.exec("CREATE TABLE threads (id TEXT, cwd TEXT, archived INTEGER, source TEXT)");
+  db.prepare("INSERT INTO threads VALUES (?, ?, 0, 'cli')").run(id, cwd); db.close();
+  const env = { CODEX_THREAD_ID: id, CODEX_HOME: home };
+  writeState(cwd, { ...defaultState(id), phase: "A" });
+  return { cwd, source, env };
+}
+function edge(cwd: string, verb: string, from: string) {
+  const att = { from, to: verb, did: "integration fixture work", ...(verb === "B" ? { auditOutput: "VERDICT: PASS", auditVerdict: "pass" } : {}) };
+  const args = parseOrchestrateCliArgs([verb, "--session", id, "--attest", JSON.stringify(att)], cwd);
+  assert.ok(!("error" in args));
+  return runOrchestrateCli(args);
+}
+function bind(f: ReturnType<typeof fixture>) {
+  const r = runSessionCli(["source", f.source, "--json"], f.cwd, f.env);
+  assert.equal(r.code, 0, r.output);
+}
+
+test("worktree change advances B and Check runs there while receipts stay native", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  writeFileSync(join(f.source, "implemented"), "yes");
+  const c = edge(f.cwd, "C", "B"); assert.equal(c.code, 0, c.output);
+  const r = runReceiptCli({ verb: "test", cwd: f.cwd, session: id, command: [process.execPath, "-e", `require('node:assert/strict').equal(process.cwd(), ${JSON.stringify(f.source)})`] });
+  assert.equal(r.code, 0, r.output);
+  assert.ok(r.output.startsWith(join(f.cwd, ".codexclaw", "evidence")));
+  assert.equal(validateCheckReceipt(readState(f.cwd, id), id, r.output, f.cwd).ok, true);
+  writeFileSync(join(f.source, "implemented"), "changed after check");
+  assert.equal(validateCheckReceipt(readState(f.cwd, id), id, r.output, f.cwd).ok, false);
+});
+
+test("native-only changes cannot satisfy a bound B baseline", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  writeFileSync(join(f.cwd, "unrelated"), "another task");
+  const r = edge(f.cwd, "C", "B"); assert.equal(r.code, 1, r.output);
+  assert.match(r.output, /SOURCE-DELTA-01/);
+});
+
+test("chat phase path observes the same bound source", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  writeFileSync(join(f.source, "implemented"), "yes");
+  const out = handleUserPromptSubmit({ hook_event_name: "UserPromptSubmit", cwd: f.cwd, session_id: id, prompt: "orchestrate c", transcript_path: null, turn_id: "worktree-flow" });
+  assert.equal(readState(f.cwd, id).phase, "C", out);
+});
+
+test("a removed source refuses progression and preserves the baseline", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  const before = readFileSync(join(f.cwd, ".codexclaw", "sessions", `${id}.json`), "utf8");
+  rmSync(f.source, { recursive: true });
+  const r = edge(f.cwd, "C", "B"); assert.equal(r.code, 1);
+  assert.equal(readFileSync(join(f.cwd, ".codexclaw", "sessions", `${id}.json`), "utf8"), before);
+});
+
+test("reproduction control: unbound native cwd misses real linked-worktree implementation", t => {
+  const f = fixture(t);
+  const current = runSessionCli(["current", "--json"], f.cwd, f.env);
+  assert.equal(current.code, 0, current.output);
+  assert.equal(JSON.parse(current.output).cwd, f.cwd);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  writeFileSync(join(f.source, "implemented"), "yes");
+  const r = edge(f.cwd, "C", "B");
+  assert.equal(r.code, 1); assert.match(r.output, /SOURCE-DELTA-01/);
+});
+
+test("Check rejects receipt from a different root even with the same hash", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  writeFileSync(join(f.source, "implemented"), "yes");
+  assert.equal(edge(f.cwd, "C", "B").code, 0);
+  const r = runReceiptCli({ verb: "test", cwd: f.cwd, session: id, command: [process.execPath, "-e", "process.exitCode=0"] });
+  assert.equal(r.code, 0, r.output);
+  const receipt = JSON.parse(readFileSync(r.output, "utf8"));
+  assert.equal(receipt.sourceIdentity.sourceRoot, f.source);
+  receipt.sourceIdentity.sourceRoot = f.cwd;
+  writeFileSync(r.output, JSON.stringify(receipt));
+  assert.equal(validateCheckReceipt(readState(f.cwd, id), id, r.output, f.cwd).ok, false);
+});
+
+test("bound command rewrites cannot produce a passing receipt", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  writeFileSync(join(f.source, "implemented"), "yes");
+  assert.equal(edge(f.cwd, "C", "B").code, 0);
+  const r = runReceiptCli({ verb: "test", cwd: f.cwd, session: id,
+    command: [process.execPath, "-e", "require('node:fs').writeFileSync('implemented','rewritten')"] });
+  assert.equal(r.code, 1, r.output);
+  assert.match(r.output, /changed the source/);
+});
+
+test("removing the binding is not implementation in CLI or chat", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  rmSync(join(f.cwd, ".codexclaw", "sources", `${id}.json`));
+  writeFileSync(join(f.cwd, "unrelated"), "not source work");
+  const r = edge(f.cwd, "C", "B"); assert.equal(r.code, 1);
+  assert.match(r.output, /SOURCE-ROOT/); assert.doesNotMatch(r.output, /SOURCE-DELTA-01/);
+  const out = handleUserPromptSubmit({ hook_event_name: "UserPromptSubmit", cwd: f.cwd, session_id: id, prompt: "orchestrate c", transcript_path: null, turn_id: "deleted-binding" });
+  assert.match(out, /SOURCE-ROOT/);
+  assert.equal(readState(f.cwd, id).phase, "B");
+});
+
+test("source command preserves native identity and refuses late or foreign binding", t => {
+  const f = fixture(t);
+  const late = edge(f.cwd, "B", "A"); assert.equal(late.code, 0);
+  assert.equal(runSessionCli(["source", f.source], f.cwd, f.env).code, 1);
+  writeState(f.cwd, { ...defaultState(id), phase: "A" });
+  const before = readFileSync(join(f.cwd, ".codexclaw", "sessions", `${id}.json`), "utf8");
+  bind(f);
+  assert.equal(readFileSync(join(f.cwd, ".codexclaw", "sessions", `${id}.json`), "utf8"), before);
+  const current = JSON.parse(runSessionCli(["current", "--json"], f.cwd, f.env).output);
+  assert.equal(current.cwd, f.cwd); assert.equal(current.sourceCwd, f.source);
+  assert.equal(current.sourceIdentity.sourceRoot, f.source);
+  assert.equal(runSessionCli(["source", f.source], f.cwd, { ...f.env, CODEX_THREAD_ID: "019a0000-0000-7000-8000-000000000999" }).code, 1);
+  assert.equal(runSessionCli(["source", f.source], f.source, f.env).code, 1);
+});
+
+
+test("final reviewer uses the bound worktree and rejects stale commits", t => {
+  const f = fixture(t); bind(f);
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: f.source, stdio: "pipe" });
+  writeFileSync(join(f.source, "implemented"), "yes"); git("add", "."); git("commit", "-qm", "work");
+  const identity = captureSessionSourceIdentity(f.cwd, id);
+  writeState(f.cwd, { ...readState(f.cwd, id), slug: "review" });
+  const receipt = join(f.cwd, ".codexclaw", "evidence", "test.json");
+  mkdirSync(join(receipt, ".."), { recursive: true });
+  writeFileSync(receipt, JSON.stringify({ kind: "test", sourceIdentity: identity }));
+  const planPath = join(f.cwd, ".codexclaw", "goalplans", "review", "goalplan.json");
+  mkdirSync(join(planPath, ".."), { recursive: true });
+  writeFileSync(planPath, JSON.stringify({ criteria: [], finalGate: { testReceiptPath: receipt } }));
+  assert.equal(checkFinalGatePrereqs("[CXC-FINAL-GATE] review", id, f.cwd).ok, true);
+  writeFileSync(join(f.source, "implemented"), "dirty");
+  writeFileSync(receipt, JSON.stringify({ kind: "test", sourceIdentity: captureSessionSourceIdentity(f.cwd, id) }));
+  assert.equal(checkFinalGatePrereqs("[CXC-FINAL-GATE] review", id, f.cwd).ok, true);
+  writeFileSync(join(f.source, "implemented"), "other");
+  assert.equal(checkFinalGatePrereqs("[CXC-FINAL-GATE] review", id, f.cwd).ok, false);
+  writeFileSync(join(f.source, "implemented"), "new"); git("add", "."); git("commit", "-qm", "new");
+  assert.equal(checkFinalGatePrereqs("[CXC-FINAL-GATE] review", id, f.cwd).ok, false);
+});
+
+test("only same-repository worktree roots can be bound and binding is immutable", t => {
+  const f = fixture(t);
+  const foreign = join(f.cwd, "..", "foreign"); mkdirSync(foreign);
+  execFileSync("git", ["init", "-q"], { cwd: foreign });
+  for (const bad of [foreign, f.cwd, "relative", join(f.source, "missing")]) {
+    assert.equal(runSessionCli(["source", bad], f.cwd, f.env).code, 1, bad);
+  }
+  const child = join(f.source, "child"); mkdirSync(child);
+  assert.equal(runSessionCli(["source", child], f.cwd, f.env).code, 1);
+  bind(f);
+  const other = join(f.cwd, "..", "other");
+  execFileSync("git", ["worktree", "add", "-qb", "other", other], { cwd: f.cwd, stdio: "pipe" });
+  assert.equal(runSessionCli(["source", other], f.cwd, f.env).code, 1);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  assert.equal(runSessionCli(["source", f.source], f.cwd, f.env).code, 0);
+});
+
+for (const corruption of ["json", "owner", "symlink"]) {
+  test(`damaged ${corruption} binding fails closed`, t => {
+    const f = fixture(t); bind(f);
+    assert.equal(edge(f.cwd, "B", "A").code, 0);
+    const path = join(f.cwd, ".codexclaw", "sources", `${id}.json`);
+    if (corruption === "json") writeFileSync(path, "broken{");
+    if (corruption === "owner") {
+      const b = JSON.parse(readFileSync(path, "utf8")); b.ownerSessionId = "foreign"; writeFileSync(path, JSON.stringify(b));
+    }
+    if (corruption === "symlink") {
+      const external = join(f.cwd, "..", "binding.json"); writeFileSync(external, readFileSync(path));
+      rmSync(path); symlinkSync(external, path);
+    }
+    const r = edge(f.cwd, "C", "B"); assert.equal(r.code, 1); assert.match(r.output, /SOURCE-ROOT/);
+    assert.equal(readState(f.cwd, id).phase, "B");
+  });
+}
+
+test("deleting a binding during Check cannot certify the native tree", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  writeFileSync(join(f.source, "implemented"), "yes");
+  assert.equal(edge(f.cwd, "C", "B").code, 0);
+  rmSync(join(f.cwd, ".codexclaw", "sources", `${id}.json`));
+  const r = runReceiptCli({ verb: "test", cwd: f.cwd, session: id, command: [process.execPath, "-e", "process.exitCode=0"] });
+  assert.equal(r.code, 1, r.output);
+  assert.match(r.output, /SOURCE-ROOT/);
+  const beforeRestore = readFileSync(join(f.cwd, ".codexclaw", "sessions", `${id}.json`), "utf8");
+  bind(f);
+  assert.equal(readFileSync(join(f.cwd, ".codexclaw", "sessions", `${id}.json`), "utf8"), beforeRestore);
+  const restored = runReceiptCli({ verb: "test", cwd: f.cwd, session: id,
+    command: [process.execPath, "-e", `require('node:assert/strict').equal(process.cwd(), ${JSON.stringify(f.source)})`] });
+  assert.equal(restored.code, 0, restored.output);
+});
+
+
+test("shipped CLI binds and checks a worktree without relocating native state", t => {
+  const f = fixture(t);
+  const cli = fileURLToPath(new URL("../../../bin/cxc.mjs", import.meta.url));
+  const run = (...args: string[]) => execFileSync(process.execPath, [cli, ...args], {
+    cwd: f.cwd, env: { ...process.env, ...f.env, CODEX_SQLITE_HOME: f.env.CODEX_HOME }, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  const bound = JSON.parse(run("session", "source", f.source, "--json"));
+  assert.equal(bound.cwd, f.cwd); assert.equal(bound.sourceCwd, f.source);
+  run("orchestrate", "B", "--session", id, "--attest", JSON.stringify({ from: "A", to: "B", did: "CLI fixture audited", auditOutput: "VERDICT: PASS", auditVerdict: "pass" }));
+  writeFileSync(join(f.source, "implementation"), "real work");
+  run("orchestrate", "C", "--session", id, "--attest", JSON.stringify({ from: "B", to: "C", did: "CLI fixture implemented" }));
+  const receipt = run("receipt", "test", "--session", id, "--", process.execPath, "-e", `require('node:assert/strict').equal(process.cwd(), ${JSON.stringify(f.source)})`);
+  assert.ok(receipt.startsWith(join(f.cwd, ".codexclaw", "evidence")));
+  assert.equal(JSON.parse(readFileSync(receipt, "utf8")).sourceIdentity.sourceRoot, f.source);
+  assert.equal(readState(f.cwd, id).phase, "C");
+});
+
+
+test("explicit loop validation rejects a lost binding even for legacy goalplans", t => {
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  const base = buildGoalplan({ objective: "completed legacy goal" });
+  const plan = { ...base, schemaVersion: 1,
+    workPhases: [{ id: "wp1", title: "done", status: "done" as const, tasks: [], criteriaIds: ["c-1"] }],
+    criteria: [{ id: "c-1", scenario: "logic", expectedEvidence: "check", capturedEvidence: "checked", status: "met" as const, surface: "logic" as const }],
+  };
+  writeGoalplan(f.cwd, plan);
+  const args = { verb: "validate" as const, cwd: f.cwd, session: id, slug: plan.slug, criteria: [] };
+  assert.equal(runGoalplanCli(args).code, 0);
+  rmSync(join(f.cwd, ".codexclaw", "sources", `${id}.json`));
+  const result = runGoalplanCli(args);
+  assert.equal(result.code, 1); assert.match(result.output, /SOURCE-ROOT/);
+});

--- a/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
@@ -256,3 +256,25 @@ test("explicit loop validation rejects a lost binding even for legacy goalplans"
   const result = runGoalplanCli(args);
   assert.equal(result.code, 1); assert.match(result.output, /SOURCE-ROOT/);
 });
+
+test("receipt command runs without inherited Git routing variables", t => {
+  // Round-2 reviewer probe: with GIT_DIR/GIT_WORK_TREE pointing at the clean native
+  // checkout, `git diff --exit-code` inside the bound (dirty) source must still see the
+  // bound tree and exit 1, so no receipt is written.
+  const f = fixture(t); bind(f);
+  assert.equal(edge(f.cwd, "B", "A").code, 0);
+  writeFileSync(join(f.source, "implemented"), "yes");
+  assert.equal(edge(f.cwd, "C", "B").code, 0);
+  writeFileSync(join(f.source, "seed"), "dirty in bound source");
+  const saved = { GIT_DIR: process.env.GIT_DIR, GIT_WORK_TREE: process.env.GIT_WORK_TREE };
+  process.env.GIT_DIR = join(f.cwd, ".git");
+  process.env.GIT_WORK_TREE = f.cwd;
+  try {
+    const r = runReceiptCli({ verb: "test", cwd: f.cwd, session: id, command: ["git", "diff", "--exit-code", "--quiet", "--", "seed"] });
+    assert.equal(r.code, 1, r.output);
+    assert.match(r.output, /exited 1; no receipt written/);
+  } finally {
+    for (const [k, v] of Object.entries(saved)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+  }
+});
+

--- a/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
@@ -19,7 +19,8 @@ import { handleUserPromptSubmit } from "../src/hook.ts";
 
 const id = "019a0000-0000-7000-8000-000000000123";
 function fixture(t: TestContext) {
-  const root = realpathSync(mkdtempSync(join(tmpdir(), "cxc-source-flow-")));
+  // realpathSync.native expands Windows 8.3 short names (RUNNER~1) the way Git reports them.
+  const root = realpathSync.native(mkdtempSync(join(tmpdir(), "cxc-source-flow-")));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const cwd = join(root, "native"), source = join(root, "source"), home = join(root, "home");
   mkdirSync(cwd); mkdirSync(home);

--- a/plugins/codexclaw/components/subagent-config/dist/final-gate-guard.js
+++ b/plugins/codexclaw/components/subagent-config/dist/final-gate-guard.js
@@ -6,20 +6,20 @@
  * against a tree nobody had tested.
  *
  * This is NOT the enforcement layer. It only fires when the packet carries the
- * [CXC-FINAL-GATE] marker, so omitting the marker skips it entirely, and every
- * broken link in the lookup chain fails open. The layer that actually refuses is
+ * [CXC-FINAL-GATE] marker, so omitting the marker skips it entirely. Missing
+ * goal metadata retains the legacy fail-open behavior; an explicit source
+ * resolution failure refuses the marked spawn. The layer that actually refuses is
  * validateGoalplan's v2 checks, which deny `update_goal complete` when the gate
  * is not approved. This one just says it earlier.
  *
- * Reads the goalplan JSON directly rather than importing pabcd-state: the build
- * compiles each component's src into its own dist and only rewrites relative
- * specifiers (build.mjs:25-27, :42), so a cross-component source import would
- * resolve to a path that does not exist in the shipped dist. The cost is a
- * second copy of schema knowledge, which is why schema drift here fails open.
+ * Reads the goalplan projection locally. Source identity is loaded from the
+ * sibling pabcd-state dist module so this guard and the enforcing final gate
+ * use identical worktree resolution and dirty-content hashing in installed payloads.
  */
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
-import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+const nodeRequire = createRequire(import.meta.url);
 
 export const FINAL_GATE_MARKER = "[CXC-FINAL-GATE]";
 
@@ -36,13 +36,15 @@ export const FINAL_GATE_MARKER = "[CXC-FINAL-GATE]";
 
 
 
+
 /**
- * Same four branches, in the same order, as compareSource in
+ * Same identity fields, in the same order, as compareSource in
  * pabcd-state/src/source-identity.ts. "unavailable" is checked first and is
  * never treated as an empty sha, so the two implementations cannot disagree.
  */
 function compareIdentity(a                    , b                    )                                       {
   if (a.kind === "unavailable" || b.kind === "unavailable") return "unavailable";
+  if (a.sourceRoot !== b.sourceRoot) return "different";
   if (a.commitSha !== b.commitSha) return "different";
   if (a.dirty !== b.dirty) return "different";
   if ((a.treeHash ?? "") !== (b.treeHash ?? "")) return "different";
@@ -74,19 +76,11 @@ function readIdentity(raw         )                            {
   if (typeof s.commitSha !== "string" || typeof s.dirty !== "boolean") return null;
   const id                     = { kind: s.kind, commitSha: s.commitSha, dirty: s.dirty };
   if (typeof s.treeHash === "string") id.treeHash = s.treeHash;
-  return id;
-}
-
-function captureCurrentIdentity(cwd        )                     {
-  // Deliberately minimal: this guard only needs to notice that the tree moved.
-  // The authoritative capture lives in pabcd-state/src/source-identity.ts.
-  try {
-    const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
-    const status = execFileSync("git", ["status", "--porcelain=v1", "-z", "--untracked-files=all"], { cwd, encoding: "utf8" });
-    return { kind: "resolved", commitSha: sha, dirty: status.length > 0 };
-  } catch {
-    return { kind: "unavailable", commitSha: "", dirty: false };
+  if (s.sourceRoot !== undefined) {
+    if (typeof s.sourceRoot !== "string" || !isAbsolute(s.sourceRoot)) return null;
+    id.sourceRoot = s.sourceRoot;
   }
+  return id;
 }
 
 
@@ -116,7 +110,7 @@ export function checkFinalGatePrereqs(
   packetText        ,
   sessionId        ,
   cwd        ,
-  captureIdentity                                      = captureCurrentIdentity,
+  captureIdentity                                      ,
 )                 {
   try {
     if (!packetText.includes(FINAL_GATE_MARKER)) return { ok: true };
@@ -143,7 +137,24 @@ export function checkFinalGatePrereqs(
 
     const missing           = [];
     const stale           = [];
-    const current = captureIdentity(cwd);
+    let current                    ;
+    try {
+      // Both src/ and dist/ sit one level below the component root. Load shipped
+      // dist explicitly: build's .ts -> .js rewrite cannot translate cross-src paths.
+      const source = nodeRequire("../../pabcd-state/dist/session-source-identity.js")
+
+       ;
+      if (captureIdentity) {
+        const binding = nodeRequire("../../pabcd-state/dist/session-source.js")
+
+         ;
+        const sourceCwd = binding.resolveSessionSource(cwd, sessionId);
+        const captured = captureIdentity(sourceCwd);
+        current = sourceCwd === cwd ? captured : { ...captured, sourceRoot: sourceCwd };
+      } else current = source.captureSessionSourceIdentity(cwd, sessionId);
+    } catch {
+      return { ok: false, reason: "[codexclaw — final gate] SOURCE-ROOT: source identity is unavailable; inspect the binding and installed modules before review." };
+    }
 
     for (const slot of slots) {
       if (typeof slot.path !== "string" || slot.path.length === 0) {

--- a/plugins/codexclaw/components/subagent-config/src/final-gate-guard.ts
+++ b/plugins/codexclaw/components/subagent-config/src/final-gate-guard.ts
@@ -6,20 +6,20 @@
  * against a tree nobody had tested.
  *
  * This is NOT the enforcement layer. It only fires when the packet carries the
- * [CXC-FINAL-GATE] marker, so omitting the marker skips it entirely, and every
- * broken link in the lookup chain fails open. The layer that actually refuses is
+ * [CXC-FINAL-GATE] marker, so omitting the marker skips it entirely. Missing
+ * goal metadata retains the legacy fail-open behavior; an explicit source
+ * resolution failure refuses the marked spawn. The layer that actually refuses is
  * validateGoalplan's v2 checks, which deny `update_goal complete` when the gate
  * is not approved. This one just says it earlier.
  *
- * Reads the goalplan JSON directly rather than importing pabcd-state: the build
- * compiles each component's src into its own dist and only rewrites relative
- * specifiers (build.mjs:25-27, :42), so a cross-component source import would
- * resolve to a path that does not exist in the shipped dist. The cost is a
- * second copy of schema knowledge, which is why schema drift here fails open.
+ * Reads the goalplan projection locally. Source identity is loaded from the
+ * sibling pabcd-state dist module so this guard and the enforcing final gate
+ * use identical worktree resolution and dirty-content hashing in installed payloads.
  */
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
-import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+const nodeRequire = createRequire(import.meta.url);
 
 export const FINAL_GATE_MARKER = "[CXC-FINAL-GATE]";
 
@@ -34,15 +34,17 @@ export interface SourceIdentityLite {
   commitSha: string;
   dirty: boolean;
   treeHash?: string;
+  sourceRoot?: string;
 }
 
 /**
- * Same four branches, in the same order, as compareSource in
+ * Same identity fields, in the same order, as compareSource in
  * pabcd-state/src/source-identity.ts. "unavailable" is checked first and is
  * never treated as an empty sha, so the two implementations cannot disagree.
  */
 function compareIdentity(a: SourceIdentityLite, b: SourceIdentityLite): "same" | "different" | "unavailable" {
   if (a.kind === "unavailable" || b.kind === "unavailable") return "unavailable";
+  if (a.sourceRoot !== b.sourceRoot) return "different";
   if (a.commitSha !== b.commitSha) return "different";
   if (a.dirty !== b.dirty) return "different";
   if ((a.treeHash ?? "") !== (b.treeHash ?? "")) return "different";
@@ -74,19 +76,11 @@ function readIdentity(raw: unknown): SourceIdentityLite | null {
   if (typeof s.commitSha !== "string" || typeof s.dirty !== "boolean") return null;
   const id: SourceIdentityLite = { kind: s.kind, commitSha: s.commitSha, dirty: s.dirty };
   if (typeof s.treeHash === "string") id.treeHash = s.treeHash;
-  return id;
-}
-
-function captureCurrentIdentity(cwd: string): SourceIdentityLite {
-  // Deliberately minimal: this guard only needs to notice that the tree moved.
-  // The authoritative capture lives in pabcd-state/src/source-identity.ts.
-  try {
-    const sha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, encoding: "utf8" }).trim();
-    const status = execFileSync("git", ["status", "--porcelain=v1", "-z", "--untracked-files=all"], { cwd, encoding: "utf8" });
-    return { kind: "resolved", commitSha: sha, dirty: status.length > 0 };
-  } catch {
-    return { kind: "unavailable", commitSha: "", dirty: false };
+  if (s.sourceRoot !== undefined) {
+    if (typeof s.sourceRoot !== "string" || !isAbsolute(s.sourceRoot)) return null;
+    id.sourceRoot = s.sourceRoot;
   }
+  return id;
 }
 
 interface ReceiptSlot {
@@ -116,7 +110,7 @@ export function checkFinalGatePrereqs(
   packetText: string,
   sessionId: string,
   cwd: string,
-  captureIdentity: (cwd: string) => SourceIdentityLite = captureCurrentIdentity,
+  captureIdentity?: (cwd: string) => SourceIdentityLite,
 ): FinalGateCheck {
   try {
     if (!packetText.includes(FINAL_GATE_MARKER)) return { ok: true };
@@ -143,7 +137,24 @@ export function checkFinalGatePrereqs(
 
     const missing: string[] = [];
     const stale: string[] = [];
-    const current = captureIdentity(cwd);
+    let current: SourceIdentityLite;
+    try {
+      // Both src/ and dist/ sit one level below the component root. Load shipped
+      // dist explicitly: build's .ts -> .js rewrite cannot translate cross-src paths.
+      const source = nodeRequire("../../pabcd-state/dist/session-source-identity.js") as {
+        captureSessionSourceIdentity(cwd: string, sessionId: string): SourceIdentityLite;
+      };
+      if (captureIdentity) {
+        const binding = nodeRequire("../../pabcd-state/dist/session-source.js") as {
+          resolveSessionSource(cwd: string, sessionId: string): string;
+        };
+        const sourceCwd = binding.resolveSessionSource(cwd, sessionId);
+        const captured = captureIdentity(sourceCwd);
+        current = sourceCwd === cwd ? captured : { ...captured, sourceRoot: sourceCwd };
+      } else current = source.captureSessionSourceIdentity(cwd, sessionId);
+    } catch {
+      return { ok: false, reason: "[codexclaw — final gate] SOURCE-ROOT: source identity is unavailable; inspect the binding and installed modules before review." };
+    }
 
     for (const slot of slots) {
       if (typeof slot.path !== "string" || slot.path.length === 0) {

--- a/plugins/codexclaw/skills/pabcd/references/phase-control.md
+++ b/plugins/codexclaw/skills/pabcd/references/phase-control.md
@@ -114,3 +114,40 @@ re-entry occurs.
 
 Execution intent and HOTL activation belong to [cxc-loop](../../loop/SKILL.md).
 This reference owns phase commands and attestations, not permission to execute.
+
+### Source worktrees
+
+A native session may keep its original cwd while implementing in a linked Git
+worktree. From the native cwd, run `cxc session source /absolute/worktree --json`
+before entering B. It verifies native identity, pins the source worktree in the
+same repository, and leaves session/goalplan/evidence storage in the native cwd.
+`cxc session current --json` reports `sourceCwd` and, for a bound worktree,
+`sourceIdentity`. This is a source snapshot, not evidence that a check ran.
+
+B entry/delta, `receipt test` execution and Check/final validation use that
+worktree. Plans and receipt paths still resolve from the native cwd; use absolute
+worktree paths for plan documents. The binding is immutable; repeating the same
+command is idempotent. B entry pins the root in session state; if its binding file
+is lost, the command can restore only that same pinned root, including during Check. A missing or changed binding cannot count as implementation.
+A linked worktree is not exclusive to a session: edits by another actor in the
+same worktree remain indistinguishable. Use a task-owned worktree.
+
+For QA verdict `sourceSnapshotAt`, reviewer-lane `sourceIdentity` and final-gate
+`sourceIdentity`, capture `session current --json` at observation time and retain
+the entire identity, including `sourceRoot`. Do not copy an old snapshot or
+reconstruct it from native HEAD. Test receipts capture automatically. Rootless
+legacy receipts remain usable for unbound sessions only. Run
+`cxc loop validate --session <id> --slug <slug>` so validation uses the same binding.
+
+An old, unbound B cycle cannot be rebound retroactively: its baseline describes the old
+source. Preserve its evidence, stop any active goal using host-supported controls,
+then use the supported return-to-I/replan path (I -> P with an explicit documented
+readiness override when requirements are already known), bind before B, review the
+plan and perform real new work before Check. Never fabricate a baseline or edit
+native SQLite/FSM bytes to make the old cycle pass. An explicit reset also starts
+a new cycle but is a separately authorized control operation.
+
+If the pinned worktree was removed, recreate it at that path or start a new
+native session for a different worktree. Reset does not retarget a source.
+Binding publication requires filesystem hard-link support; unsupported filesystems
+fail without replacing existing state or bindings.

--- a/plugins/codexclaw/skills/qa/references/visual-qa.md
+++ b/plugins/codexclaw/skills/qa/references/visual-qa.md
@@ -67,7 +67,9 @@ the screenshot.
 
 Record the source identity at capture time in `verdict.json` as
 `sourceSnapshotAt` (the `SourceIdentity` shape: `kind`, `commitSha`, `dirty`,
-`capturedAt`, and `treeHash` when dirty). If that identity no longer describes
+`capturedAt`, `treeHash` when dirty, and `sourceRoot` for a bound worktree).
+For a bound session, capture the `sourceIdentity` from `cxc session current --json`
+at observation time; keep its canonical root in every scenario and receipt. If that identity no longer describes
 the tree, the artifact does not support a PASS — re-capture rather than
 re-argue.
 

--- a/plugins/codexclaw/skills/qa/scripts/validate-evidence.mjs
+++ b/plugins/codexclaw/skills/qa/scripts/validate-evidence.mjs
@@ -9,7 +9,7 @@
 // integrity from a curl transcript would fail three surfaces that are working
 // correctly.
 import { existsSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { basename, dirname, join, resolve } from "node:path";
+import { isAbsolute, basename, dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -36,6 +36,7 @@ function identityErrors(id, label) {
   if (typeof id.dirty !== "boolean") out.push(`${label}.dirty must be a boolean`);
   if (!isRfc3339(id.capturedAt)) out.push(`${label}.capturedAt must be an RFC3339 timestamp`);
   if (id.treeHash !== undefined && typeof id.treeHash !== "string") out.push(`${label}.treeHash must be a string when present`);
+  if (id.sourceRoot !== undefined && (typeof id.sourceRoot !== "string" || !isAbsolute(id.sourceRoot))) out.push(`${label}.sourceRoot must be an absolute path when present`);
   return out;
 }
 
@@ -46,6 +47,7 @@ function identityErrors(id, label) {
  * fresh time, so comparing it would reject QA runs that never left the tree.
  */
 function sameTree(a, b) {
+  if (a.sourceRoot !== b.sourceRoot) return false;
   if (a.kind !== b.kind) return false;
   if (a.commitSha !== b.commitSha) return false;
   if (a.dirty !== b.dirty) return false;

--- a/plugins/codexclaw/test/qa-validate-evidence.test.mjs
+++ b/plugins/codexclaw/test/qa-validate-evidence.test.mjs
@@ -9,6 +9,8 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { validateEvidence } from "../skills/qa/scripts/validate-evidence.mjs";
+import { buildGoalplan, writeGoalplan, readGoalplan, validateGoalplan } from "../components/pabcd-state/src/goalplan.ts";
+import { compareSource } from "../components/pabcd-state/src/source-identity.ts";
 import { parseSourceBoundReceipt } from "../components/pabcd-state/src/source-receipt.ts";
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -293,4 +295,53 @@ test("V17: the CLI entry point prints usage without a directory", async () => {
   // which is how a genuinely broken entry point read as a code mismatch.
   assert.equal(result.exited, 2, "the entry point must run and reject a missing directory");
   assert.match(result.stderr, /usage: validate-evidence\.mjs/);
+});
+
+test("bound QA receipts retain the root and reject mixed worktrees", () => {
+  const root = workspace();
+  const sourceRoot = resolve(root, "worktree");
+  scenario(root, "a", webVerdict({ sourceSnapshotAt: identity({ sourceRoot }) }), { "shot.png": pngBytes() });
+  const receipt = validateEvidence(qaDir(root), { emitReceipt: true });
+  assert.equal(receipt.ok, true, receipt.errors.join("; "));
+  const parsed = parseSourceBoundReceipt(receipt.receiptPath, root, "qa");
+  assert.equal(parsed.sourceIdentity?.sourceRoot, sourceRoot);
+  scenario(root, "b", webVerdict({ sourceSnapshotAt: identity({ sourceRoot: resolve(root, "other") }) }), { "shot.png": pngBytes() });
+  assert.equal(validateEvidence(qaDir(root)).ok, false);
+});
+
+test("malformed QA source roots are refused", () => {
+  for (const sourceRoot of [123, "", "relative/path"]) {
+    const root = workspace();
+    scenario(root, "a", webVerdict({ sourceSnapshotAt: identity({ sourceRoot }) }), { "shot.png": pngBytes() });
+    assert.equal(validateEvidence(qaDir(root)).ok, false);
+  }
+});
+
+
+test("bound QA receipt survives final goalplan validation and root removal fails", () => {
+  const root = workspace();
+  const source = identity({ sourceRoot: resolve(root, "worktree") });
+  scenario(root, "a", webVerdict({ sourceSnapshotAt: source }), { "shot.png": pngBytes() });
+  const qa = validateEvidence(qaDir(root), { emitReceipt: true });
+  assert.equal(qa.ok, true, qa.errors.join("; "));
+  const testPath = join(root, ".codexclaw", "evidence", "test.json");
+  writeFileSync(testPath, JSON.stringify({ kind: "test", sourceIdentity: source }));
+  const base = buildGoalplan({ objective: "bound final QA" });
+  const plan = { ...base, schemaVersion: 2,
+    workPhases: [{ id: "wp1", title: "done", status: "done", tasks: [], criteriaIds: ["c-1"] }],
+    criteria: [{ id: "c-1", scenario: "visual", expectedEvidence: "capture", capturedEvidence: qa.receiptPath, status: "met", surface: "web" }],
+    finalGate: { status: "approved", reviewRoundId: "r1", sourceIdentity: source, testReceiptPath: testPath, qaReceiptPath: qa.receiptPath, verdict: "pass", qaRequired: true, updatedAt: source.capturedAt },
+    reviewRounds: [{ roundId: "r1", purpose: "final_gate", planPath: "plan.md", planSha256: "c".repeat(64), status: "approved", openedAt: source.capturedAt, lane: { launchId: "r1-x", verdict: "pass", sourceIdentity: source } }],
+  };
+  writeGoalplan(root, plan);
+  const restored = readGoalplan(root, plan.slug);
+  const context = { cwd: root, captureSourceIdentity: () => source, compareSource, readReceipt: (path, kind) => parseSourceBoundReceipt(path, root, kind) };
+  const result = validateGoalplan(restored, context);
+  assert.equal(result.ok, true, result.reasons.join("; "));
+  const bytes = JSON.parse(readFileSync(qa.receiptPath, "utf8"));
+  delete bytes.sourceIdentity.sourceRoot;
+  writeFileSync(qa.receiptPath, JSON.stringify(bytes));
+  const invalid = validateGoalplan(restored, context);
+  assert.equal(invalid.ok, false);
+  assert.match(invalid.reasons.join("; "), /QA receipt.*different source/);
 });


### PR DESCRIPTION
When a native Codex session stays in the original checkout but implementation happens in a linked worktree, CXC compares the original checkout at B→C and refuses with `SOURCE-DELTA-01`. Check commands and later source checks also use that original directory.

Add `cxc session source <absolute-worktree>` to bind a same-repository worktree without moving native identity, workflow state or evidence storage. CLI/chat delta checks, test execution, receipts, QA identities and final validation follow the bound source. A B-entry root pin prevents deleted or switched bindings from becoming false implementation evidence. Existing unbound sessions retain their behavior; old B baselines are not rewritten retroactively.

Installation CI uses the matching PR-head repository and immutable SHA for fork contributions, and the published test count is regenerated from the measured suite.

Validation:
- Full suite: 2,598 passed, 0 failed, 70 existing conditional skips (2,668 total).
- 17 integration cases, including shipped CLI subprocesses, wrong/removed roots, same-size dirty edits, Check-time binding loss and restoration.
- Installed payload: 32 files hash-verified, 36 integration/QA checks passed.
- Build, repository gate, packaging checks and Linux smoke passed. Disabling source routing in an isolated copy reproduces the original `SOURCE-DELTA-01` failure.
- Independent plan and implementation reviews passed.

Limits: scoped strict TypeScript checking reports the same seven pre-existing diagnostics as the untouched base. Non-Linux execution remains for CI. Bindings are intentionally immutable and require hard-link-capable storage; an old unbound B cycle requires a new audited cycle. The pre-existing final-review `--generated` exclusion mismatch is unchanged. No merge or release is included.

Design and evidence: `devlog/_plan/260907_worktree_source_binding/`.
