### PR TITLE
test: cover Windows short-path source bindings

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C670_passing-brightgreen" alt="2,670 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C671_passing-brightgreen" alt="2,671 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C670_passing-brightgreen" alt="2,670 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C671_passing-brightgreen" alt="2,671 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C670_passing-brightgreen" alt="2,670 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C671_passing-brightgreen" alt="2,671 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-23-blue" alt="23 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260907_worktree_source_binding/030_short_path_regression.md
+++ b/devlog/_plan/260907_worktree_source_binding/030_short_path_regression.md
@@ -1,0 +1,32 @@
+# Preserve Windows 8.3 regression coverage
+
+PR #84 merged the native-path fix in bb204ead04935a8970c3b9f70f9019eebb74e8f6.
+The runtime behavior and fixture canonicalization are already present on dev and
+main. The actual short-name regression from thisisjun786/codexclaw#1 was not
+included, so this follow-up carries only that coverage forward.
+
+The test asks cmd.exe for the fixture's real 8.3 alias, binds using short paths,
+then checks resolution and byte-preserving repeat binding using long paths.
+It also checks the source command's native cwd, pinned source root, B/C
+progression, and a validated receipt executed in the linked worktree.
+The test explicitly skips outside Windows or when the temporary volume does
+not provide 8.3 aliases. Production code is unchanged.
+
+Verification on Node 24.15.0:
+
+- Windows: the new regression passed without skipping.
+- WSL Ubuntu: the affected integration file passed 18 tests with zero failures;
+  the Windows-only regression skipped. This includes the damaged-symlink case
+  and the shipped CLI flow.
+- Repository gate and whitespace checks passed.
+- Full Windows suite: 2,671 tests, 2,580 passed, 81 skipped, 10 failed. The
+  failures are the nine existing session-binding symlink fixtures and the
+  damaged-symlink integration case on this host without symlink creation
+  permission. The new regression passed. No failing test was weakened or
+  suppressed; this is not a green full-suite result.
+- Published test-count badges were updated from the measured total using
+  `inventory.mjs --write --tests 2671`; the measured-count check passed.
+
+The original version of this regression was verified red before the native-path
+fix and green after it in the earlier follow-up. The current run checks the
+upstream implementation without replacing it with that earlier patch.

--- a/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
@@ -3,10 +3,11 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { DatabaseSync } from "node:sqlite";
 import { runSessionCli } from "../src/session-cli.ts";
+import { bindSessionSource, resolveSessionSource } from "../src/session-source.ts";
 import { defaultState, writeState, readState } from "../src/state.ts";
 import { runOrchestrateCli, parseOrchestrateCliArgs } from "../src/orchestrate-cli.ts";
 import { runReceiptCli } from "../src/receipt-cli.ts";
@@ -45,6 +46,40 @@ function bind(f: ReturnType<typeof fixture>) {
   const r = runSessionCli(["source", f.source, "--json"], f.cwd, f.env);
   assert.equal(r.code, 0, r.output);
 }
+
+test("Windows short paths bind and resolve the same immutable worktree", { skip: process.platform !== "win32" }, t => {
+  const f = fixture(t);
+  const root = dirname(f.cwd);
+  const shortRoot = execFileSync("cmd.exe", ["/d", "/c", 'for %I in ("%CXC_TEST_LONG_PATH%") do @echo %~sI'], {
+    env: { ...process.env, CXC_TEST_LONG_PATH: root }, encoding: "utf8", windowsVerbatimArguments: true,
+  }).trim();
+  if (shortRoot === root) { t.skip("8.3 names are unavailable on the temporary volume"); return; }
+  assert.equal(realpathSync.native(shortRoot), root);
+  const shortCwd = join(shortRoot, "native"), shortSource = join(shortRoot, "source");
+  assert.equal(bindSessionSource(shortCwd, id, shortSource), f.source);
+  const path = join(f.cwd, ".codexclaw", "sources", `${id}.json`);
+  const bytes = readFileSync(path, "utf8");
+  const binding = JSON.parse(bytes);
+  assert.equal(binding.nativeCwd, f.cwd);
+  assert.equal(binding.sourceRoot, f.source);
+  assert.equal(resolveSessionSource(f.cwd, id), f.source);
+  assert.equal(resolveSessionSource(shortCwd, id), f.source);
+  assert.equal(bindSessionSource(f.cwd, id, f.source), f.source);
+  const bound = runSessionCli(["source", shortSource, "--json"], f.cwd, f.env);
+  assert.equal(bound.code, 0, bound.output);
+  assert.equal(JSON.parse(bound.output).cwd, f.cwd);
+  assert.equal(JSON.parse(bound.output).sourceCwd, f.source);
+  assert.equal(readFileSync(path, "utf8"), bytes);
+  assert.equal(edge(shortCwd, "B", "A").code, 0);
+  assert.equal(readState(f.cwd, id).boundSourceRoot, f.source);
+  writeFileSync(join(f.source, "implemented"), "yes");
+  const check = edge(f.cwd, "C", "B");
+  assert.equal(check.code, 0, check.output);
+  const receipt = runReceiptCli({ verb: "test", cwd: f.cwd, session: id,
+    command: [process.execPath, "-e", `require('node:assert/strict').equal(process.cwd(), ${JSON.stringify(f.source)})`] });
+  assert.equal(receipt.code, 0, receipt.output);
+  assert.equal(validateCheckReceipt(readState(f.cwd, id), id, receipt.output, f.cwd).ok, true);
+});
 
 test("worktree change advances B and Check runs there while receipts stay native", t => {
   const f = fixture(t); bind(f);


### PR DESCRIPTION
The Windows 8.3 source-binding fix already landed in #84 via bb204ead04935a8970c3b9f70f9019eebb74e8f6. Its integration fixture expands temporary paths to long names, so the suite does not explicitly exercise a caller supplying the short alias.

Carry forward the missing regression from https://github.com/thisisjun786/codexclaw/pull/1. It obtains an actual 8.3 alias using cmd.exe and verifies short/long binding resolution, byte-preserving repeat binding, native cwd identity, pinned source root, B/C progression, and a validated receipt executed in the linked worktree. It skips outside Windows or when the volume does not provide 8.3 aliases.

Production code is unchanged. The README test counts are updated to the measured 2,671 tests, and verification notes are included in the existing worktree-source-binding unit.

Validation (Node 24.15.0):

- New Windows regression: passed without skipping against current dev.
- WSL Ubuntu integration file: 18 passed, 0 failed, 1 skipped (Windows-only alias regression), including the damaged-symlink test and shipped CLI flow.
- Repository gate, inventory check against 2,671, and whitespace check: passed.
- Full local Windows suite: 2,580 passed, 81 skipped, 10 failed. These are the nine existing session-binding symlink fixtures and the damaged-symlink integration fixture on a host without symlink creation permission. The new regression passed; the full suite is **not green locally**. No tests or permission checks were relaxed.

The regression was previously verified failing before the native-path fix and passing afterward in the original follow-up; this PR verifies it against the merged upstream implementation.
