### PR TITLE
dev-devops: drop the chain-delivery phrasing from the §2.9 owner rows

### DIFF
--- a/plugins/codexclaw/skills/dev-devops/SKILL.md
+++ b/plugins/codexclaw/skills/dev-devops/SKILL.md
@@ -235,9 +235,9 @@ actually still matter. Treat branch lifecycle as delivery infrastructure.
 | `DEVOPS-BRANCH-SNAPSHOT-01` | STRICT | Snapshot `git for-each-ref` (SHA + refname) for every local and remote ref to scratch space before the first deletion. Deleted remote branches are restorable with `git push origin <sha>:refs/heads/<name>` only while you still hold the SHA. |
 | `DEVOPS-WORKTREE-DIRTY-01` | STRICT | Check every attached worktree for uncommitted work before removing it, and remove worktrees **before** their branches — an attached branch cannot be deleted, and `--force` on a dirty tree discards work no reflog will return. |
 | `DEVOPS-BRANCH-NAMESPACE-01` | STRICT | Automation deletes only inside a declared disposable namespace (planner default `codex/`, `ingw/`; a repository may add prefixes such as `agent/`) and only when the branch tip still equals a closed PR's head SHA. A name match is not evidence; a reused name is new work. |
-| `DEVOPS-REPO-BOOTSTRAP-01` | DEFAULT | A repository that receives agent PRs is set up ruleset-first: protected integration lines, auto-delete on merge, closed-PR cleanup job, merge-method policy, PR limits, labels and template, each verified by a read-back command. Owner: `references/repo-bootstrap.md` (arrives with L2 of the 260909 chain). |
-| `DEVOPS-AGENT-INTAKE-01` | DEFAULT | Agent-authored PRs enter through a declared intake policy (weak, medium or strong) that names identity, draft rule, review budget, supersede procedure and close conditions. Owner: `references/agent-pr-intake.md` (L3). |
-| `DEVOPS-LOCAL-GC-01` | STRICT | Local worktree and branch GC uses PR state as merge truth, snapshots first, audits dirty trees, never touches the active or a locked worktree, and defaults to dry-run. Owner: `references/local-gc.md` (L4). |
+| `DEVOPS-REPO-BOOTSTRAP-01` | DEFAULT | A repository that receives agent PRs is set up ruleset-first: protected integration lines, auto-delete on merge, closed-PR cleanup job, merge-method policy, PR limits, labels and template, each verified by a read-back command. Owner: `references/repo-bootstrap.md`. |
+| `DEVOPS-AGENT-INTAKE-01` | DEFAULT | Agent-authored PRs enter through a declared intake policy (weak, medium or strong) that names identity, draft rule, review budget, supersede procedure and close conditions. Owner: `references/agent-pr-intake.md`. |
+| `DEVOPS-LOCAL-GC-01` | STRICT | Local worktree and branch GC uses PR state as merge truth, snapshots first, audits dirty trees, never touches the active or a locked worktree, and defaults to dry-run. Owner: `references/local-gc.md`. |
 
 **Why the merged/closed distinction is load-bearing.** `delete_branch_on_merge`
 reads as complete branch hygiene, and a repository with it enabled looks solved.
@@ -258,7 +258,7 @@ same branch names as upstream, so name comparison silently misclassifies it.
 
 Mechanics, the deletion-plan algorithm, and a worked audit live in
 `references/branch-lifecycle.md`. Setup, intake and local GC have their own owner
-files; each is registered in Modular References by the chain layer that adds it.
+files, listed in Modular References above.
 
 ---
 


### PR DESCRIPTION
The three owner references landed with #95, #96 and #97. Until now the §2.9 rows still pointed at them as future arrivals — "arrives with L2 of the 260909 chain", "(L3)", "(L4)", and a closing line saying each file "is registered in Modular References by the chain layer that adds it".

A reader opening the skill today sees three files that already exist, described as if they were still in flight, and a delivery sequence they have no way to observe. The rows now name their owner files plainly.

Prose only; `node plugins/codexclaw/scripts/gate.mjs` exit 0 and the skill-catalog + manifest-policy tests pass 10/10.
