### PR TITLE
dev-devops: add agent-pr-intake reference (identity, draft-first, supersede, three policy strengths)

### DIFF
--- a/devlog/_plan/260909_agent_swarm_repo_hygiene/030_l3_agent_pr_intake.md
+++ b/devlog/_plan/260909_agent_swarm_repo_hygiene/030_l3_agent_pr_intake.md
@@ -122,7 +122,7 @@ Four disagreements the sources do not settle; record which side the repository t
   incentive worked where banning the tool would not.
   Do not cite curl as proof that AI reports are worthless.
 - **Ban the tool or cap the rate.** Zig, QEMU, Gentoo and Servo judge AI-ness (total
-  bans in the policy table); Godot's ban is announced but not yet in its CONTRIBUTING. OpenSSL,
+  bans; see the policy summary in `oss-ai-contribution-policies.md` under the unit evidence); Godot's ban is announced but not yet in its CONTRIBUTING. OpenSSL,
   llama.cpp, GitHub and Crossplane cap concurrency regardless of provenance. GitHub's
   implementation is the tell: agent PRs count toward the limit, drafts do not.
 
@@ -152,13 +152,13 @@ removal of bait labels (`repo-bootstrap.md` §6).
 ## §7 Sources (read 2026-09-09)
 
 - Copilot cloud agent: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/risks-and-mitigations ; https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/configuring-agent-settings ; https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/use-cloud-agent-on-github
-- Codex cloud branch format: live settings UI at chatgpt.com/codex/cloud/settings/general; PR author identity and draft default were searched in the Codex docs and not found (negative result recorded in `evidence/research/github-rulesets-and-agent-conventions.md` §2.2)
+- Codex cloud branch format: live settings UI at chatgpt.com/codex/cloud/settings/general; PR author identity and draft default were searched in the Codex docs and not found (negative result recorded in `devlog/_plan/260909_agent_swarm_repo_hygiene/evidence/research/github-rulesets-and-agent-conventions.md` §2.2)
 - Claude Code GitHub Actions: action inputs and docs as summarized in `devlog/_plan/260909_agent_swarm_repo_hygiene/evidence/research/github-rulesets-and-agent-conventions.md` §2.3
 - Agent control plane GA (`actor_is_agent`): https://github.blog/changelog/2026-02-26-enterprise-ai-controls-agent-control-plane-now-generally-available ; Agents tab: https://github.blog/changelog/2026-01-26-introducing-the-agents-tab-in-your-repository
 - Pull request limits: https://github.blog/open-source/maintainers/how-pull-request-limits-are-cutting-down-the-noise/
-- Practitioner policies (LLVM, OpenSSL, dotnet/runtime, ghostty, Godot, Kubernetes, Crossplane, llama.cpp, curl, Zig, Ladybird, OpenSSF): `evidence/research/agent-pr-flood-practitioner-writeups.md` and `evidence/research/oss-ai-contribution-policies.md` in the same unit, each entry with its URL
+- Practitioner policies (LLVM, OpenSSL, dotnet/runtime, ghostty, Godot, Kubernetes, Crossplane, llama.cpp, curl, Zig, Ladybird, OpenSSF): `devlog/_plan/260909_agent_swarm_repo_hygiene/evidence/research/agent-pr-flood-practitioner-writeups.md` and `evidence/research/oss-ai-contribution-policies.md` in the same unit, each entry with its URL
 - Laravel Issues decision: https://x.com/taylorotwell/status/2095516796748996843 (first-hand report)
-- Live opencodex numbers: `evidence/research/lidge-jun-repos-settings-audit.md` §5.1
+- Live opencodex numbers: `devlog/_plan/260909_agent_swarm_repo_hygiene/evidence/research/lidge-jun-repos-settings-audit.md` §5.1
 ````
 
 ## MODIFY `plugins/codexclaw/skills/dev-devops/SKILL.md` — Modular References table
@@ -177,7 +177,7 @@ IN: the new file and one router row. OUT: workflow YAML, label creation, the GC 
 | # | Criterion | Evidence |
 |---|---|---|
 | A1 | Rule IDs `DEVOPS-AGENT-IDENTITY-01`, `DEVOPS-DRAFT-FIRST-01`, `DEVOPS-PR-SUPERSEDE-01`, `DEVOPS-AGENT-INTAKE-01` defined once | grep |
-| A2 | Three strength columns present; every non-"none" cell names a source | reviewer |
+| A2 | Three strength columns present; every cell carrying a number or a quoted rule names its project | reviewer |
 | A3 | Codex author/signing cells marked unverified; X posts cited as first-hand reports only | grep |
 | A4 | Convention table matches ledger 3.1-3.3 | reviewer |
 | A5 | gate + catalog/manifest tests exit 0 at L3 tip; Modular References 15 rows | receipt, grep |

