### PR TITLE
docs(plan): merge receipt for the agent-swarm hygiene chain

### DIFF
--- a/devlog/_plan/260909_agent_swarm_repo_hygiene/080_merge_receipt.md
+++ b/devlog/_plan/260909_agent_swarm_repo_hygiene/080_merge_receipt.md
@@ -1,0 +1,80 @@
+# 080 — Merge receipt
+
+Status: DONE — all four layers landed on `dev`
+Repository: lidge-jun/codexclaw. Method: merge commit (`--merge`), each pinned with
+`--match-head-commit` on the full head SHA per `070_merge_plan.md`.
+Base at start: `origin/dev` = `6e97e73d`. No ruleset or branch protection applies to
+`dev` (verified: `GET /rules/branches/dev` empty, `GET /branches/dev/protection` 404),
+so no gate was bypassed or overridden; `--admin` was never used.
+
+| Layer | PR | Head merged (full) | Checks at merge | Merge commit | dev after |
+|-------|----|--------------------|-----------------|--------------|-----------|
+| L1 | #94 | 46a9bc9dfa4e44c381a169645b0b850f3b8f1fa8 | 11/11 pass | c45e515911ece7dacd52871dabfe852d14713918 | c45e5159 |
+| L2 | #95 | 3e7302ec616d5d95d788d25495d86ce140c2981f | 11/11 pass | 2d3c95a0f58939c26861b4266dbeb1ee57bd51be | 2d3c95a0 |
+| L3 | #96 | 6ca0c3d88861d2ed3b6096d7b820681bf41cea95 | 11/11 pass | 44f2617065c9d1f5f44d2e1cb4345e08c555bb18 | 44f26170 |
+| L4 | #97 | a72d73c167107647a0ccbc1b75ca5d6860491595 | 11/11 pass | 1f81109209450a70ffe96595c8f449fbf0bc570b | 1f811092 |
+
+## Log
+
+- **#94 (L1)** merged 2026-09-09T00:38:40Z. Pre-merge: OPEN, base `dev`,
+  `MERGEABLE`/`CLEAN`, 11 checks all pass, diff limited to the roadmap unit plus
+  `dev-devops/SKILL.md` and `references/branch-lifecycle.md`. After merge:
+  `git merge-base --is-ancestor 46a9bc9d origin/dev` exit 0.
+- **#95 (L2)** retargeted to `dev` with `gh pr edit 95 --base dev`, then merged
+  2026-09-09T00:39:56Z. The retarget cleared the `[WRONG BRANCH]` title prefix on its
+  own through `enforce-pr-target.yml`'s `edited` path, and the diff shrank to this
+  layer's four files (`001_research_ledger.md`, `020_l2_repo_bootstrap.md`,
+  `dev-devops/SKILL.md`, `references/repo-bootstrap.md`) because L1 had already landed.
+  Pre-merge `MERGEABLE`/`CLEAN`, 11 checks pass. After merge:
+  `git merge-base --is-ancestor 3e7302ec origin/dev` exit 0.
+- **#96 (L3)** retargeted to `dev`, then merged 2026-09-09T00:46:06Z. Its
+  `enforce-pr-target` run (34296005962) sat queued for about three minutes, leaving the
+  PR `UNSTABLE` with the prefix still on the title; per the 070 refusal table the merge
+  waited for that run to conclude `success` rather than proceeding on a pending check.
+  Diff was this layer's three files (`030_l3_agent_pr_intake.md`, `dev-devops/SKILL.md`,
+  `references/agent-pr-intake.md`). After merge:
+  `git merge-base --is-ancestor 6ca0c3d8 origin/dev` exit 0.
+- **#97 (L4)** retargeted to `dev` and merged 2026-09-09T00:50:28Z at head
+  `a72d73c1`, which is past the `ccfdf7fd` recorded in `060_publish_receipt.md` because
+  `070_merge_plan.md` itself landed on that branch. Its diff carried the L4 layer
+  (`local-gc.md`, the four pointer files, `CHANGELOG.md`, `dev-devops/SKILL.md`) plus the
+  `040`, `060` and `070` plan documents. Pre-merge `CLEAN`, 11 checks pass.
+
+`origin/dev`: `6e97e73d` → `c45e5159` → `2d3c95a0` → `44f26170` → `1f811092`.
+
+## Post-merge verification (2026-09-09, dev at `1f811092`)
+
+**Ancestry.** After `git fetch origin dev`, `git merge-base --is-ancestor <head>
+origin/dev` exits 0 for all four merged heads: `46a9bc9d`, `3e7302ec`, `6ca0c3d8`,
+`a72d73c1`. The four merge commits appear in order on `dev`:
+
+```
+1f811092 Merge pull request #97 from lidge-jun/codex/agent-swarm-hygiene-l4
+44f26170 Merge pull request #96 from lidge-jun/codex/agent-swarm-hygiene-l3
+2d3c95a0 Merge pull request #95 from lidge-jun/codex/agent-swarm-hygiene-l2
+c45e5159 Merge pull request #94 from lidge-jun/codex/agent-swarm-hygiene-l1
+```
+
+**Tree equality.** `git diff --quiet origin/dev codex/agent-swarm-hygiene-l4` over the
+eleven touched paths (`dev-devops/SKILL.md`, `branch-lifecycle.md`,
+`repo-bootstrap.md`, `agent-pr-intake.md`, `local-gc.md`, `agent-infra-safety.md`,
+`ci-cd-deploy.md`, `dev/references/skill-ownership.md`, `dev/references/stacked-prs.md`,
+`worktree-guardian/SKILL.md`, `CHANGELOG.md`) exits 0 — the merged tree is byte-identical
+to the reviewed L4 content.
+
+**Fresh checkout.** A clean `git clone --branch dev` at `1f81109` (not the working
+worktree) reports:
+
+| Check | Result |
+|---|---|
+| `node plugins/codexclaw/scripts/gate.mjs` | OK, exit 0 |
+| `node --test` skill-catalog + manifest-policy | tests 10, pass 10, fail 0 |
+| `references/` contains the three new files | `repo-bootstrap.md`, `agent-pr-intake.md`, `local-gc.md` present |
+| Modular References rows in `dev-devops/SKILL.md` | 16 |
+| New rule IDs registered | `DEVOPS-BRANCH-NAMESPACE-01`, `DEVOPS-REPO-BOOTSTRAP-01`, `DEVOPS-AGENT-INTAKE-01`, `DEVOPS-LOCAL-GC-01` |
+| CHANGELOG | `## [Unreleased]` at line 7; compare link targets `v0.2.24...HEAD` |
+
+**Left as found.** `delete_branch_on_merge` is still false, so the four
+`codex/agent-swarm-hygiene-l*` branches survive on the remote. Changing that setting or
+deleting the branches is outside this goal; both are separately authorized actions.
+`dev` was not promoted to `main`, and no repository setting was modified.


### PR DESCRIPTION
The chain #94-#97 landed on `dev` (`6e97e73d` → `1f811092`). This records how, with the evidence a reviewer would otherwise have to reconstruct from the Actions tab.

`080_merge_receipt.md` lists each layer's merged head, its checks at merge time, its merge commit, and the resulting `dev` SHA, plus the post-merge verification: ancestry proof for all four heads, a byte-equality diff of the eleven touched files against the reviewed L4 tip, and gate + skill tests run on a fresh clone of merged `dev` (gate OK, tests 10/10).

Two things worth flagging for whoever picks this up next: `delete_branch_on_merge` is false, so the four `codex/agent-swarm-hygiene-l*` branches are still on the remote, and `dev` has not been promoted to `main`.
