### PR TITLE
chore(release): prepare 0.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to codexclaw are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses
 [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.24] - 2026-09-08
+
+### Added
+
+- Reader-facing document structure: `cxc-dev` `references/reader-documents.md`
+  (READER-DOC-01..05) — reader contract, answer first (SCQA / 두괄식), claim-shaped
+  descending sections, evidence separated into an anchored appendix, fresh-reader
+  check — routed from `cxc-dev-diagram-viewer`, `cxc-pabcd` plan/check/D,
+  `cxc-dev-scaffolding` implementation-log and `cxc-kwrite`.
+- Deep research protocol: `cxc-search` `references/deep-research.md`
+  (SEARCH-DEEP-01..06) with query families, gap matrix, budgets and stop rules,
+  claim-to-source ledger, `report-source.md`, artifact delivery and an Aside
+  browser lane; triggers 딥리서치 / 심층 조사 / deep-research; aligned with the host
+  deep-research skill.
 
 ### Fixed
 
@@ -13,6 +26,9 @@ All notable changes to codexclaw are documented here. The format follows
   follow that tree while native session identity and evidence storage stay put.
   `session current --json` exposes a bound source snapshot for QA/review producers.
   Refuse missing/switched source roots instead of accepting them as implementation.
+  (#84, thisisjun786). Canonicalize binding paths with `realpathSync.native` so Windows
+  8.3 short-name temp directories bind, and strip inherited Git routing variables from
+  source capture and the receipt command so a receipt never describes another tree.
 
 ## [0.2.23] - 2026-09-08
 
@@ -63,8 +79,6 @@ All notable changes to codexclaw are documented here. The format follows
   with host permission and wake checks. Routine progress notices and unsolicited
   follow-ups stay in the current task; read-only context and authorized subagents
   remain available.
-
-## [Unreleased]
 
 ## [0.2.16] — 2026-08-30
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "codexclaw CLI \u2014 status, subagent config, provider toggle, GUI launcher.",

--- a/devlog/_plan/260908_narrative_documents/000_plan.md
+++ b/devlog/_plan/260908_narrative_documents/000_plan.md
@@ -91,3 +91,10 @@ See 001_sources.md for research and 002_verifiers.md for commands with observed 
   not described) which is a property of the input dump, not of the reference; direction kept.
 - wp3 P (re-entry): implement 020 as written; SKILL.md Tier 3 replacement is net-negative
   (268 -> 240 lines); Aside permission text uses guard default per audit fold.
+- wp3 D: DONE at 260469de. Two trial leaves stalled after planning with zero opens;
+  the reference now requires opening sources in wave 1 and incremental artifacts; trial 3
+  completed with 12 opens and a rendered report. Direction kept.
+- wp4 P (re-entry): 030 amended in the field — maintainerCanModify path taken; merge commit
+  2947266b pushed to the fork; Windows CI exposed an 8.3 short-name path bug in the PR's
+  session-source.ts (SOURCE-ROOT refusal), reproduced on desktop-c795oh4 with TEMP forced
+  to a short name and fixed with realpathSync.native (bb204ead). Waiting on exact-head CI.

--- a/devlog/_plan/260908_narrative_documents/000_plan.md
+++ b/devlog/_plan/260908_narrative_documents/000_plan.md
@@ -98,3 +98,9 @@ See 001_sources.md for research and 002_verifiers.md for commands with observed 
   2947266b pushed to the fork; Windows CI exposed an 8.3 short-name path bug in the PR's
   session-source.ts (SOURCE-ROOT refusal), reproduced on desktop-c795oh4 with TEMP forced
   to a short name and fixed with realpathSync.native (bb204ead). Waiting on exact-head CI.