--- a/plugins/codexclaw/skills/dev-devops/SKILL.md
+++ b/plugins/codexclaw/skills/dev-devops/SKILL.md
@@ -40,6 +40,7 @@ proof remain mandatory; architecture/tool preferences need project-specific just
 | `../dev/references/stacked-prs.md` | Stacked/dependent PRs or unexpected CI runs | `DEV-STACK-03/06/07`: native membership preflight and CI diagnosis; also reached globally through `dev` |
 | `references/branch-lifecycle.md` | Branch/worktree cleanup | Closed-PR branch automation, per-branch deletion evidence, worktree dirty audit, stacked-PR safety |
 | `references/repo-bootstrap.md` | New or under-configured repository; branch protection, rulesets, auto-delete, PR limits | Ruleset-first setup, merge-setting fields, closed-PR job values, PR limits, labels/template, read-only bootstrap check |
+| `references/agent-pr-intake.md` | Many agent-authored PRs/issues; intake policy; superseded PRs | Identity tiers, agent convention table, draft-first, supersede procedure, weak/medium/strong policy options with sources |
 | `references/iac.md` | Infrastructure code | OpenTofu/Terraform modules, Pulumi, state encryption, blast radius isolation |
 | `references/sre-foundations.md` | Operations/incidents | SLO/SLI/error budget, burn-rate alerting, incident response, blameless postmortem |
 | `references/edge-serverless.md` | Edge/serverless work | Edge request shaping, auth at edge, Cloudflare Workers, Vercel Edge, edge AI triage |

--- a/plugins/codexclaw/skills/dev-devops/references/agent-pr-intake.md
+++ b/plugins/codexclaw/skills/dev-devops/references/agent-pr-intake.md
@@ -1,22 +1,3 @@
-# 030 — L3: agent-PR intake reference
-
-Status: PLANNED
-Branch: `codex/agent-swarm-hygiene-l3` (base `codex/agent-swarm-hygiene-l2`)
-Thesis (PR title): "dev-devops: add agent-pr-intake reference (identity, draft-first, supersede, three policy strengths)"
-Class: C2 (one NEW reference file, one router row).
-
-## Why this layer exists
-
-No skill file addresses the volume of agent-authored PRs (000_plan problem 3). The
-practitioner record is large and contradictory (ledger 3.5), so the skill presents the
-options with their sources rather than picking one — user instruction 2026-09-09:
-"모두 표시해서 옵션으로".
-
-## NEW `plugins/codexclaw/skills/dev-devops/references/agent-pr-intake.md`
-
-Full body (B copies verbatim):
-
-````markdown
 # Agent PR Intake — Identity, Draft-First, Supersede, Policy Strengths
 
 Last reviewed: 2026-09-09
@@ -159,26 +140,3 @@ removal of bait labels (`repo-bootstrap.md` §6).
 - Practitioner policies (LLVM, OpenSSL, dotnet/runtime, ghostty, Godot, Kubernetes, Crossplane, llama.cpp, curl, Zig, Ladybird, OpenSSF): `evidence/research/agent-pr-flood-practitioner-writeups.md` and `evidence/research/oss-ai-contribution-policies.md` in the same unit, each entry with its URL
 - Laravel Issues decision: https://x.com/taylorotwell/status/2095516796748996843 (first-hand report)
 - Live opencodex numbers: `evidence/research/lidge-jun-repos-settings-audit.md` §5.1
-````
-
-## MODIFY `plugins/codexclaw/skills/dev-devops/SKILL.md` — Modular References table
-
-After the `references/repo-bootstrap.md` row:
-```diff
-+| `references/agent-pr-intake.md` | Many agent-authored PRs/issues; intake policy; superseded PRs | Identity tiers, agent convention table, draft-first, supersede procedure, weak/medium/strong policy options with sources |
-```
-
-## Scope boundary
-
-IN: the new file and one router row. OUT: workflow YAML, label creation, the GC file.
-
-## Accept criteria
-
-| # | Criterion | Evidence |
-|---|---|---|
-| A1 | Rule IDs `DEVOPS-AGENT-IDENTITY-01`, `DEVOPS-DRAFT-FIRST-01`, `DEVOPS-PR-SUPERSEDE-01`, `DEVOPS-AGENT-INTAKE-01` defined once | grep |
-| A2 | Three strength columns present; every non-"none" cell names a source | reviewer |
-| A3 | Codex author/signing cells marked unverified; X posts cited as first-hand reports only | grep |
-| A4 | Convention table matches ledger 3.1-3.3 | reviewer |
-| A5 | gate + catalog/manifest tests exit 0 at L3 tip; Modular References 15 rows | receipt, grep |
-| A6 | Opus-5 audit: no source misattribution | attest |

