### PR TITLE
release: promote 0.2.23 visual document skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to codexclaw are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.23] - 2026-09-08
+
+### Changed
+
+- Extend `cxc-dev-diagram-viewer` to compose visual documents, HTML reports,
+  editable SVG, interactive explanations and PDF deliverables. Preserve explicit
+  formats and the current host rendering contract.
+- Add audience-specific design recipes, Korean typography, print pagination,
+  offline interaction and output verification guidance, with an original report
+  example and a dated source/license ledger.
+
 ## [0.2.22] - 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Every coding task is classified (C0-C5) before process depth is chosen. The pare
 | DevOps / infra | `dev-devops` | `dev-security` for credentials |
 | Scaffolding | `dev-scaffolding` | `dev-architecture` for boundaries |
 | Code review | `dev-code-reviewer` | `dev-security` + `dev-testing` |
-| Diagrams | `dev-diagram-viewer` | — |
+| Diagrams, visual documents, HTML/SVG reports and PDF composition | `dev-diagram-viewer` | Available document-format owner for export |
 
 Each router carries its own modular references (loaded on demand, never preloaded) and inherits the parent's verification gate, rule classes, and safety rules.
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI \u2014 status, subagent config, provider toggle, GUI launcher.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexclaw",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexclaw",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "workspaces": [
         "plugins/codexclaw/components/*",
@@ -20,7 +20,7 @@
     },
     "cli": {
       "name": "@codexclaw/cli",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "bin": {
         "codexclaw": "bin/codexclaw.mjs"
       }
@@ -1949,39 +1949,39 @@
     },
     "plugins/codexclaw/components/config-guard": {
       "name": "@codexclaw/config-guard",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     "plugins/codexclaw/components/cxc-ops": {
       "name": "@codexclaw/cxc-ops",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     "plugins/codexclaw/components/messenger-bridge": {
       "name": "@codexclaw/messenger-bridge",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     "plugins/codexclaw/components/pabcd-state": {
       "name": "@codexclaw/pabcd-state",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     "plugins/codexclaw/components/provider-bridge": {
       "name": "@codexclaw/provider-bridge",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     "plugins/codexclaw/components/recall": {
       "name": "@codexclaw/recall",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     "plugins/codexclaw/components/skill-search": {
       "name": "@codexclaw/skill-search",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     "plugins/codexclaw/components/subagent-config": {
       "name": "@codexclaw/subagent-config",
-      "version": "0.2.22"
+      "version": "0.2.23"
     },
     "plugins/codexclaw/gui": {
       "name": "@codexclaw/gui",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.22+codex.20260906224615",
+  "version": "0.2.23+codex.20260908004251",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI \u2014 doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge \u2014 cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) \u2014 subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.22+codex.20260906224615",
-    "packageVersion": "0.2.22"
+    "manifestVersion": "0.2.23+codex.20260908004251",
+    "packageVersion": "0.2.23"
   },
   "skills": [
     {
@@ -263,49 +263,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasTests": true
     }
   ]

--- a/plugins/codexclaw/skills/dev-diagram-viewer/SKILL.md
+++ b/plugins/codexclaw/skills/dev-diagram-viewer/SKILL.md
@@ -1,87 +1,134 @@
 ---
 name: cxc-dev-diagram-viewer
-description: "MUST USE when producing or displaying diagrams, charts, visualizations, SVG, mermaid, or interactive widgets in any Codex surface. Detects the runtime environment (Codex Desktop app vs CLI) and routes diagram output to the correct rendering path — native inline for supported formats, browser-based rendering for everything else. On-demand: activates by description match or explicit mention. Triggers: diagram, chart, SVG, mermaid, visualization, visualize, flowchart, sequence diagram, ER diagram, architecture diagram, Chart.js, ECharts, D3, Leaflet, map, interactive, widget, 다이어그램, 차트, 시각화, 그려줘, 플로우차트."
+description: "Create well-composed visual documents, HTML reports, SVG diagrams, charts, interactive explainers and PDF deliverables. Use for visualize, visual explanations, architecture diagrams, comparison reports, infographics, document creation, 시각화, 그려줘, 문서 만들어줘, 보고서, PDF 생성. Preserve explicit formats and templates; text-only requests and ordinary code changes do not need a visual."
 metadata:
-  last-verified: "2026-07-11"
-  short-description: "Environment-aware diagram rendering: native pass-through or browser-based display."
-  keywords: [diagram, chart, SVG, mermaid, visualization, browser, rendering, interactive, widget]
+  last-verified: "2026-09-08"
+  short-description: "Visual documents, SVG/HTML explainers and verified PDF delivery."
+  keywords: [diagram, visualization, visualize, document, report, SVG, HTML, PDF, interactive]
 ---
 
-# Diagram delivery — detect the actual rendering contract
+# Visual documents — compose, render, deliver
 
-Use `dev` for class, scope, safety and verification. This router selects delivery;
-it does not duplicate the host's visualization contract or assume a native renderer.
+Turn the reader's question and supplied facts into a useful visual artifact.
+The existing `cxc-dev-diagram-viewer` name remains the entrypoint. Use `dev`
+for scope, work class and verification; a document request does not automatically
+require a development loop. This skill owns artifact composition and delivery.
+`dev-uiux-design` owns broader design judgment, `dev-frontend` owns frontend
+implementation, and available format-specific skills own document mechanics.
 
-## Choose the smallest useful surface
+## Start with the requested outcome
 
-- Plain prose or a small table is enough when a visual adds no clarity.
-- When the current host explicitly supports native Mermaid, use a supported type.
-  Do not infer renderer support from the app name or an environment variable alone.
-- When the host exposes the `visualize` skill for inline charts, comparisons or
-  interactive explainers, read its CURRENT SKILL.md fully and follow its file location,
-  fragment, size, resource, output-reference and interaction requirements.
-  Do not emit a historical directive from memory.
-- If no inline contract is exposed, use a standalone HTML/SVG artifact with an available
-  browser, or a static/text alternative appropriate to the host. Never claim a file
-  opened successfully without observing it.
+Infer the audience, question to answer, source material and output format from
+context. Ask only for missing information that materially changes the result.
+For “문서 만들어줘” with no format constraint, a readable HTML document is a
+reasonable stated assumption. “visualize” in a conversation usually needs a
+focused explanation. Neither phrase grants permission to publish or install.
 
-Reference routing: [environment detection](reference/environment-detection.md),
-[current visualization contract](reference/visualize-contract.md),
-[standalone templates](reference/html-templates.md).
-Browser selection follows [portable browser routing](../dev/references/browser-routing.md):
-suitable available Aside is preferred, agbrowse supports parallel and local UI work,
-and available native browsers remain valid alternatives. None is required on every host.
+- Preserve a named format, existing template, branding, section order and required
+  contents. A DOCX request ends with DOCX; HTML can be a preview, not a substitute.
+- Read supplied data and documents before designing. Distinguish observations,
+  user-provided figures, assumptions and illustrative data. Never invent facts
+  to populate a chart. Retain sources, dates, units and uncertainty where relevant.
+- A requested Markdown table or text-only answer stays Markdown/text. A visual
+  earns its space by clarifying a relationship, comparison or decision.
+- Match document scale to content: one figure can be enough; reports need narrative,
+  evidence and conclusions. Do not turn every request into a dashboard or slide deck.
 
-## Standalone artifacts
+## Select a route; read only what it needs
 
-Write to an authorized, durable task-owned directory when delivering a file. OS temp
-space is only for disposable previews and must not be assumed conversation-readable.
-Use an absolute artifact path. Do not hardcode a user home, account ID or /tmp path
-into a distributed workflow.
+| Requested result | Authoring route | Read when selected |
+|---|---|---|
+| In-conversation comparison, simulation or explainer | Current host's exposed `visualize` skill, if available | Its current full SKILL.md; [delivery](reference/environment-detection.md) |
+| Small static structure expressible as labeled nodes/edges | Mermaid if host supports it; otherwise a suitable artifact | [SVG and interaction](reference/svg-and-interaction.md) only for custom output |
+| Editable SVG diagram or infographic | Native SVG with legible geometry and text | [Visual design](reference/visual-design.md), [SVG and interaction](reference/svg-and-interaction.md) |
+| HTML report, technical brief, visual review or document | Semantic HTML with purposeful figures and readable sections | [Visual design](reference/visual-design.md), [documents/PDF](reference/document-pdf.md) |
+| Interactive HTML model | One useful visual plus requested inputs that change it | [SVG and interaction](reference/svg-and-interaction.md), design reference if styling is open |
+| PDF, print report or handout | Choose an available print/PDF engine; actually export | [Documents/PDF](reference/document-pdf.md); current PDF skill if available |
+| Word/Google Docs, Slides/PPTX or spreadsheet | Available format-specific owner; use this skill for visual composition | [Documents/PDF](reference/document-pdf.md) for boundaries |
+| Scientific figure intended for export/publication | Standard plotting tools and vector/raster artifact | Design/label principles here; scientific tool's own workflow |
+| Website, app page or existing component change | Frontend owner and project conventions; Sites if required by the project | This skill only for embedded explanatory artifacts |
 
-The optional `scripts/diagram-to-html.sh` wraps trusted locally authored content on
-hosts with Bash and its prerequisites. It is a standalone HTML helper, NOT an inline
-fragment generator, sanitizer or Windows installation prerequisite. Supply an explicit
-authorized output path. On other hosts, generate the needed HTML with existing tools.
+No tool or companion skill is assumed installed. Inspect available capabilities;
+if a required exporter is absent, deliver the useful editable source and identify
+the missing requested output. Never call print-ready HTML a generated PDF.
 
-The templates use CDN dependencies and therefore need network access; "standalone"
-does not mean offline or self-contained dependencies. Pin executable assets according
-to the task's trust policy. Do not copy arbitrary retrieved HTML/JS into executable
-output. For restricted/offline environments prefer a static asset or vetted local
-dependencies already available; do not install new ones without authorization.
+## Compose before styling
 
-Only use platform open commands or host file/browser panels when available.
-Some in-app browsers need task-scoped HTTP serving instead of file URLs: check the
-current binding. If serving, use loopback and a scoped directory, record the process,
-and stop only the server this task owns.
+Use a compact design read: **reader → question → information structure → visual
+encoding → type/color/spacing → output constraints**. State the chosen direction
+briefly when it helps the user evaluate an open brief. Reuse existing design tokens.
 
-## Layout and verification
+[Visual design](reference/visual-design.md) supplies distinct optional directions
+and composition recipes. Select a coherent set for this artifact. Borrow principles
+from several references, then reconcile them: one type hierarchy, one spacing rhythm,
+consistent semantic colors, a deliberate level of detail. A source's trend or star
+count is not a design requirement.
 
-**DIAGRAM-LAYOUT-01:** put text-bearing HTML nodes in normal responsive flow using
-Grid/Flexbox. SVG/canvas may draw marks or connectors; derive connector positions from
-rendered bounds rather than hand-positioning labels. Use intrinsic sizing/wrapping
-and inspect long labels at narrow and wide sizes appropriate to the surface.
+Examples of structure that earns its form:
 
-**DIAGRAM-RENDER-VERIFY-01:** run/render the artifact, inspect the actual output, and
-correct blank content, clipped labels, overlap and runtime errors. For interactive
-artifacts, exercise at least the primary state change; initial render alone is not
-interaction verification. Save meaningful evidence and repeat after relevant changes.
+- Explain a mechanism with actions on connectors and a caption stating what changes.
+- Compare alternatives on the same dimensions and scale, with a table for exact values.
+- Introduce the decision in a report, show its evidence, then expose detail and sources.
+- For a dense system, use overview plus focused detail rather than shrinking every label.
 
-**DIAGRAM-SYNTAX-01:** run an existing supported parser/checker when available.
-Do not invent a Mermaid CLI parse command or install a runner just for ad-hoc proof.
-Static validity does not replace rendering.
+Keep document narrative in the document. Inline conversation visuals instead obey
+the host's narrower composition contract; do not paste a whole report into a fragment.
 
-**DIAGRAM-A11Y-01:** provide accessible labels/text alternatives, keyboard controls,
-non-color meaning, sufficient contrast, and reduced-motion support as applicable.
+## Build the smallest complete artifact
 
-## Classification and compatibility
+Use semantic, editable source. Keep text-bearing HTML in normal responsive Grid/Flex
+flow; derive SVG connector endpoints from rendered bounds if needed
+(**DIAGRAM-LAYOUT-01**). Standalone SVG is a vector document: geometric coordinates
+are appropriate, but size/wrap labels from actual text metrics and inspect the result.
 
-Classify by behavior and risk, not file count or format. A text-only fence may be C0;
-a bounded local artifact may be C1. External executable dependencies, untrusted input,
-permission changes or security effects can require higher care under `dev` §0.0.
-A CDN script is not automatically low-risk because it lives in one HTML file.
+[editorial-report.html](assets/editorial-report.html) is an optional original,
+dependency-free example for reports with a live scenario and print output. Adapt
+its content and visual direction; it is not a mandatory template or a finished
+report about the user's data. See the document reference for export readiness.
 
-A host contract copied at one date does not establish current compatibility.
-`upstream/visualize-upstream.md` records inspection provenance; the current host skill
-wins over that snapshot. The optional Unix `upstream/sync-check.sh` is a drift reminder,
-not proof that output works, and its absence/failure does not justify a false PASS.
+Prefer native HTML/CSS/SVG and existing libraries. For library-dependent visuals,
+verify actual versions and APIs, use authorized pinned assets, and distinguish
+“one HTML file” from “works offline.” Do not execute retrieved HTML/JS or insert
+untrusted strings as executable markup. Preserve dependency/font notices when copying.
+
+The legacy `reference/html-templates.md` and `scripts/diagram-to-html.sh` remain
+optional compatibility samples, **not the normal authoring route**. Their dark-theme,
+CDN and environment defaults are not requirements. The shell helper wraps trusted
+local content, is not a sanitizer or inline-fragment generator, and needs an explicit
+authorized output path for durable delivery. Do not install it as a prerequisite.
+
+## Verify what the reader receives
+
+**DIAGRAM-RENDER-VERIFY-01:** render the final artifact, read the screenshot/page,
+fix clipping, collisions, empty charts and runtime errors. Inspect the longest
+labels at narrow and wide widths appropriate to the artifact; for responsive
+HTML include 320/736px and the intended desktop size. SVG text must remain legible
+at its intended display/export sizes, not merely within a valid viewBox.
+
+For interaction, change the primary input and observe the resulting marks/values;
+exercise keyboard access and reset when provided. A static screenshot is not
+interaction proof. For PDF, inspect the **actual exported pages**, including
+multipage tables, final content, Korean glyphs and selected scenario state.
+Print CSS or a PDF filename alone proves nothing.
+
+**DIAGRAM-SYNTAX-01:** use an existing supported parser/checker where available.
+XML validation can catch malformed SVG; it cannot catch overlapped labels. Do not
+invent a Mermaid CLI parse command or install a runner just for incidental proof.
+
+**DIAGRAM-A11Y-01:** provide names/descriptions, meaningful heading order, data/text
+alternatives, visible keyboard focus, non-color meaning, readable contrast and
+reduced motion where applicable. Inspect actual contrast and reading order;
+adding ARIA does not establish accessibility conformance.
+
+## Deliver and retain provenance
+
+Save deliverables to a durable, authorized task-owned directory. Return a clickable
+absolute file link for a requested standalone artifact. Use the current host's exact
+content-reference contract for inline output. Only say it opened, rendered, exported
+or published when that outcome was observed. Describe the useful result concisely.
+
+[Source patterns](reference/source-patterns.md) records the GitHub references,
+observed dates, licensing and adopted/rejected ideas. Read it when borrowing further
+material or refreshing the skill, not for every small diagram. Existing
+`reference/visualize-contract.md` and `upstream/` are historical snapshots/maintenance
+aids. The current exposed host skill wins; a snapshot cannot grant renderer support.

--- a/plugins/codexclaw/skills/dev-diagram-viewer/agents/openai.yaml
+++ b/plugins/codexclaw/skills/dev-diagram-viewer/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: "cxc-dev-diagram-viewer"
-  short_description: "Environment-aware diagram rendering: native pass-through or browser-based display."
+  short_description: "Visual documents, SVG/HTML explainers and PDF delivery."
 policy:
   allow_implicit_invocation: false

--- a/plugins/codexclaw/skills/dev-diagram-viewer/assets/editorial-report.html
+++ b/plugins/codexclaw/skills/dev-diagram-viewer/assets/editorial-report.html
@@ -1,0 +1,264 @@
+<!doctype html>
+<!-- Original codexclaw example; provenance: ../reference/source-patterns.md -->
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>분기 운영 검토 | 원가 변화 시나리오</title>
+<meta name="description" content="72개 예시 기록으로 살펴보는 원가 상승과 잔액의 관계">
+<style>
+:root { color-scheme: light; --ink: #20252c; --muted: #505d6b; --blue: #204f9b; --line: #c8cdd3; --paper: #fff; --wash: #f1f3f5; }
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--wash); color: var(--ink); font: 1rem/1.7 "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", sans-serif; }
+main { max-width: 1000px; margin: 36px auto; padding: 44px 56px; background: var(--paper); }
+a { color: var(--blue); }
+.skip { position: absolute; left: 12px; top: -80px; background: white; padding: 10px; }
+.skip:focus { top: 12px; }
+h1, h2, h3, figcaption { text-wrap: balance; word-break: keep-all; overflow-wrap: anywhere; }
+h1 { font-size: clamp(1.8rem, 4vw, 2.5rem); line-height: 1.35; margin: 18px 0; font-weight: 700; }
+h2 { font-size: 1.3rem; line-height: 1.4; margin: 0 0 16px; }
+h3 { font-size: 1rem; margin: 0 0 6px; }
+p { max-width: 66ch; word-break: keep-all; overflow-wrap: anywhere; margin: 0 0 16px; }
+.masthead { display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap; border-bottom: 2px solid var(--ink); padding-bottom: 12px; font-size: .85rem; }
+.lead { color: var(--muted); font-size: 1.05rem; }
+.notice { font-size: .85rem; color: var(--muted); }
+section { margin-top: 36px; }
+.summary { border-top: 1px solid var(--line); padding-top: 24px; }
+.summary-line { font-size: 1.1rem; }
+.summary-line strong { font-size: 1.4rem; font-variant-numeric: tabular-nums; color: var(--blue); }
+.controls { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; padding: 16px 0; }
+.control { flex: 1 1 260px; }
+label { display: block; font-weight: 600; }
+input { accent-color: var(--blue); width: 100%; min-height: 44px; margin: 0; }
+button { min-height: 44px; border: 1px solid var(--muted); background: white; color: var(--ink); padding: 8px 16px; font: inherit; cursor: pointer; }
+button:hover { background: var(--wash); }
+button:active { transform: translateY(1px); }
+button.primary { background: var(--blue); color: white; border-color: var(--blue); }
+:focus-visible { outline: 3px solid var(--blue); outline-offset: 4px; }
+[hidden] { display: none !important; }
+.scenario { padding: 12px 16px; border-left: 3px solid var(--blue); background: var(--wash); }
+.scenario p { margin: 0; }
+figure { margin: 20px 0; }
+.chart-label { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 4px 16px; font-size: .9rem; }
+.chart-label strong { font-variant-numeric: tabular-nums; }
+svg { display: block; width: 100%; height: auto; margin: 10px 0; }
+.cost-mark { fill: var(--blue); }
+.margin-mark { fill: #d8dfe9; stroke: var(--muted); stroke-width: 1; }
+.legend { display: flex; gap: 20px; margin: 12px 0; font-size: .85rem; }
+.legend span { display: flex; gap: 8px; align-items: center; }
+.swatch { display: inline-block; width: 18px; height: 12px; border: 1px solid var(--muted); }
+.swatch.cost { background: var(--blue); }
+.swatch.balance { background: #d8dfe9; }
+figcaption { color: var(--muted); font-size: .85rem; margin-top: 12px; }
+.reading { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 24px; }
+.reading > div { min-width: 0; }
+.reading p { font-size: .9rem; }
+.table-note { color: var(--muted); font-size: .85rem; }
+table { width: 100%; border-collapse: collapse; table-layout: fixed; font-size: .9rem; font-variant-numeric: tabular-nums; }
+caption { text-align: left; font-weight: 600; padding: 0 0 12px; }
+th, td { padding: 7px 10px; border-bottom: 1px solid var(--line); text-align: right; overflow-wrap: anywhere; }
+th:first-child, td:first-child { text-align: left; width: 40%; }
+thead th { background: var(--wash); border-top: 2px solid var(--ink); font-weight: 700; }
+tbody th { font-weight: 400; }
+tfoot th, tfoot td { border-top: 2px solid var(--ink); font-weight: 700; }
+footer { margin-top: 24px; padding-top: 12px; border-top: 1px solid var(--ink); color: var(--muted); font-size: .8rem; }
+@media (max-width: 767px) {
+  main { margin: 0; padding: 28px 20px; }
+  .reading { grid-template-columns: 1fr; gap: 8px; }
+  th, td { padding: 7px 4px; font-size: .8rem; }
+  th:first-child, td:first-child { width: 34%; }
+  .controls { gap: 12px; }
+}
+@media (prefers-reduced-motion: reduce) { button:active { transform: none; } }
+@page { size: A4; margin: 16mm; }
+@media print {
+  html, body { background: white; font-size: 10.5pt; }
+  main { max-width: none; width: auto; margin: 0; padding: 0; }
+  .screen-controls, .skip { display: none !important; }
+  h1 { font-size: 24pt; }
+  h2 { font-size: 15pt; break-after: avoid; }
+  h3 { break-after: avoid; }
+  p { widows: 3; orphans: 3; }
+  section { margin-top: 18pt; }
+  .records { break-before: page; }
+  .reading { display: block; }
+  .reading > div { break-inside: avoid; }
+  .reading p { margin-bottom: 8pt; }
+  .scenario { background: white; }
+  figure { break-inside: avoid; margin: 12pt 0; }
+  svg { max-height: 80px; }
+  table, tbody { break-inside: auto; }
+  thead { display: table-header-group; }
+  tfoot { display: table-row-group; }
+  tr { break-inside: avoid; }
+  th, td { padding: 4pt 6pt; font-size: 10pt; }
+  th:first-child, td:first-child { width: 40%; }
+  * { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+}
+</style>
+</head>
+<body>
+<a class="skip" href="#report">보고서 본문으로</a>
+<main id="report">
+<header>
+  <div class="masthead"><strong>분기 운영 검토</strong><span>2026년 3분기 / 검토용 예시</span></div>
+  <h1>원가가 오르면<br>얼마가 남을까</h1>
+  <p class="lead">매출을 유지한 채 원가만 바뀌는 상황을 살펴봅니다. 72개 작업 기록의 합계에서 비용 변동이 잔액에 미치는 영향을 확인합니다.</p>
+  <p class="notice">모든 이름과 수치는 설명을 위한 가상 자료입니다. 실제 회사의 실적이나 예측이 아닙니다. 금액 단위: 만원.</p>
+</header>
+<section class="summary" aria-labelledby="scenario-heading">
+  <h2 id="scenario-heading">원가 변화 시나리오</h2>
+  <p class="summary-line">매출 <strong>9,828</strong>만원 중 기준 원가는 <strong>6,948</strong>만원입니다.</p>
+  <div class="controls screen-controls" id="controls" hidden>
+    <div class="control"><label for="uplift">원가 상승률 <output id="rate" for="uplift">0%</output></label>
+    <input id="uplift" type="range" min="0" max="20" step="1" value="0" aria-describedby="range-help">
+    <small id="range-help">0%부터 20%까지, 1% 단위로 조정</small></div>
+    <button id="reset" type="button">기준값으로</button>
+    <button id="print" class="primary" type="button">인쇄 / PDF 저장</button>
+  </div>
+  <noscript><p class="notice">현재 문서는 기준값 0%입니다. 시나리오 조정은 JavaScript를 켠 브라우저에서 사용할 수 있습니다.</p></noscript>
+  <div class="scenario" aria-live="polite" aria-atomic="true">
+    <p id="selected">선택한 원가 상승률: 0%</p>
+    <p>조정 원가 <strong id="cost">6,948</strong>만원 / 남는 금액 <strong id="balance">2,880</strong>만원</p>
+    <p>기준 대비 잔액 감소: <strong id="loss">0</strong>만원</p>
+  </div>
+  <figure>
+    <div class="chart-label"><span>기준 원가 / 잔액</span><strong>6,948 / 2,880만원</strong></div>
+    <svg viewBox="0 0 600 34" role="img" aria-labelledby="base-title base-desc">
+      <title id="base-title">기준 매출의 구성</title><desc id="base-desc">총 9,828만원 중 원가 6,948만원, 잔액 2,880만원.</desc>
+      <rect class="cost-mark" x="0" y="2" width="424.1768" height="30"/>
+      <rect class="margin-mark" x="424.1768" y="2" width="175.8232" height="30"/>
+    </svg>
+    <div class="chart-label"><span>선택한 시나리오 원가 / 잔액</span><strong id="chart-values">6,948 / 2,880만원</strong></div>
+    <svg viewBox="0 0 600 34" role="img" aria-labelledby="scenario-title scenario-desc">
+      <title id="scenario-title">선택한 시나리오의 매출 구성</title><desc id="scenario-desc">원가 상승률 0%. 원가 6,948만원, 잔액 2,880만원.</desc>
+      <rect id="cost-bar" class="cost-mark" x="0" y="2" width="424.1768" height="30"/>
+      <rect id="balance-bar" class="margin-mark" x="424.1768" y="2" width="175.8232" height="30"/>
+    </svg>
+    <div class="legend" aria-hidden="true"><span><i class="swatch cost"></i>원가</span><span><i class="swatch balance"></i>잔액</span></div>
+    <figcaption>두 막대의 전체 길이는 같은 매출 9,828만원입니다. 원가 증가분만큼 잔액이 줄어듭니다.</figcaption>
+  </figure>
+  <div class="reading">
+    <div><h3>계산 범위</h3><p>조정 원가 = 기준 원가 × (1 + 상승률). 잔액 = 매출 - 조정 원가. 소수 둘째 자리까지 표시합니다.</p></div>
+    <div><h3>해석할 때</h3><p>매출과 작업 수는 고정했습니다. 세금, 금융비용, 추가 고정비를 제외하므로 잔액은 회계상 순이익과 다릅니다.</p></div>
+  </div>
+</section>
+<section class="records" aria-labelledby="records-heading">
+  <h2 id="records-heading">기준 작업 기록</h2>
+  <p class="table-note">아래 표는 조정 전 기준값입니다. 원가 상승률은 앞의 시나리오 합계에만 적용됩니다.</p>
+  <table>
+    <caption>72개 가상 작업의 매출과 원가 (단위: 만원)</caption>
+    <thead><tr><th scope="col">작업명</th><th scope="col">매출</th><th scope="col">원가</th><th scope="col">잔액</th></tr></thead>
+    <tbody>
+    <tr><th scope="row">서교 편집 01</th><td>101</td><td>61</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 02</th><td>102</td><td>62</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 03</th><td>103</td><td>63</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 04</th><td>104</td><td>64</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 05</th><td>105</td><td>65</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 06</th><td>106</td><td>66</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 07</th><td>107</td><td>67</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 08</th><td>108</td><td>68</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 09</th><td>109</td><td>69</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 10</th><td>110</td><td>70</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 11</th><td>111</td><td>71</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 12</th><td>112</td><td>72</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 13</th><td>113</td><td>73</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 14</th><td>114</td><td>74</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 15</th><td>115</td><td>75</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 16</th><td>116</td><td>76</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 17</th><td>117</td><td>77</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 18</th><td>118</td><td>78</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 19</th><td>119</td><td>79</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 20</th><td>120</td><td>80</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 21</th><td>121</td><td>81</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 22</th><td>122</td><td>82</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 23</th><td>123</td><td>83</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 24</th><td>124</td><td>84</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 25</th><td>125</td><td>85</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 26</th><td>126</td><td>86</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 27</th><td>127</td><td>87</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 28</th><td>128</td><td>88</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 29</th><td>129</td><td>89</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 30</th><td>130</td><td>90</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 31</th><td>131</td><td>91</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 32</th><td>132</td><td>92</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 33</th><td>133</td><td>93</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 34</th><td>134</td><td>94</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 35</th><td>135</td><td>95</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 36</th><td>136</td><td>96</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 37</th><td>137</td><td>97</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 38</th><td>138</td><td>98</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 39</th><td>139</td><td>99</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 40</th><td>140</td><td>100</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 41</th><td>141</td><td>101</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 42</th><td>142</td><td>102</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 43</th><td>143</td><td>103</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 44</th><td>144</td><td>104</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 45</th><td>145</td><td>105</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 46</th><td>146</td><td>106</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 47</th><td>147</td><td>107</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 48</th><td>148</td><td>108</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 49</th><td>149</td><td>109</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 50</th><td>150</td><td>110</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 51</th><td>151</td><td>111</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 52</th><td>152</td><td>112</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 53</th><td>153</td><td>113</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 54</th><td>154</td><td>114</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 55</th><td>155</td><td>115</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 56</th><td>156</td><td>116</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 57</th><td>157</td><td>117</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 58</th><td>158</td><td>118</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 59</th><td>159</td><td>119</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 60</th><td>160</td><td>120</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 61</th><td>161</td><td>121</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 62</th><td>162</td><td>122</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 63</th><td>163</td><td>123</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 64</th><td>164</td><td>124</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 65</th><td>165</td><td>125</td><td>40</td></tr>
+    <tr><th scope="row">을지 검수 66</th><td>166</td><td>126</td><td>40</td></tr>
+    <tr><th scope="row">서교 편집 67</th><td>167</td><td>127</td><td>40</td></tr>
+    <tr><th scope="row">성수 인쇄 68</th><td>168</td><td>128</td><td>40</td></tr>
+    <tr><th scope="row">연남 교정 69</th><td>169</td><td>129</td><td>40</td></tr>
+    <tr><th scope="row">망원 제본 70</th><td>170</td><td>130</td><td>40</td></tr>
+    <tr><th scope="row">문래 제작 71</th><td>171</td><td>131</td><td>40</td></tr>
+    <tr><th scope="row">최종기록 72</th><td>172</td><td>132</td><td>40</td></tr>
+    </tbody>
+    <tfoot><tr><th scope="row">기준 합계</th><td>9,828</td><td>6,948</td><td>2,880</td></tr></tfoot>
+  </table>
+</section>
+<footer>
+  <p>자료: 설명용으로 구성한 72개 기록. i번째 기록의 매출은 100+i, 원가는 60+i입니다. 실제 의사결정에는 검증된 자료를 사용하세요.</p>
+</footer>
+</main>
+<script>
+(() => {
+  const input = document.getElementById('uplift');
+  const text = (id, value) => { document.getElementById(id).textContent = value; };
+  const format = value => new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 2 }).format(value);
+  function update() {
+    const rate = Number(input.value);
+    const cost = 6948 * (1 + rate / 100);
+    const balance = 9828 - cost;
+    const width = 600 * cost / 9828;
+    text('rate', `${rate}%`);
+    input.setAttribute('aria-valuetext', `${rate}%`);
+    text('selected', `선택한 원가 상승률: ${rate}%`);
+    text('cost', format(cost));
+    text('balance', format(balance));
+    text('loss', format(cost - 6948));
+    text('chart-values', `${format(cost)} / ${format(balance)}만원`);
+    text('scenario-desc', `원가 상승률 ${rate}%. 원가 ${format(cost)}만원, 잔액 ${format(balance)}만원.`);
+    document.getElementById('cost-bar').setAttribute('width', width);
+    document.getElementById('balance-bar').setAttribute('x', width);
+    document.getElementById('balance-bar').setAttribute('width', 600 - width);
+  }
+  input.addEventListener('input', update);
+  document.getElementById('reset').addEventListener('click', () => { input.value = '0'; update(); });
+  document.getElementById('print').addEventListener('click', async () => { await document.fonts.ready; update(); window.print(); });
+  window.addEventListener('beforeprint', update);
+  update();
+  document.getElementById('controls').hidden = false;
+})();
+</script>
+</body>
+</html>

--- a/plugins/codexclaw/skills/dev-diagram-viewer/reference/document-pdf.md
+++ b/plugins/codexclaw/skills/dev-diagram-viewer/reference/document-pdf.md
@@ -1,0 +1,169 @@
+# Document authoring and PDF delivery
+
+Use this reference for reports, proposals and other flowing documents.
+Choose the requested medium before choosing the renderer. A PDF is a fixed
+snapshot; an HTML tool and an editable Word document have different contracts.
+
+## Preserve the source contract
+
+- Inspect supplied documents, all relevant tabs/pages, templates and examples.
+- Inventory headings, tables, footnotes, captions, citations and required fields.
+- Preserve their meaning, order, relationships and native editing affordances.
+- Keep supplied text and data separate from assumptions or illustrative examples.
+- State units, reporting period, rounding and source provenance near the data.
+- Use real headings, lists, table cells and links, not screenshots of paragraphs.
+- Retain the editable source alongside an export when the user needs revisions.
+- Do not flatten forms, signatures, spreadsheets or slide objects implicitly.
+- For AcroForms, verify canonical field values as well as visible appearances.
+- For native Docs/Word/Sheets/Slides, use the available format-specific owner.
+  Preserve document tabs, formulas, notes and template constraints as applicable.
+- HTML-to-DOCX conversion is not a promise of identical pagination or native charts.
+- A PDF preview never substitutes for an explicitly requested editable deliverable.
+
+## Select a route from observed capabilities
+
+| Requested result | Suitable route | Boundary to explain |
+| --- | --- | --- |
+| Interactive report | Semantic HTML, CSS, inline SVG and small local JS | PDF cannot retain controls |
+| HTML plus PDF | Existing browser print/export API | Freeze and verify current state |
+| Static paged report | Available WeasyPrint with HTML/CSS | Does not execute JavaScript |
+| Book or press layout | Available Paged.js/Vivliostyle or publishing tool | Verify CSS support and license |
+| Editable Word/Slides | Available native/document owner | Preserve native structure first |
+| Fixed drawing/form | Available PDF authoring/form tool | Verify text, fields and geometry |
+
+Probe existing executables/modules before promising a route. Do not install,
+reconfigure a browser, or launch a service outside the user's authorized scope.
+Read the current exporter API; browser bindings differ in options and units.
+A browser screenshot, successful open command or HTML file is not a PDF export.
+
+## Build the reading order
+
+Lead with the decision or result, then evidence, method and detailed records.
+Use a bounded text measure and a clear heading scale; avoid a cover that pushes
+all useful information off the first page. Label chart axes and disclose units.
+Keep a chart's source data in a table or equivalent readable text.
+Long tables belong in normal flow and may occupy as many pages as needed.
+Use explicit chapter breaks only at real reading boundaries, not every section.
+
+## HTML print baseline
+
+This is an adaptable fragment, not a compulsory visual style:
+
+```css
+@page { size: A4; margin: 18mm 16mm 20mm; }
+@media print {
+  .screen-controls { display: none !important; }
+  html, body, main { width: auto; max-width: none; margin: 0; }
+  body { background: white; color: #16191e; font-size: 11pt; }
+  .table-scroll { overflow: visible; max-height: none; }
+  table { width: 100%; table-layout: fixed; break-inside: auto; }
+  thead { display: table-header-group; }
+  tfoot { display: table-row-group; } /* a final total, not repeated */
+  tr { break-inside: avoid; }
+  th, td { overflow-wrap: anywhere; }
+  h2, h3 { break-after: avoid; }
+  p { widows: 3; orphans: 3; }
+  figure { break-inside: avoid; }
+  img, svg { max-width: 100%; height: auto; }
+  .chapter { break-before: page; }
+}
+```
+
+Use `<caption>`, `<thead>`, `<tbody>` and `<th scope="col|row">` correctly.
+Never apply `break-inside: avoid` to an entire long table or containing section.
+For a row taller than a page, allow that row to fragment or redesign its content
+into smaller semantic records; do not shrink the whole document to fit one page.
+Remove screen-only fixed heights, sticky positioning and overflow clipping.
+Repeating headers must be observed in the resulting PDF, not inferred from CSS.
+Keep footnotes and sources printable. Do not blanket-hide every footer or aside.
+Use only one page-number mechanism, with enough reserved margin for its text.
+Margin boxes, named pages and running headers differ across rendering engines.
+
+## Fonts and Korean text
+
+Choose a Korean-capable family deliberately, including the required weights.
+A useful local fallback order is Noto Sans KR, Apple SD Gothic Neo, Malgun Gothic,
+then sans-serif. Availability differs by machine; the family list embeds nothing.
+For reproducible delivery, bundle licensed font files or embed them in the HTML.
+Retain font notices and verify embedding/redistribution terms for the exact files.
+Do not copy a font from a commercial product merely because the browser loads it.
+Use `lang="ko"`, natural phrase boundaries and comfortable line-height.
+Browser `word-break: keep-all` plus `overflow-wrap` can help long Korean labels;
+verify the renderer's support instead of assuming the same result in WeasyPrint.
+Its inspected CSS reference explicitly excludes `line-break` support.
+Test Hangul, Hanja where relevant, Latin, currency and composed/decomposed text.
+A glyph may extract correctly while displaying as a missing-glyph box.
+
+## Readiness and current-state export
+
+1. Wait for `document.fonts.ready`; check required fonts actually loaded.
+2. Await image decoding and the chart library's explicit render completion.
+3. Disable animation for export and finish any asynchronous pagination pass.
+4. Commit the selected values into visible text and SVG/canvas output.
+5. Record parameter names, values and units in a printable summary.
+6. Export using print media with deliberate size, margins and background options.
+7. Reopen the written PDF and compare it to the selected nondefault state.
+
+`networkidle`, a sleep, or a font-ready promise alone does not prove chart readiness.
+Fail with the missing readiness condition when a bounded wait expires.
+Do not silently print defaults after a pagination timeout.
+Use a print event only for synchronous state synchronization; precompute any
+asynchronous work before invoking print. Avoid resetting state in `beforeprint`.
+For browser Save as PDF, explain that the user must finish the system print dialog;
+calling `window.print()` alone does not create or verify a file.
+
+## WeasyPrint and other no-JavaScript paths
+
+WeasyPrint lays out HTML/CSS without running scripts. Supply complete static HTML,
+SVG and tables; pre-render JavaScript charts and resolve interaction values first.
+Do not send an empty chart container and assume its script will execute.
+If capturing a browser DOM, serialize current text/attributes and replace canvases
+with image assets; canvas pixels and input properties do not survive plain HTML
+serialization automatically. Remove controls/scripts from the static export.
+Resolve relative asset paths against a deliberate base directory.
+When using `@font-face` in its Python API, share a `FontConfiguration` between CSS
+and `HTML.write_pdf`; check current documentation for the installed version.
+Prefer SVG for chart lines and labels when the renderer supports the features used.
+PDF/A, PDF/UA or tagged-output options require independent conformance validation.
+
+## Output QA and evidence
+
+- Check file existence, nonzero size, parsability, page count and page dimensions.
+- Extract text; reconcile all records, totals, final-row marker and selected inputs.
+- Render every PDF page to images with an available tool such as `pdftoppm`.
+- Inspect those images for missing glyphs, truncation, overlap and unintended blanks.
+- Check the ending too: a nearly empty page containing only a short source note
+  may need local spacing or page-break adjustment. Keep the source note and
+  readable type; do not drop records or shrink the whole report to reduce pages.
+- Name the pages containing table continuations and verify repeated column headers.
+- Inspect links, bookmarks, forms and accessible reading order when required.
+- Compare charts with their underlying values; color must not carry meaning alone.
+- Exercise keyboard changes and reset; test narrow/tablet/desktop HTML separately.
+- Test offline with requests blocked when offline operation is promised.
+- Record renderer/version, input state, commands, outcomes and artifact paths.
+
+If export is unavailable, deliver the authorized editable source and precise manual
+export steps, labeled PDF NOT GENERATED. If rasterization or extraction is absent,
+state that specific check as NOT RUN; a successful export is not visual QA.
+Do not install tools automatically or present an unperformed check as passing.
+
+## Original runnable example
+
+Open [editorial-report.html](../assets/editorial-report.html) directly in a browser.
+It contains 72 static illustrative records, a cost scenario, accessible SVG and
+print rules. Defaults remain readable without JS; interaction needs JS.
+When replacing its data, regenerate the static totals, chart baseline and model
+constants from the same input. Editing table rows alone leaves stale example
+numbers elsewhere. Reconcile initial and nondefault states with the new rows.
+Change the cost increase, then print: the visible scenario is the export source.
+Fonts use local Korean fallbacks; deterministic cross-machine typography needs
+licensed embedded fonts. This is an optional layout, not a universal house style.
+
+## Source provenance
+
+Original guidance synthesized from source inspection on 2026-09-08; no upstream
+skill text, implementation or assets copied. See the main-owned source ledger.
+Relevant primary locators: [WeasyPrint fonts and CSS](https://github.com/Kozea/WeasyPrint/blob/e4b8b45e409392197441bc449d110f323b0eeb66/docs/api_reference.rst),
+[Paged.js preview lifecycle](https://github.com/pagedjs/pagedjs/blob/6b0ff8089f472a17247e44671da93d2d931e656e/src/polyfill/previewer.js),
+[Gstack export orchestration](https://github.com/garrytan/gstack/blob/0530392821c277b95e5cd65aa9d9fda4248718b2/make-pdf/src/orchestrator.ts),
+and [Noto font license](https://github.com/notofonts/noto-cjk/blob/f8d157532fbfaeda587e826d4cd5b21a49186f7c/Sans/LICENSE).

--- a/plugins/codexclaw/skills/dev-diagram-viewer/reference/environment-detection.md
+++ b/plugins/codexclaw/skills/dev-diagram-viewer/reference/environment-detection.md
@@ -1,25 +1,47 @@
-# Detect capabilities, not product names
+# Delivery — inspect capabilities, not application labels
 
-The current host's instructions and callable tool/skill catalog are authoritative.
-Environment variables such as CODEX_INTERNAL_ORIGINATOR_OVERRIDE, TERM and bundle
-IDs are hints only; they do not prove that Mermaid, inline HTML or a browser is available.
+Choose delivery from the user's requested artifact and the current host contract.
+Environment variables, app names, ports and installed packages are hints only;
+they do not establish that the conversation supports a renderer.
 
-| Observation | Consequence |
+| Evidence actually available | Use |
 |---|---|
-| Current host explicitly documents native Mermaid | Use its supported syntax; do not assume every Mermaid release/type is available |
-| visualize skill is listed | Read it and follow the actual inline output contract |
-| A browser tool or documented local CLI is available | Read its API and verify access/ownership before driving it |
-| Only terminal/text delivery exists | Offer text/static output or an authorized standalone file |
-| A local web server answers | Proves only that server exists, not which app the user is viewing |
+| Host explicitly supports the needed Mermaid type | Normal fenced Mermaid |
+| Current `visualize` skill is exposed and the request is in-conversation | Read it fully; follow its current fragment/path/resource/reference contract |
+| User asks for a standalone HTML/SVG/PDF file | Create that file in an authorized durable output directory |
+| Browser is available, inline rendering is not established | Inspect the standalone artifact in that browser and return its file link |
+| No renderer/exporter is available | Provide useful editable source/text and state which verification/output is unavailable |
 
-Do not probe an unrelated service port to infer the current conversation's renderer.
-Never infer a signed-in session from tool installation or an OS label.
+An exposed host contract takes priority over `reference/visualize-contract.md`.
+Do not emit historical directives, assume an app version, or use a local server's
+health response as proof that the user is reading its UI. The embedded contract
+and its extractor are maintenance provenance, not an alternative renderer owner.
 
-Standalone opening is platform-specific and optional:
-macOS `open`, Linux `xdg-open`, Windows `Start-Process`, or a host file/browser panel
-when exposed. A headless host may have none. Report the file and verification limits
-instead of claiming it was displayed. Do not execute an OS command from an untrusted
-artifact path without argument-safe handling.
+## Files and browser inspection
 
-For interactive work, use `../../dev/references/browser-routing.md`.
-No Aside, agbrowse, Bash, or native browser plugin is required on every platform.
+- Use an absolute path on the executor that writes the file. A writable file is
+  not automatically conversation-readable; follow the host's declared artifact path.
+- System temporary space is suitable for disposable inspection, not durable delivery.
+- Follow the available browser's current documentation. Aside is suitable for the
+  user's signed-in browser and research; other available browser tools are valid
+  for local QA. Do not assume a vendor-specific method or force an installation.
+- Some browser surfaces cannot open file URLs. If HTTP is required, serve only the
+  artifact directory on loopback with a task-owned process and available port.
+  Record its handle, inspect the page, and stop only that process after use.
+- Platform open commands are optional conveniences. Successful process dispatch
+  proves the request was sent, not that a page rendered. Inspect before claiming it.
+
+## Inline and standalone are different products
+
+A conversation fragment uses host-provided utilities, resource restrictions and
+interaction APIs. A standalone report uses its own document structure and tokens.
+Do not deliver a fragment as a full HTML file or depend on host-only globals in
+exported files. When exporting an existing inline visual, use the current host
+skill's supported export procedure and replace unavailable host interactions.
+
+“Self-contained” means the necessary code/data/assets are included; a CDN-backed
+single file still needs network access. Test with network disabled before claiming
+offline behavior. Do not fetch private data or introduce telemetry into an artifact.
+
+PDF is a separate output: perform the export and inspect its pages following
+[documents/PDF](document-pdf.md). Browser rendering alone cannot certify PDF layout.

--- a/plugins/codexclaw/skills/dev-diagram-viewer/reference/source-patterns.md
+++ b/plugins/codexclaw/skills/dev-diagram-viewer/reference/source-patterns.md
@@ -1,0 +1,93 @@
+# Source patterns and reuse ledger
+
+Inspected **2026-09-08** with Aside search, original GitHub pages, API metadata and
+pinned source files. This is a dated design/engineering survey, not a dependency
+manifest. The shipped instructions and example are independently authored; no
+upstream code, font binary, artwork or long prose passage is vendored here.
+
+Star counts below are repository-wide snapshots, not skill usage or growth rates.
+HEAD dates describe the default branch, not necessarily the last edit of a skill.
+Source inspection proves what a project implements or documents; it does not prove
+our output looks good. Rendered trials are required separately.
+
+## Visual explanations and design
+
+| Source and inspected revision | Snapshot | Useful pattern | Adaptation boundary |
+|---|---|---|---|
+| [visual-explainer](https://github.com/nicobailon/visual-explainer/blob/7163c3e10660912e0b89e1af465db9f387282b88/plugins/visual-explainer/SKILL.md) | 9,664 stars; HEAD 2026-08-28 | Select representation by question; explain mechanisms; separate overview/detail; compose prose and tables | Do not adopt automatic HTML replacement of requested Markdown tables, fixed home paths, or compulsory zoom controls for tiny diagrams |
+| [agent-html-skills / playground](https://github.com/f-labs-io/agent-html-skills/blob/d4f259ea4959aecd1240a10c60a950dfb6d1a3f5/plugins/html-skills/skills/html-interactive-playground/SKILL.md) | 55; 2026-09-02 | Visible parameters/units, immediate model consequences, reset and comparison sweeps | Do not import its Claude receiver, submission server, clipboard or publishing assumptions |
+| [taste-skill](https://github.com/Leonxlnx/taste-skill/blob/ccbc15639c97057cbfcf32ecebc38ef716e4bb37/skills/taste-skill/SKILL.md) | 85,154; 2026-08-24 | Audience/page kind before layout variance, density and motion | Marketing/portfolio style constraints do not govern data reports; existing `dev-uiux-design` remains the taste owner |
+| [design-taste / editorial-minimal](https://github.com/madebymustafa/design-taste/blob/c4a6bff0871eb4b15371b0e7d2751628b0ed4608/skills/editorial-minimal/SKILL.md) | 1; 2026-08-15 | Text measure, asymmetric hierarchy, rows and restrained rules | An optional genre, not evidence of broad adoption or a universal document look |
+| [explainer-pack / aesthetic](https://github.com/Angelopvtac/explainer-pack/blob/09fd3f1de384d71858f0ba678af2abc5721907d1/skills/Explainer/References/Aesthetic.md) | 1; 2026-05-23 | Separate UI accent and semantic colors; direct labels; print tokens | Its skill's conflicting light-theme guidance is rejected; source popularity is limited |
+| [visualise](https://github.com/bentossell/visualise/blob/35cd185b58af5db2f9d0fe13d9872b544a467483/SKILL.md) | 480; 2026-03-12 | Question-first SVG/HTML selection and local calculations | Renderer is not included; no host contract can be inferred; copy clearance incomplete |
+| [show-html](https://github.com/GoDiao/show-html/blob/67b01f7a219a4fa76bd1c2232adb8c7dca95d51c/show-html/SKILL.md) | 4; 2026-05-23 | Index examples by comparison/explanation/tuning scenario | Mixed provenance; do not copy sample files without their specific notices |
+| [html-effectiveness](https://github.com/ThariqS/html-effectiveness/tree/1787245d94aa680edf18b52027e3f859032776ba) | Mature comparator; README calls it unmaintained | Broader vocabulary for interactive explanations | Sample ideas, not a maintained runtime or reusable host integration |
+
+Inspected license files:
+
+- [visual-explainer MIT](https://github.com/nicobailon/visual-explainer/blob/7163c3e10660912e0b89e1af465db9f387282b88/LICENSE)
+- [agent-html-skills MIT](https://github.com/f-labs-io/agent-html-skills/blob/d4f259ea4959aecd1240a10c60a950dfb6d1a3f5/LICENSE)
+- [taste-skill MIT](https://github.com/Leonxlnx/taste-skill/blob/ccbc15639c97057cbfcf32ecebc38ef716e4bb37/LICENSE)
+- [design-taste MIT](https://github.com/madebymustafa/design-taste/blob/c4a6bff0871eb4b15371b0e7d2751628b0ed4608/LICENSE)
+- [explainer-pack MIT](https://github.com/Angelopvtac/explainer-pack/blob/09fd3f1de384d71858f0ba678af2abc5721907d1/LICENSE)
+- [html-effectiveness Apache-2.0](https://github.com/ThariqS/html-effectiveness/blob/1787245d94aa680edf18b52027e3f859032776ba/LICENSE)
+
+`visualise` declares MIT in its [README](https://github.com/bentossell/visualise/blob/35cd185b58af5db2f9d0fe13d9872b544a467483/README.md)
+but no LICENSE file was found. `show-html`'s [README](https://github.com/GoDiao/show-html/blob/67b01f7a219a4fa76bd1c2232adb8c7dca95d51c/README.md)
+describes MIT packaging and Apache-2.0 examples; its root LICENSE returned 404.
+Both are observation-only comparators here.
+
+## Documents, pagination and export
+
+| Source and inspected revision | Snapshot | Useful pattern | Adaptation boundary |
+|---|---|---|---|
+| [gstack / make-pdf](https://github.com/garrytan/gstack/blob/0530392821c277b95e5cd65aa9d9fda4248718b2/make-pdf/SKILL.md) | 131,972 stars; HEAD 2026-09-06 | Explicit content → asset rendering → pagination → export pipeline | Preview can omit final diagram/image work; inspect final PDF. Reject silent readiness timeout and blanket keep-together rules for long tables |
+| [glebis / pdf-generation](https://github.com/glebis/claude-skills/blob/d0bc2063d00d9d1a76d9fde5cd098fd8c92a68bc/pdf-generation/SKILL.md) | 372; 2026-09-02 | Small command wrapper with paper-size/TOC intent | [Generator](https://github.com/glebis/claude-skills/blob/d0bc2063d00d9d1a76d9fde5cd098fd8c92a68bc/pdf-generation/scripts/generate_pdf.py) does not implement every advertised styling setting; confirm flags in executed path |
+| [WeasyPrint](https://github.com/Kozea/WeasyPrint/blob/e4b8b45e409392197441bc449d110f323b0eeb66/docs/api_reference.rst) | 9,569; 2026-09-07; mature engine | Static HTML/CSS print, page rules, vector SVG, font embedding | Render JS charts first with a suitable browser; Korean line-breaking and PDF conformance need actual validation |
+| [Paged.js](https://github.com/pagedjs/pagedjs/blob/6b0ff8089f472a17247e44671da93d2d931e656e/src/polyfill/previewer.js) | 1,495; HEAD 2026-03-20 | Await completed pagination before browser export, inspect page boundaries | Later repository push date is not newer default-branch code; do not install for simple browser print |
+| [Vivliostyle CLI](https://github.com/vivliostyle/vivliostyle-cli/blob/0db54ab6005ad20987de5ed36a8d543f82665f36/README.md) | 233; 2026-09-07; mature publishing system | Book/press outputs, bleed/crop marks and PDF/EPUB distinction | Comparator only; AGPL integration is not part of this skill upgrade |
+| [HTML-to-PDF Fidelity Benchmark](https://github.com/NicolasMartalog/html-to-pdf-benchmark/blob/1a290622403ffbecc2065d6e00b0e25bae34f59e/run.mjs) | 0; 2026-07-20; recent, not popular | Distinct semantic markers, page counts, size/timing and raster checks | Vendor-maintained; first-page Chromium similarity does not measure whole-document quality |
+| [Noto CJK / Korean distributions](https://github.com/notofonts/noto-cjk/blob/f8d157532fbfaeda587e826d4cd5b21a49186f7c/Sans/README.md) | GitHub displayed 4.0k; HEAD 2024-09-19 | Explicit Korean font family and distributed weights | Verify selected font exists and is used; font redistributions require their notices |
+| [Anthropic PDF skill license](https://github.com/anthropics/skills/blob/41bbe19d1a1a7eaab5e7bb9050a417e5c6cffc8f/skills/pdf/LICENSE.txt) | Public repository; inspected 2026-09-08 | License exception discovery | Excluded from adaptation/copying: inspected PDF-specific license is proprietary, unlike some neighboring skills |
+
+Inspected licenses and source details:
+
+- [gstack MIT](https://github.com/garrytan/gstack/blob/0530392821c277b95e5cd65aa9d9fda4248718b2/LICENSE),
+  [orchestrator](https://github.com/garrytan/gstack/blob/0530392821c277b95e5cd65aa9d9fda4248718b2/make-pdf/src/orchestrator.ts),
+  [renderer readiness](https://github.com/garrytan/gstack/blob/0530392821c277b95e5cd65aa9d9fda4248718b2/lib/aside-render.ts),
+  [print CSS](https://github.com/garrytan/gstack/blob/0530392821c277b95e5cd65aa9d9fda4248718b2/make-pdf/src/print-css.ts).
+- [Glebis MIT](https://github.com/glebis/claude-skills/blob/d0bc2063d00d9d1a76d9fde5cd098fd8c92a68bc/LICENSE).
+- [WeasyPrint BSD-3-Clause](https://github.com/Kozea/WeasyPrint/blob/e4b8b45e409392197441bc449d110f323b0eeb66/LICENSE),
+  [shared font configuration example](https://github.com/Kozea/WeasyPrint/blob/e4b8b45e409392197441bc449d110f323b0eeb66/docs/first_steps.rst#L406-L424).
+- [Paged.js MIT](https://github.com/pagedjs/pagedjs/blob/6b0ff8089f472a17247e44671da93d2d931e656e/LICENSE.md).
+- [Vivliostyle AGPL-3.0](https://github.com/vivliostyle/vivliostyle-cli/blob/0db54ab6005ad20987de5ed36a8d543f82665f36/LICENSE).
+- [Benchmark MIT](https://github.com/NicolasMartalog/html-to-pdf-benchmark/blob/1a290622403ffbecc2065d6e00b0e25bae34f59e/LICENSE).
+- [Noto Sans OFL-1.1](https://github.com/notofonts/noto-cjk/blob/f8d157532fbfaeda587e826d4cd5b21a49186f7c/Sans/LICENSE).
+
+## How the synthesis fits together
+
+The reader's question chooses the representation. Audience and document genre
+choose the composition. A single set of tokens joins prose, tables and SVG.
+Interaction changes a real model, then print captures its chosen state. Output
+engines supply the mechanics; final semantic and visual checks establish delivery.
+This is why the source list becomes a few focused references rather than sixteen
+competing style guides loaded on every request.
+
+The current host's `visualize` skill supplies inline behavior; none of these
+repositories supplies Codex renderer compatibility. Production frontend and
+format-specific document owners remain authoritative in their own domains.
+
+## Extending or refreshing the skill
+
+Inspect the actual source file and its license at a recorded revision before
+copying anything. Repository visibility and a README badge are insufficient when
+a subdirectory has its own license. For copied/substantially adapted MIT/BSD
+material retain required notices; Apache copies also need applicable notices and
+modification markings. Inspect font/artwork licenses separately. Record source,
+revision, changed file and retained notice location beside the adaptation.
+
+Prefer independently authored recipes when only the general idea is needed.
+Do not paste a conflicting upstream mandate into this skill. Recheck live dates
+before describing a source as current; inspect examples before claiming visual
+quality. Dependencies, accounts and host integrations require actual availability
+and task authorization, not just a link in this ledger.

--- a/plugins/codexclaw/skills/dev-diagram-viewer/reference/svg-and-interaction.md
+++ b/plugins/codexclaw/skills/dev-diagram-viewer/reference/svg-and-interaction.md
@@ -1,0 +1,138 @@
+# SVG geometry and meaningful interaction
+
+Use after [visual design](visual-design.md). This reference guides authoring;
+it does not establish host capabilities or add runtime enforcement.
+The current host contract governs inline output; requested files retain their format.
+
+## Choose the layout authority
+
+| Deliverable | Text layout | Appropriate export |
+|---|---|---|
+| Responsive HTML explanation | Semantic HTML in Grid/Flex normal flow | HTML; print through document owner |
+| Editable standalone SVG | Measured SVG text and deliberate geometry | Real `.svg` with native text/shapes |
+| HTML chart | SVG/canvas marks plus HTML labels/table as appropriate | Explicit vector or raster snapshot |
+| Host-inline widget | Only the current host's supported layout | Export only through verified capability |
+
+For HTML, do not place text-bearing nodes using hand-calculated absolute positions.
+Use intrinsic sizing, `gap`, wrapping and `min-width: 0`; stack groups at narrow widths.
+If SVG connects HTML nodes, derive endpoints from rendered node bounds in one coordinate
+space; recompute after resize, font loading, content changes and disclosure.
+Keep decorative connector overlays out of the reading order and pointer hit path.
+
+Standalone SVG is a different medium: native coordinates are necessary and legitimate.
+Measure text, size nodes, then arrange them; do not force labels into prechosen boxes.
+Do not wrap an HTML screenshot in SVG and call it editable vector output.
+`foreignObject` can use HTML flow in a browser, but is not a portable native-text export.
+For a native SVG request, use `<text>`/`<tspan>` or disclose and test the specific viewer limit.
+
+## Size for the actual reader
+
+Choose a `viewBox`, intended display width and intended export dimensions together.
+A `viewBox="0 0 960 480"` at 320 CSS px scales 14-unit labels to about 4.7px;
+being vector does not make that readable. Container padding can reduce it further.
+Measure the rendered SVG rectangle, not just the browser viewport.
+For uniform scaling, use the smaller width/height scale when both constrain the viewport.
+Adapt by reducing scope, splitting figures or making a narrow composition, not shrinking text.
+A zoomable overview may have detail controls, but provide readable labels at the stated default size.
+For fixed-size exports, state the intended size and inspect it; do not claim universal responsiveness.
+
+## Measure, wrap, then lay out
+
+1. Select font stack, real weight, size and line spacing; wait for available fonts to settle.
+2. Measure each candidate line with the rendered SVG font, for example
+   `getComputedTextLength()` on a measurement `<text>` element in the document.
+3. Break at meaningful words/phrases; SVG `<text>` does not automatically wrap like a paragraph.
+4. Emit one `<tspan>` per line with an explicit starting `x` and baseline offset.
+5. Size the node from measured maximum width, line count, ascent/descent and padding.
+6. Arrange nodes and route connectors outside label bounds; reserve room for arrowheads.
+7. Inspect rendered bounds and actual screenshots, including the longest-label state.
+
+Do not substitute character-count times a fixed width for measurement, especially with CJK.
+If a token exceeds the line budget, widen/split the figure or wrap at grapheme boundaries;
+never split surrogate pairs/combining sequences or silently remove qualifiers and units.
+Re-measure after fallback fonts, changed text or changed weight. Canvas measurement can help
+estimate layout, but inspect final SVG text because shaping and fallback may differ.
+`getBBox()` helps inspect geometry; account separately for strokes, markers and clipping.
+Do not use `textLength` to squeeze a long label into an unreadable narrow box.
+
+Example native text structure; dimensions must still be measured for the chosen font:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 160"
+     width="320" height="160" role="img" aria-labelledby="flow-title" aria-describedby="flow-desc">
+  <title id="flow-title">검토 단계</title>
+  <desc id="flow-desc">계약 조건 검토 후 담당자의 승인을 기다리는 단계.</desc>
+  <rect x="16" y="28" width="288" height="104" rx="8" fill="#eef3f6"/>
+  <text x="32" y="68" font-family="sans-serif" font-size="18" fill="#182c39">
+    <tspan x="32">계약 조건 검토 후</tspan>
+    <tspan x="32" dy="28">담당자 승인 대기</tspan>
+  </text>
+</svg>
+```
+
+Give each figure unique IDs, escaped text, a descriptive title and useful description.
+Keep `<defs>`/markers self-contained; define export styles inside the SVG rather than
+depending on an HTML ancestor's CSS variables. Preserve text for editing and selection.
+Converting text to paths sacrifices that property; offer it only as an explicitly chosen variant.
+Check font embedding permissions if embedding fonts; otherwise disclose required fonts/fallbacks.
+Reopen the saved SVG itself, XML-parse it and inspect a render at 320/736px and export size.
+Check labels against node edges, other labels, connectors and the outer viewport.
+
+## Interaction should answer a question
+
+Name input → transformation → output before adding a control.
+Good: requests/s → required capacity and monthly cost, with an explicit capacity model.
+Weak: a slider that changes only decorative color while the explanation stays identical.
+Use one shared state model to update values, marks, table, caption and export summary.
+Local calculation/filtering must work without a model call or automatic message submission.
+Treat imported data and returned selections as data; render labels with safe text insertion.
+
+Example illustrative model, with every constant labeled as an assumption:
+
+```text
+input: demand r requests/s, integer 0..1000
+assume: each server handles 100 requests/s; price $30/server/month; no redundancy
+servers = ceil(r / 100); cost = servers * 30
+baseline r=200 → 2 servers, $60/month
+chosen r=350 → 4 servers, $120/month; reset returns to r=200
+```
+
+Explain that this models capacity, not latency or availability; disclose omitted costs.
+Test boundaries 0, 100 and 101, a nondefault value, invalid input and reset.
+Reject invalid input visibly instead of showing a plausible number from stale state.
+Label controls with units/ranges; show current values as text and keep focus stable during updates.
+Use native buttons, labeled inputs and disclosure controls; provide numeric input beside a slider
+when precision matters. Keep drag/pan alternatives and zoom/reset buttons keyboard-reachable.
+Expose focus visibly; use concise live announcements for committed changes, not every animation frame.
+Tooltips must also be available on focus, and must not contain the only explanation of a mark.
+Honor reduced motion, provide pause for ongoing animation and retain all meaning without movement.
+
+## Dependencies, offline use and export state
+
+| Mode | Promise only when… | Failure behavior |
+|---|---|---|
+| Fully embedded file | CSS, JS, data and required assets are inside it | Verify with network blocked |
+| Local asset bundle | Relative files travel with the document | List the bundle; test moved location |
+| Network-dependent page | Remote URLs and versions are declared | Show error plus usable static evidence |
+
+A single HTML file with CDN scripts or remote fonts is not inherently offline.
+Prefer small native controls and inline marks when they cover the task; use a library only
+for a named need. Verify its current API, exact version, license and exporting behavior.
+Do not install or start a server merely because an upstream skill assumes one.
+Storage and agent bridges are optional host capabilities, not prerequisites for reading.
+Use in-memory state by default; add persistence only when requested and actually supported.
+If scripting or a dependency fails, retain labeled static data/assumptions and explain what is unavailable.
+
+Before print/export, settle fonts and computation, stop animation and expose the chosen inputs.
+Print a visible state summary with units and active filters; default and selected states must not mix.
+Include required disclosed content, remove scroll clipping, and keep table rows and headers readable.
+Do not compress a multipage table onto one page or silently print only the visible screenful.
+Ensure canvas marks are captured by the exporter or provide an explicit static alternative.
+Verify a nondefault state's printed value and marks against the live state; pagination belongs to
+the document/PDF owner. A screenshot of HTML does not establish SVG or PDF export fidelity.
+
+## Provenance
+
+Original adaptation of [local parameter exploration](https://github.com/f-labs-io/agent-html-skills/blob/d4f259ea4959aecd1240a10c60a950dfb6d1a3f5/plugins/html-skills/skills/html-interactive-playground/SKILL.md#L35-L79)
+and [SVG accessibility/direct annotation patterns](https://github.com/Angelopvtac/explainer-pack/blob/09fd3f1de384d71858f0ba678af2abc5721907d1/skills/Explainer/References/Aesthetic.md#L133-L180).
+Sources inspected 2026-09-08; no receiver code, fixed theme or upstream implementation is copied.

--- a/plugins/codexclaw/skills/dev-diagram-viewer/reference/visual-design.md
+++ b/plugins/codexclaw/skills/dev-diagram-viewer/reference/visual-design.md
@@ -1,0 +1,138 @@
+# Visual design for explanatory documents
+
+Use this reference to choose composition and visual language before authoring.
+These are agent instructions, not runtime enforcement or a mandatory template.
+Preserve the requested format, supplied template, brand and content coverage.
+Use [SVG and interaction](svg-and-interaction.md) for geometry and behavior.
+
+## Establish the reading task
+
+State the audience, the question the artifact answers, and its intended size.
+Distinguish a document read once from a reference searched repeatedly.
+Choose a useful first viewport: conclusion, decisive comparison or mechanism.
+Keep assumptions and source dates visible near the claims they qualify.
+Do not infer a slide deck, theme picker or interactive application from “visual.”
+
+Example brief: “For engineering leads deciding capacity, compare observed demand
+with modeled headroom; show units, assumptions and a changeable demand input.”
+That suggests a comparison plus a local model, not a decorative architecture map.
+
+## Select a representation
+
+| Reader needs to… | Start with… | Preserve… |
+|---|---|---|
+| Compare exact values | Semantic table or aligned dot plot | Units, common scale and full labels |
+| Understand change over time | Line chart with dated observations | Missing intervals and forecast boundary |
+| Understand a mechanism | Annotated flow or sequence | Direction, action verbs and branching conditions |
+| Find responsibility | Lanes or grouped hierarchy | Ownership and cross-boundary handoffs |
+| Explore sensitivity | Input, computed result and comparison | Formula, range and baseline |
+| Read an argument | Prose with supporting figures | Qualifications, evidence and counterexamples |
+
+Give each figure one intended takeaway; write its caption before drawing it.
+“Retries amplify load after timeouts” determines edges better than “System diagram.”
+If labels explain everything while geometry explains nothing, revise the encoding.
+For dense systems, pair a small overview with named detail sections and cross-links.
+Do not require a diagram in every section or reduce nuanced evidence to captions.
+
+## Compose a document, not a collection of panels
+
+Group by the reader's question; use headings that identify the answer or subject.
+Reserve the strongest size/contrast for the main result, then its supporting proof.
+Use proximity and alignment before adding borders, backgrounds or containers.
+Cards suit independently actionable items; aligned rows suit repeated comparisons.
+Use numbering for order, stages or stable references, not decorative credibility.
+Keep related charts adjacent with matched axes; stack them with the same order on mobile.
+Separate evidence from interpretation with captions or labels, not unexplained color.
+Place definitions near first use; put optional derivations in clearly named disclosure.
+Long tables remain complete: split or paginate appropriately rather than dropping rows.
+
+## Four optional art directions
+
+Choose one only when it fits the audience. These recipes illustrate decisions;
+their colors, proportions and typefaces are replaceable, not universal bans.
+
+### Technical review sheet — maintainers comparing mechanisms
+
+- Surface `#f4f7fa`, ink `#152b3a`, accent `#176b83`; give state colors separate roles.
+- Use a restrained sans heading/body stack; mono only for paths, identifiers and values.
+- Compose a compact conclusion above a large mechanism figure and aligned evidence rows.
+- Use lane headers and fine rules to expose boundaries; omit display-sized marketing text.
+- Good for architecture and change reviews; excessive chrome would compete with topology.
+
+### Editorial argument — policy or strategy readers
+
+- Surface `#fffdf9`, ink `#242320`, accent `#315c9b`; keep charts' semantic palette distinct.
+- Pair a serif display face with a readable sans body; verify the required language coverage.
+- Use an asymmetric opening, a narrow reading column and occasional full-width comparisons.
+- Use pull quotes only for meaningful source quotations with attribution; no invented testimony.
+- Good for a sustained argument; switch to denser aligned rows for audit evidence.
+
+### Operational reference — repeated expert lookup
+
+- Surface `#151c21`, ink `#edf2f5`, accent `#e9b85c`; provide deliberate paper-safe colors.
+- Use compact sans headings, aligned numeric columns and stable positions for labels/units.
+- Put a status summary above indexed sections; let the reader reach raw values quickly.
+- Use shape and text as well as status color; animate only a change that needs attention.
+- Good for live or frequently revisited evidence; a dark palette alone does not imply freshness.
+
+### Teaching notebook — learners testing a causal model
+
+- Surface `#f8faf4`, ink `#243329`, accent `#35634d`; highlight one changing variable at a time.
+- Use generous body leading, short headings and a stable baseline beside the experiment.
+- Sequence question, prediction, control and observed/model output; expose assumptions nearby.
+- Use direct annotations and a visible reset; avoid scroll animation that hides causal steps.
+- Good for guided understanding; keep an equivalent static explanation available for print.
+
+## Type and CJK hierarchy
+
+Set type by role: title, section heading, body, caption, data and code.
+For ordinary screen documents, start around 16–18px body and 1.5–1.75 leading;
+adjust after inspecting the actual face, density and intended viewing distance.
+Use rem for document text so one root setting scales it coherently.
+Start Latin prose around 60–70ch; `ch` measures the zero glyph, not CJK characters.
+For Korean, Chinese and Japanese, judge the actual column and glyphs at rendered width.
+Use language-appropriate fallbacks and real weights; Latin-only fonts cannot establish CJK quality.
+Avoid applying Latin uppercase/tracking treatments to whole Korean or Japanese headings.
+Use size, weight, spacing and position to distinguish CJK headings from body text.
+
+```css
+.reading { max-inline-size: 65ch; line-height: 1.65; }
+.reading:lang(ko) { max-inline-size: 36em; word-break: keep-all; }
+.reading p { overflow-wrap: anywhere; }
+.reading h1, .reading h2 { text-wrap: balance; }
+.reading code, .reading a { overflow-wrap: anywhere; }
+.numeric { font-variant-numeric: tabular-nums; }
+```
+
+This is a starting point, not proof of correct wrapping. Set the document's `lang`.
+Keep Korean phrase boundaries where possible; allow emergency wrapping of long tokens.
+Do not apply Korean `keep-all` indiscriminately to Chinese/Japanese line breaking.
+Inspect mixed Hangul/Latin identifiers, punctuation, units and fallback glyphs.
+Fix stranded endings such as “합니다.” by adjusting measure or phrasing without changing meaning.
+Do not insert viewport-specific hard breaks or ellipsize evidence to make a heading fit.
+Check font-loaded and fallback states; do not assume matching font names mean identical metrics.
+
+## Truthful charts and evidence
+
+- State source, observation period, units, denominator and relevant aggregation/filter.
+- Mark illustrative data and modeled/forecast values explicitly; do not imply measurements.
+- Use zero baselines for bars encoding magnitude; disclose justified truncation on other axes.
+- Use comparable axes across comparisons; disclose log scales and avoid decorative 3D distortion.
+- Encode area by area, not radius; prefer position/length when precise comparison matters.
+- Keep missing data distinct from zero; show uncertainty when the source provides it.
+- Do not connect missing observations or extrapolate without labeling the inference.
+- Calculate totals from unrounded data; explain rounding differences rather than altering rows.
+- Use labels, patterns or shapes alongside color; supply an accessible table for exact values.
+- In filtered views, identify both selected and total populations so the denominator stays clear.
+
+## Review and provenance
+
+Inspect the first viewport, longest text and dense comparisons at 320, 360, 736
+and 1280 CSS pixels, plus the requested output size. Resize between presets.
+Check zoom, contrast, reading order and that decorative emphasis does not outrank evidence.
+This review is an authoring obligation; a source scan alone cannot establish visual success.
+
+Original synthesis of mechanism/composition guidance and audience-first selection:
+[visual-explainer, pinned skill](https://github.com/nicobailon/visual-explainer/blob/7163c3e10660912e0b89e1af465db9f387282b88/plugins/visual-explainer/SKILL.md#L32-L109)
+and [taste-skill, brief inference](https://github.com/Leonxlnx/taste-skill/blob/ccbc15639c97057cbfcf32ecebc38ef716e4bb37/skills/taste-skill/SKILL.md#L13-L75).
+Sources inspected 2026-09-08; recipes and examples above are newly authored.

--- a/plugins/codexclaw/skills/dev/SKILL.md
+++ b/plugins/codexclaw/skills/dev/SKILL.md
@@ -148,7 +148,7 @@ numbered, contiguous, non-overlapping chunks through EOF and verify no gaps.
 | DevOps / deploy / infra | `dev-devops` | `dev-security` for credentials |
 | Scaffolding / docs / setup | `dev-scaffolding` | `dev-architecture` for boundaries |
 | Code review | `dev-code-reviewer` | `dev-security` + `dev-testing` |
-| Diagrams / charts | `dev-diagram-viewer` | — |
+| Diagrams / charts / visual documents / reports / PDF composition | `dev-diagram-viewer` | Available document-format owner for PDF/DOCX/Slides mechanics; `dev-frontend` and `dev-uiux-design` retain implementation/design ownership |
 
 ### Subagent Skill Injection (DEV-SKILL-INJECT-01)
 Attach `cxc-dev` and every relevant surface skill explicitly to governed subagents.

--- a/plugins/codexclaw/skills/dev/references/skill-ownership.md
+++ b/plugins/codexclaw/skills/dev/references/skill-ownership.md
@@ -27,6 +27,7 @@ Each rule area has exactly one canonical owner. Other skills may contain stubs b
 | Frontend implementation | `dev-frontend` | `dev-uiux-design` |
 | Design intent discovery | `dev-uiux-design` | `dev-frontend` |
 | Design judgment | `dev-uiux-design` | `dev-frontend` |
+| Visual document composition / diagram and report delivery | `dev-diagram-viewer` | `dev`; format-specific document owners retain PDF/DOCX/Slides mechanics |
 | Operational gates | `dev-devops` | `dev-backend`, `dev-scaffolding` |
 | Project scaffolding / docs | `dev-scaffolding` | `pabcd` |
 | C0/C1 classification and record exemption | dev §0.0/§0.1 | pabcd, dev-scaffolding |


### PR DESCRIPTION
Promote the visual document skill release from dev to main.

Includes HTML reports, editable SVG, interactive explainers and verified PDF delivery, with source/license references and an original Korean report example. Version surfaces are synchronized at 0.2.23; dependencies and test definitions are unchanged.

Feature PR #85 passed all 11 checks, including four CI platform/line-ending configurations, packed-install lifecycle and WSL. Promotion and final main checks must pass before the Release workflow publishes v0.2.23.