+- wp4 D: DONE. PR #84 merged as c44ab989 after three review rounds surfaced two real
+  environment-leak defects on top of the Windows short-name failure; all fixed with
+  red/green tests. TOCTOU on the sources dir is recorded as follow-up, not fixed.
+- wp5 P (re-entry): 040/050 re-verified against dev c44ab989 (PRs #87 and #84 both in).
+  Version surfaces to bump: package.json, cli, 8 component package.json, gui, lock,
+  plugin.json stamp, inventory.json, CHANGELOG (top Unreleased -> 0.2.24; stale one deleted).

--- a/devlog/_plan/260908_narrative_documents/evidence/wp4/pr84-checks-c0f466d2.txt
+++ b/devlog/_plan/260908_narrative_documents/evidence/wp4/pr84-checks-c0f466d2.txt
@@ -1,0 +1,10 @@
+artifact (macos-latest)	pass	16s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089768/job/101923062598	
+artifact (ubuntu-latest)	pass	10s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089768/job/101923062597	
+artifact (windows-latest)	pass	30s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089768/job/101923062560	
+install (macos-latest)	pass	35s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089768/job/101923062657	
+install (ubuntu-latest)	pass	20s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089768/job/101923062368	
+test (macos-latest, false)	pass	2m31s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089685/job/101923062406	
+test (ubuntu-latest, false)	pass	1m28s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089685/job/101923062352	
+test (windows-latest, false)	pass	4m12s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089685/job/101923062391	
+test (windows-latest, true)	pass	3m40s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089685/job/101923062191	
+wsl	pass	11m34s	https://github.com/lidge-jun/codexclaw/actions/runs/34182089702/job/101923062230	

--- a/devlog/_plan/260908_narrative_documents/evidence/wp4/pr84-merged.json
+++ b/devlog/_plan/260908_narrative_documents/evidence/wp4/pr84-merged.json
@@ -1,0 +1,1 @@
+{"headRefOid":"c0f466d223064779d0679baf19ce06e97f4bd56b","mergeCommit":{"oid":"c44ab989cd9b61c01a39c7d2eb12395dcaf66d88"},"mergedAt":"2026-09-08T03:15:14Z"}

--- a/devlog/_plan/260908_narrative_documents/evidence/wp4/review-verdict.md
+++ b/devlog/_plan/260908_narrative_documents/evidence/wp4/review-verdict.md
@@ -1,0 +1,61 @@
+Review anchor: `/private/tmp/pr84-merge-260908`, HEAD `bb204ead04935a8970c3b9f70f9019eebb74e8f6`; base/merge-base `50b7309c`. `2947266b` is the merge commit, not the dev parent. GitHub PR #84 currently matches this head and targets dev.
+
+Automated checks: Node 24.17.0 build succeeded (160 modules); **no dist file changed**. Initial/final status contains only the pre-existing untracked `node_modules`. Requested pabcd-state dist diff: 13 files, +251/-24. Four focused files (source-identity, worktree-source-integration, final-gate-guard, qa-validate-evidence): **73 passed, 0 failed/skipped**. Diff whitespace check passed. Expected negative Git-fixture stderr and Node experimental warning observed. Full suite, dedicated SAST, Linux/Windows runtime checks were not run.
+
+BLOCKERS
+
+- **High — wrong-tree receipts accepted (verified).** `plugins/codexclaw/components/pabcd-state/src/session-source-identity.ts:7` passes the bound cwd to a capture helper whose Git subprocess inherits `GIT_DIR`/`GIT_WORK_TREE` (`src/source-identity.ts:58`). Binding verification clears these variables, but capture and receipt execution do not. With both variables pointing at the native repository, an isolated real-worktree probe changed the bound source during `runReceiptCli`; result: `receiptExit:0`, source contents `MUTATED`, `validateCheckReceipt:{ok:true}`. The new wrapper labels native-tree hashes with the bound `sourceRoot`. Sanitize Git-routing variables consistently for bound capture and command execution; add this negative regression. Existing 73 passing tests do not exercise it.
+
+NITS
+
+- **Low — parent-directory TOCTOU (verified).** `plugins/codexclaw/components/pabcd-state/src/session-source.ts:119`: replacing `sources` with a symlink after validation redirects temporary creation/hard-link publication outside the directory. Deterministic syscall-boundary injection created the external binding; final validation then refused. `O_NOFOLLOW` protects the leaf, not ancestors; `linkSync` preserves an existing destination but does not pin its parent. Non-blocking under the documented exclusion of hostile same-user filesystem edits; document trusted ancestors or harden publication if that threat becomes supported.
+
+Fix assessment: `.native` correctly handles ordinary macOS symlink/case aliases; probes confirmed alias binding, case-variant idempotence, and that retargeting the input symlink does not retarget the stored physical worktree. It is not universally equivalent: native symlink limits differ, and Linux musl requires mounted `/proc` ([Node documentation](https://nodejs.org/api/fs.html#fsrealpathsyncnativepath-options)). `session-binding.ts:31,74` still uses JS realpaths and merits paired native normalization for mixed short/long or case spellings; this is pre-existing, not a new blocker. Other family calls do not feed this binding comparison.
+
+Coverage: all 43 changed files accounted for—29 non-dist files reviewed (including three devlog records, three README badges, tests, workflow and changelog); 14 generated dist files verified by unchanged rebuild. README aggregate test totals were not independently reproduced. CHANGELOG preserves all dev release entries and adds only the intended Unreleased entry.
+
+VERDICT: FAIL
+
+## Fold (main, 2026-09-08)
+
+Blocker (wrong-tree receipts): source-identity.ts now strips GIT_DIR/GIT_WORK_TREE/
+GIT_COMMON_DIR/GIT_INDEX_FILE/GIT_OBJECT_DIRECTORY/GIT_ALTERNATE_OBJECT_DIRECTORIES before
+every git call; negative regression "capture ignores inherited GIT_DIR/GIT_WORK_TREE"
+fails on the previous source (22 pass / 1 fail) and passes after (40/0 with the
+integration file). Commit 0671be68 pushed to the PR head.
+Nit (parent-directory TOCTOU on .codexclaw/sources): accepted as out of scope under the
+documented same-user hostile-filesystem exclusion; recorded here for a follow-up issue.
+Nit (session-binding.ts JS realpath): pre-existing, not part of PR #84; recorded.
+
+## Round 2
+
+Anchors: `/private/tmp/pr84-merge-260908`; previous reviewed head `bb204ead04935a8970c3b9f70f9019eebb74e8f6`; new head `0671be68738eec1d88e16c1653828dbef838f8ee`. Reviewed all three interdiff files: source-identity.ts, its generated dist/source-identity.js, and source-identity.test.ts. Revisited receipt-cli.ts as the downstream execution boundary.
+
+Automated evidence: source-identity + worktree-source-integration tests: **40 pass, 0 fail/skipped**. Requested build succeeded (160 modules); `git diff --exit-code -- plugins/codexclaw/components` passed, confirming no dist changes. Status still contains only pre-existing untracked `node_modules`. `git diff --check bb204ead..HEAD` reports a non-blocking extra blank line at source-identity.test.ts:300.
+
+Original probe: **fixed**. With inherited native GIT_DIR/GIT_WORK_TREE, a command mutating the bound source now returns code 1, “command changed the source,” without a receipt. A non-mutating command produces a receipt in native `.codexclaw/evidence` with the correct bound root and dirty identity; Check accepts it, then rejects a subsequent source edit.
+
+BLOCKERS
+
+- **High — command execution still checks the wrong repository (verified).** `plugins/codexclaw/components/pabcd-state/src/receipt-cli.ts:134` changes cwd but leaves the child environment inherited. The original request to sanitize command execution remains unresolved. Isolated fixture: native tree clean, bound source tracked file dirty, GIT_DIR/GIT_WORK_TREE pointing at native; receipt command `git diff --exit-code --quiet` returns **0**, publishes a receipt, and `validateCheckReceipt` returns **ok:true**. An independent control runs that exact command against the bound source with those variables removed and returns **1**. Capture now correctly describes the source, but the recorded successful check ran against native Git state. Apply equivalent Git-routing environment sanitization to the bound command spawn and add an execution-level regression. The new unit regression only verifies capture.
+
+NITS
+
+- `plugins/codexclaw/components/pabcd-state/test/source-identity.test.ts:300`: extra blank line at EOF (style only).
+- Prior parent-directory TOCTOU remains accepted out of scope under the documented same-user exclusion, as instructed; no new blocker assigned to it.
+
+VERDICT: FAIL
+
+## Round 3
+
+Anchors: `/private/tmp/pr84-merge-260908`; previous reviewed head `0671be68738eec1d88e16c1653828dbef838f8ee`; current head `6aa739cc649df1f252fa0fd6585146443287f14f`. Reviewed all six interdiff files: src/receipt-cli.ts, src/source-identity.ts, their two dist files, source-identity.test.ts, and worktree-source-integration.test.ts. Also checked win-exec.ts options: they do not supply an environment that the new spawn option would accidentally discard.
+
+Automated evidence: source-identity + worktree-source-integration tests: **41 pass, 0 fail/skipped**. Requested build succeeded (160 modules), and component diff against HEAD is empty: **no dist file changed**. Checkout still contains only the pre-existing untracked `node_modules`. Whitespace check reports a style-only extra EOF blank line in worktree-source-integration.test.ts:280; the previous source-identity.test.ts blank line is fixed.
+
+Independent probe against current HEAD: with inherited GIT_DIR/GIT_WORK_TREE pointing at the native repository, a clean bound tree produces a valid receipt stored in native `.codexclaw/evidence`, carrying the correct sourceRoot. Editing the bound source invalidates that receipt. Re-running `git diff --exit-code --quiet` now exits **1**, matching the independently sanitized control, and leaves **no receipt** (including removal of the previous success). A command mutating the bound source during execution also returns **1** without a receipt. Both previously reported correctness blockers are resolved.
+
+BLOCKERS: None remaining in the reviewed scope.
+
+NITS: `plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts:280` extra EOF blank line, style only. Prior parent-directory TOCTOU remains the explicitly accepted out-of-scope follow-up; pre-existing native-session realpath normalization remains unchanged. This round supplies macOS focused evidence, not a new full-suite or Linux/Windows certification.
+
+VERDICT: PASS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexclaw",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexclaw",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "license": "MIT",
       "workspaces": [
         "plugins/codexclaw/components/*",
@@ -20,7 +20,7 @@
     },
     "cli": {
       "name": "@codexclaw/cli",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "bin": {
         "codexclaw": "bin/codexclaw.mjs"
       }
@@ -1949,39 +1949,39 @@
     },
     "plugins/codexclaw/components/config-guard": {
       "name": "@codexclaw/config-guard",
-      "version": "0.2.23"
+      "version": "0.2.24"
     },
     "plugins/codexclaw/components/cxc-ops": {
       "name": "@codexclaw/cxc-ops",
-      "version": "0.2.23"
+      "version": "0.2.24"
     },
     "plugins/codexclaw/components/messenger-bridge": {
       "name": "@codexclaw/messenger-bridge",
-      "version": "0.2.23"
+      "version": "0.2.24"
     },
     "plugins/codexclaw/components/pabcd-state": {
       "name": "@codexclaw/pabcd-state",
-      "version": "0.2.23"
+      "version": "0.2.24"
     },
     "plugins/codexclaw/components/provider-bridge": {
       "name": "@codexclaw/provider-bridge",
-      "version": "0.2.23"
+      "version": "0.2.24"
     },
     "plugins/codexclaw/components/recall": {
       "name": "@codexclaw/recall",
-      "version": "0.2.23"
+      "version": "0.2.24"
     },
     "plugins/codexclaw/components/skill-search": {
       "name": "@codexclaw/skill-search",
-      "version": "0.2.23"
+      "version": "0.2.24"
     },
     "plugins/codexclaw/components/subagent-config": {
       "name": "@codexclaw/subagent-config",
-      "version": "0.2.23"
+      "version": "0.2.24"
     },
     "plugins/codexclaw/gui": {
       "name": "@codexclaw/gui",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.23+codex.20260908004251",
+  "version": "0.2.24+codex.20260908031619",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "codexclaw ops CLI \u2014 doctor (plugin health), reset (scoped state cleanup).",

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "codexclaw messenger bridge \u2014 cxc serve HTTP server + SQLite state substrate (zero third-party deps).",

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "private": true,
   "type": "module",
   "description": "codexclaw local dashboard (Vite + React) \u2014 subagent config, prompts, provider link bar.",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.23+codex.20260908004251",
-    "packageVersion": "0.2.23"
+    "manifestVersion": "0.2.24+codex.20260908031619",
+    "packageVersion": "0.2.24"
   },
   "skills": [
     {
@@ -263,49 +263,49 @@
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "hasTests": true
     }
   ]


### PR DESCRIPTION
Bump every version surface from 0.2.23 to 0.2.24 (root, cli, gui, eight component packages, lock, plugin manifest stamp `0.2.24+codex.20260908031619`, inventory) and turn the CHANGELOG's Unreleased section into `[0.2.24] - 2026-09-08`. The stale empty Unreleased heading that sat below 0.2.19 is removed.

Release contents already on dev: reader-first document structure and the deep research protocol with Aside lane (#87), and worktree source binding with the Windows short-name and Git-environment fixes (#84).

Validation: `check-versions.mjs 0.2.24` OK on every surface; `skill-catalog.test.mjs` 4 pass; inventory regenerated with the measured suite count (2670). Also carries the devlog record for the wp4 integration.