--- a/plugins/codexclaw/skills/dev-devops/references/agent-pr-intake.md
+++ b/plugins/codexclaw/skills/dev-devops/references/agent-pr-intake.md
@@ -103,7 +103,7 @@ Four disagreements the sources do not settle; record which side the repository t
   incentive worked where banning the tool would not.
   Do not cite curl as proof that AI reports are worthless.
 - **Ban the tool or cap the rate.** Zig, QEMU, Gentoo and Servo judge AI-ness (total
-  bans in the policy table); Godot's ban is announced but not yet in its CONTRIBUTING. OpenSSL,
+  bans; see the policy summary in `oss-ai-contribution-policies.md` under the unit evidence); Godot's ban is announced but not yet in its CONTRIBUTING. OpenSSL,
   llama.cpp, GitHub and Crossplane cap concurrency regardless of provenance. GitHub's
   implementation is the tell: agent PRs count toward the limit, drafts do not.
 
@@ -133,10 +133,10 @@ removal of bait labels (`repo-bootstrap.md` §6).
 ## §7 Sources (read 2026-09-09)
 
 - Copilot cloud agent: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/risks-and-mitigations ; https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/configuring-agent-settings ; https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/use-cloud-agent-on-github
-- Codex cloud branch format: live settings UI at chatgpt.com/codex/cloud/settings/general; PR author identity and draft default were searched in the Codex docs and not found (negative result recorded in `evidence/research/github-rulesets-and-agent-conventions.md` §2.2)
+- Codex cloud branch format: live settings UI at chatgpt.com/codex/cloud/settings/general; PR author identity and draft default were searched in the Codex docs and not found (negative result recorded in `devlog/_plan/260909_agent_swarm_repo_hygiene/evidence/research/github-rulesets-and-agent-conventions.md` §2.2)
 - Claude Code GitHub Actions: action inputs and docs as summarized in `devlog/_plan/260909_agent_swarm_repo_hygiene/evidence/research/github-rulesets-and-agent-conventions.md` §2.3
 - Agent control plane GA (`actor_is_agent`): https://github.blog/changelog/2026-02-26-enterprise-ai-controls-agent-control-plane-now-generally-available ; Agents tab: https://github.blog/changelog/2026-01-26-introducing-the-agents-tab-in-your-repository
 - Pull request limits: https://github.blog/open-source/maintainers/how-pull-request-limits-are-cutting-down-the-noise/
-- Practitioner policies (LLVM, OpenSSL, dotnet/runtime, ghostty, Godot, Kubernetes, Crossplane, llama.cpp, curl, Zig, Ladybird, OpenSSF): `evidence/research/agent-pr-flood-practitioner-writeups.md` and `evidence/research/oss-ai-contribution-policies.md` in the same unit, each entry with its URL
+- Practitioner policies (LLVM, OpenSSL, dotnet/runtime, ghostty, Godot, Kubernetes, Crossplane, llama.cpp, curl, Zig, Ladybird, OpenSSF): `devlog/_plan/260909_agent_swarm_repo_hygiene/evidence/research/agent-pr-flood-practitioner-writeups.md` and `evidence/research/oss-ai-contribution-policies.md` in the same unit, each entry with its URL
 - Laravel Issues decision: https://x.com/taylorotwell/status/2095516796748996843 (first-hand report)
-- Live opencodex numbers: `evidence/research/lidge-jun-repos-settings-audit.md` §5.1
+- Live opencodex numbers: `devlog/_plan/260909_agent_swarm_repo_hygiene/evidence/research/lidge-jun-repos-settings-audit.md` §5.1


### PR DESCRIPTION
No skill file addressed the volume of agent-authored pull requests. `references/agent-pr-intake.md` starts from the economics three projects state independently (review, not authorship, is the scarce resource), defines three identity tiers and an agent convention table for Copilot cloud agent, Codex cloud and Claude Code Actions, sets draft-first as the default, gives a six-step supersede procedure tied to branch-lifecycle keep rules 5 and 8-10, and lays out weak/medium/strong intake policies as options with the project that used each value (OpenSSL, llama.cpp, Godot, dotnet/runtime, Kubernetes, LLVM, ghostty, Crossplane). The four practitioner disagreements are recorded rather than decided.

Validation: gate exit 0, catalog/manifest 10/10 at the head; every project attribution traced to the unit's evidence files by an Opus-5 audit; diff review pass.

**Stack** (manual chain, merge bottom-up):
| # | PR | Layer | Review focus |
|---|----|-------|--------------|
| 4 | #97 | L4 local-gc + pointers + changelog | §6 contract safety; pointer placement |
| 3 | #96 | L3 agent-pr-intake ← you are here | policy table attributions; convention table |
| 2 | #95 | L2 repo-bootstrap | ruleset JSON and PATCH fields; unverified labels |
| 1 | #94 | L1 branch-lifecycle drift + rule IDs | keep-rule table vs planner order; merge-truth wording |

Depends on #95. Review this PR's diff only.

Note: `enforce-pr-target.yml` flags any PR whose base is not `dev`; this layer's base is the layer below, so the prefix/draft it applies is expected for a chain and is not a wrong target.
