### PR TITLE
Demote repeatedly injected threads in automatic recall

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C793_passing-brightgreen" alt="2,793 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-24-blue" alt="24 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C793_passing-brightgreen" alt="2,793 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-24-blue" alt="24 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C793_passing-brightgreen" alt="2,793 tests passing">
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-24-blue" alt="24 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/plugins/codexclaw/components/recall/dist/hook.js
+++ b/plugins/codexclaw/components/recall/dist/hook.js
@@ -21,6 +21,14 @@ import {
 
 
 } from "./cwd-context.js";
+import {
+  bumpHitCounts,
+  hitCountRef,
+  indexPath,
+  openIndex,
+  readHitCounts,
+} from "./index-db.js";
+import { existsSync } from "node:fs";
 import { basename } from "node:path";
 // Cross-component dist import (established precedent: messenger-bridge api-compat).
 // Resolves from BOTH src (test-time ../../cxc-ops/dist) and shipped dist layouts.
@@ -163,6 +171,33 @@ export const FULL_BUDGET               = { chars: 1400, topN: 5, snippet: 100 };
  */
 export const COMPACTED_BUDGET               = { chars: 800, topN: 2, snippet: 100 };
 
+/**
+ * Repeat-injection penalty. A thread that has already been pushed into several
+ * sessions has had its chance to be useful, so it yields its slot to something
+ * the agent has not seen yet. Formula from jawcode memory-quality.ts:45-59:
+ * nothing below the threshold, then half a unit more for each repeat.
+ *
+ * The unit is calibrated against the scale that exists on THIS path rather than
+ * memory-search's chunk scores, which rank different objects. Adjacent sessions
+ * sit one apart here, so half a unit is half a position: the first repeats past
+ * the threshold only close the gap, a session has to keep coming back before it
+ * actually drops a place, and each further repeat costs another half step. That
+ * is deliberately gentle — a thread that is genuinely the current work should
+ * survive a few sessions of being right.
+ */
+const HIT_PENALTY_THRESHOLD = 3;
+const HIT_PENALTY_UNIT = 0.5;
+
+export function hitCountPenalty(count        )         {
+  return count >= HIT_PENALTY_THRESHOLD ? (count - HIT_PENALTY_THRESHOLD + 1) * HIT_PENALTY_UNIT : 0;
+}
+
+/**
+ * Injection-history store for the auto-inject path. Kept behind an interface so
+ * the penalty is reachable ONLY from here: explicit `cxc chat/memory search`
+ * must answer the same query the same way every time, and the surest guarantee
+ * of that is that the search core has no way to reach this code at all.
+ */
 
 
 
@@ -174,7 +209,43 @@ export const COMPACTED_BUDGET               = { chars: 800, topN: 2, snippet: 10
 
 
 
-const DEFAULT_RECALL_DEPS                    = { searchChat, listCwdSessions, loadSummaryIndex };
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * Open the sidecar index read-write for counting. Never creates the index: if
+ * recall has no index yet there is no history to record, and a hook must not
+ * materialize a 12GB cache as a side effect of starting a session.
+ */
+function openSidecarHitCounts()                       {
+  try {
+    const path = indexPath();
+    if (!existsSync(path)) return null;
+    const db = openIndex(path);
+    return {
+      read: (refs) => readHitCounts(db, refs),
+      bump: (refs) => bumpHitCounts(db, refs, new Date().toISOString()),
+      close: () => db.close(),
+    };
+  } catch {
+    return null; // fail-soft: ranking degrades to neutral, injection still happens.
+  }
+}
+
+const DEFAULT_RECALL_DEPS                    = {
+  searchChat,
+  listCwdSessions,
+  loadSummaryIndex,
+  openHitCounts: openSidecarHitCounts,
+};
 
 function quoteUntrusted(value        )         {
   // JSON quoting removes control/newline structure; escaping angle brackets
@@ -250,6 +321,73 @@ export function renderCwdBlock(
 }
 
 /**
+ * Pick what to inject, pushing back whatever has already been injected repeatedly.
+ *
+ * Candidates arrive newest-first, so their index IS their rank; the penalty is
+ * added to that index and the list re-sorted, which keeps the whole policy in
+ * units of list positions. Ties keep time order, so an entry never moves
+ * without an earned penalty and the output stays deterministic for a given
+ * (corpus, history) pair.
+ *
+ * Generic over the candidate shape because the two injection paths carry
+ * different records — enumerated sessions and chat hits — but rank on the same
+ * refs, so one history serves both and a session cannot dodge its count by
+ * arriving through the other door.
+ *
+ * Reading and writing happen exactly once each, here, and only for the entries
+ * that end up in the injection: read before the choice, write after it. Every
+ * failure mode degrades to the neutral order rather than to no injection —
+ * a broken history store must not cost the session its context.
+ */
+function demoteRepeats   (
+  candidates     ,
+  limit        ,
+  refOf                     ,
+  deps                   ,
+)      {
+  const neutral = candidates.slice(0, limit);
+  // No candidates means no injection, so there is nothing to record and no
+  // reason to touch the sidecar: an idle project cannot accumulate history.
+  if (candidates.length === 0) return neutral;
+  let store                       = null;
+  try {
+    store = deps.openHitCounts?.() ?? null;
+  } catch {
+    return neutral;
+  }
+  if (!store) return neutral;
+  try {
+    const refs = candidates.map(refOf);
+    const counts = store.read(refs);
+    const ranked = candidates
+      .map((item, index) => ({
+        item,
+        ref: refs[index] ,
+        rank: index + hitCountPenalty(counts.get(refs[index] ) ?? 0),
+      }))
+      .sort((a, b) => a.rank - b.rank);
+    const chosen = ranked.slice(0, limit);
+    store.bump(chosen.map((c) => c.ref));
+    return chosen.map((c) => c.item);
+  } catch {
+    return neutral;
+  } finally {
+    try { store.close(); } catch { /* already closed or never opened cleanly */ }
+  }
+}
+
+/**
+ * How many candidates to gather before demoting down to `topN`.
+ *
+ * Demotion can only work if there is something below the cut to promote, so the
+ * pool widens when — and only when — a history store is configured. Without one
+ * the enumeration cost stays exactly what it was before the penalty existed.
+ */
+function candidatePool(topN        , deps                   )         {
+  return deps.openHitCounts ? topN * 2 : topN;
+}
+
+/**
  * Build compact, project-scoped context. Automatic hooks never federate across
  * CWDs: global recall remains available only through the explicit CLI command.
  * Historical text is enclosed as untrusted data so it cannot impersonate hook
@@ -267,15 +405,26 @@ export function buildCwdContext(
 
     // Preferred path: enumerate this cwd's sessions from the index directly.
     // Falls through to the text-search path when the index is unavailable.
-    const direct = deps.listCwdSessions ? deps.listCwdSessions(cwd, topN) : null;
+    const direct = deps.listCwdSessions
+      ? deps.listCwdSessions(cwd, candidatePool(topN, deps))
+      : null;
     if (direct) {
+      // Rank BEFORE rendering, and only over sessions that would actually be
+      // shown: an empty excerpt renders nothing, so charging it an injection
+      // would record a hit the agent never saw.
+      const showable = direct.filter((session) => session.excerpt !== "");
+      const chosen = demoteRepeats(
+        showable,
+        topN,
+        (session) => hitCountRef(session.threadId, session.path),
+        deps,
+      );
       // Summaries are a bonus tier: loaded once, joined by thread id, and omitted
       // entirely for sessions that have none.
-      const summaries = direct.length > 0 && deps.loadSummaryIndex ? deps.loadSummaryIndex() : null;
+      const summaries = chosen.length > 0 && deps.loadSummaryIndex ? deps.loadSummaryIndex() : null;
       const sessions             = [];
       let latestDate = "";
-      for (const session of direct) {
-        if (session.excerpt === "") continue; // nothing worth showing for this session
+      for (const session of chosen) {
         const excerpt = clip(session.excerpt, budget.snippet);
         const entry = [`  \u2022 [${session.date}] ${quoteUntrusted(excerpt)}`];
         const summary = session.threadId ? summaries?.get(session.threadId) : undefined;
@@ -312,9 +461,19 @@ export function buildCwdContext(
       const key = hit.threadId ?? hit.ts;
       if (!seenThreads.has(key)) seenThreads.set(key, hit);
     }
+
+    // Nothing is recorded before this point: a CWD with no hits injects nothing
+    // and must leave no trace, so an unused project cannot accumulate history.
+    const chosenHits = demoteRepeats(
+      [...seenThreads.values()],
+      topN,
+      (hit) => hitCountRef(hit.threadId, hit.file),
+      deps,
+    );
+
     const sessions             = [];
     let latestDate = "";
-    for (const [, hit] of [...seenThreads.entries()].slice(0, topN)) {
+    for (const hit of chosenHits) {
       const date = hit.ts.slice(0, 10);
       const raw = (hit.title ?? hit.text).replace(/\n/g, " ").trim();
       sessions.push([`  \u2022 [${date}] ${quoteUntrusted(clip(raw, 60))}`]);

--- a/plugins/codexclaw/components/recall/dist/index-db.js
+++ b/plugins/codexclaw/components/recall/dist/index-db.js
@@ -26,6 +26,25 @@ export function indexPath(env                                     = process.env)
   return join(codexclawHome(env), "recall", "index.sqlite");
 }
 
+/**
+ * How often a thread has already been auto-injected into a session. Written and
+ * read by the hook path ALONE (hook.ts) so explicit `cxc chat/memory search`
+ * stays deterministic; nothing in the search core touches this table.
+ *
+ * Appended to SCHEMA instead of bumping INDEX_SCHEMA_VERSION: a version bump
+ * would drop and re-parse the whole corpus (measured 12GB / 1.2M messages),
+ * whereas CREATE TABLE IF NOT EXISTS lets an existing index gain the table on
+ * its next read-write open. openIndexReadOnly never runs schema statements, so
+ * every reader must tolerate the table being absent.
+ */
+const HIT_COUNTS_DDL = `
+CREATE TABLE IF NOT EXISTS recall_hit_counts (
+  ref TEXT PRIMARY KEY,
+  hit_count INTEGER NOT NULL DEFAULT 0,
+  last_hit_at TEXT NOT NULL
+);
+`;
+
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
 CREATE TABLE IF NOT EXISTS files (
@@ -65,7 +84,7 @@ CREATE TRIGGER IF NOT EXISTS msgs_ad AFTER DELETE ON msgs BEGIN
   INSERT INTO msgs_fts(msgs_fts, rowid, text) VALUES ('delete', old.id, old.text);
   INSERT INTO msgs_tri(msgs_tri, rowid, text) VALUES ('delete', old.id, old.text);
 END;
-`;
+${HIT_COUNTS_DDL}`;
 
 /** Open (creating directories/schema as needed) the sidecar index read-write. */
 export function openIndex(path        )       {
@@ -86,6 +105,7 @@ export function openIndex(path        )       {
     db.exec("DROP TRIGGER IF EXISTS msgs_ai; DROP TRIGGER IF EXISTS msgs_ad;");
     db.exec("DROP TABLE IF EXISTS msgs_fts; DROP TABLE IF EXISTS msgs_tri;");
     db.exec("DROP TABLE IF EXISTS msgs; DROP TABLE IF EXISTS files; DROP TABLE IF EXISTS meta;");
+    db.exec("DROP TABLE IF EXISTS recall_hit_counts;");
     db.exec(SCHEMA);
     db.prepare("INSERT INTO meta (key, value) VALUES ('schema_version', ?)").run(INDEX_SCHEMA_VERSION);
   }
@@ -111,6 +131,43 @@ export function openIndexReadOnly(path        )       {
 
 
 
+
+// ─── recall_hit_counts accessors ────────────────────────────────────────────
+// Storage only: how often a ref was injected, never what that should cost. The
+// penalty policy lives in hook.ts so the search core cannot grow a dependency
+// on it. Both accessors tolerate a missing table — an index created before this
+// table existed only gains it on its next read-write open.
+
+/** Stable ref for a chat hit: its thread when known, else its rollout file. */
+export function hitCountRef(threadId               , file        )         {
+  return threadId ? `thread:${threadId}` : `file:${file}`;
+}
+
+/** Injection counts for the given refs; refs never injected are simply absent. */
+export function readHitCounts(db      , refs          )                      {
+  const counts = new Map                ();
+  if (refs.length === 0) return counts;
+  try {
+    const holes = refs.map(() => "?").join(",");
+    const rows = db
+      .prepare(`SELECT ref, hit_count FROM recall_hit_counts WHERE ref IN (${holes})`)
+      .all(...refs)                                             ;
+    for (const row of rows) counts.set(String(row.ref), Number(row.hit_count));
+  } catch {
+    // Table absent (pre-existing index opened read-only) — no history, no penalty.
+  }
+  return counts;
+}
+
+/** Increment the injection count for each ref, stamping when it last happened. */
+export function bumpHitCounts(db      , refs          , atIso        )       {
+  if (refs.length === 0) return;
+  const stmt = db.prepare(
+    `INSERT INTO recall_hit_counts (ref, hit_count, last_hit_at) VALUES (?, 1, ?)
+     ON CONFLICT(ref) DO UPDATE SET hit_count = hit_count + 1, last_hit_at = excluded.last_hit_at`,
+  );
+  for (const ref of refs) stmt.run(ref, atIso);
+}
 
 export function indexStatus(db      , path        )              {
   const files = (db.prepare("SELECT COUNT(*) AS n FROM files").get()                 ).n;

--- a/plugins/codexclaw/components/recall/src/hook.ts
+++ b/plugins/codexclaw/components/recall/src/hook.ts
@@ -21,6 +21,14 @@ import {
   type CwdSession,
   type SummaryEntry,
 } from "./cwd-context.ts";
+import {
+  bumpHitCounts,
+  hitCountRef,
+  indexPath,
+  openIndex,
+  readHitCounts,
+} from "./index-db.ts";
+import { existsSync } from "node:fs";
 import { basename } from "node:path";
 // Cross-component dist import (established precedent: messenger-bridge api-compat).
 // Resolves from BOTH src (test-time ../../cxc-ops/dist) and shipped dist layouts.
@@ -163,6 +171,39 @@ export const FULL_BUDGET: RecallBudget = { chars: 1400, topN: 5, snippet: 100 };
  */
 export const COMPACTED_BUDGET: RecallBudget = { chars: 800, topN: 2, snippet: 100 };
 
+/**
+ * Repeat-injection penalty. A thread that has already been pushed into several
+ * sessions has had its chance to be useful, so it yields its slot to something
+ * the agent has not seen yet. Formula from jawcode memory-quality.ts:45-59:
+ * nothing below the threshold, then half a unit more for each repeat.
+ *
+ * The unit is calibrated against the scale that exists on THIS path rather than
+ * memory-search's chunk scores, which rank different objects. Adjacent sessions
+ * sit one apart here, so half a unit is half a position: the first repeats past
+ * the threshold only close the gap, a session has to keep coming back before it
+ * actually drops a place, and each further repeat costs another half step. That
+ * is deliberately gentle — a thread that is genuinely the current work should
+ * survive a few sessions of being right.
+ */
+const HIT_PENALTY_THRESHOLD = 3;
+const HIT_PENALTY_UNIT = 0.5;
+
+export function hitCountPenalty(count: number): number {
+  return count >= HIT_PENALTY_THRESHOLD ? (count - HIT_PENALTY_THRESHOLD + 1) * HIT_PENALTY_UNIT : 0;
+}
+
+/**
+ * Injection-history store for the auto-inject path. Kept behind an interface so
+ * the penalty is reachable ONLY from here: explicit `cxc chat/memory search`
+ * must answer the same query the same way every time, and the surest guarantee
+ * of that is that the search core has no way to reach this code at all.
+ */
+export interface HitCountStore {
+  read(refs: string[]): Map<string, number>;
+  bump(refs: string[]): void;
+  close(): void;
+}
+
 export interface RecallContextDeps {
   searchChat: typeof searchChat;
   /**
@@ -172,9 +213,39 @@ export interface RecallContextDeps {
   listCwdSessions?: (cwd: string, topN: number) => CwdSession[] | null;
   /** Thread id -> human-written session summary. Absent/empty is normal. */
   loadSummaryIndex?: () => Map<string, SummaryEntry>;
+  /**
+   * Absent means no history and no penalty — the neutral ordering. Callers must
+   * opt in, which is also what keeps unit tests off the operator's real index.
+   */
+  openHitCounts?: () => HitCountStore | null;
 }
 
-const DEFAULT_RECALL_DEPS: RecallContextDeps = { searchChat, listCwdSessions, loadSummaryIndex };
+/**
+ * Open the sidecar index read-write for counting. Never creates the index: if
+ * recall has no index yet there is no history to record, and a hook must not
+ * materialize a 12GB cache as a side effect of starting a session.
+ */
+function openSidecarHitCounts(): HitCountStore | null {
+  try {
+    const path = indexPath();
+    if (!existsSync(path)) return null;
+    const db = openIndex(path);
+    return {
+      read: (refs) => readHitCounts(db, refs),
+      bump: (refs) => bumpHitCounts(db, refs, new Date().toISOString()),
+      close: () => db.close(),
+    };
+  } catch {
+    return null; // fail-soft: ranking degrades to neutral, injection still happens.
+  }
+}
+
+const DEFAULT_RECALL_DEPS: RecallContextDeps = {
+  searchChat,
+  listCwdSessions,
+  loadSummaryIndex,
+  openHitCounts: openSidecarHitCounts,
+};
 
 function quoteUntrusted(value: string): string {
   // JSON quoting removes control/newline structure; escaping angle brackets
@@ -250,6 +321,73 @@ export function renderCwdBlock(
 }
 
 /**
+ * Pick what to inject, pushing back whatever has already been injected repeatedly.
+ *
+ * Candidates arrive newest-first, so their index IS their rank; the penalty is
+ * added to that index and the list re-sorted, which keeps the whole policy in
+ * units of list positions. Ties keep time order, so an entry never moves
+ * without an earned penalty and the output stays deterministic for a given
+ * (corpus, history) pair.
+ *
+ * Generic over the candidate shape because the two injection paths carry
+ * different records — enumerated sessions and chat hits — but rank on the same
+ * refs, so one history serves both and a session cannot dodge its count by
+ * arriving through the other door.
+ *
+ * Reading and writing happen exactly once each, here, and only for the entries
+ * that end up in the injection: read before the choice, write after it. Every
+ * failure mode degrades to the neutral order rather than to no injection —
+ * a broken history store must not cost the session its context.
+ */
+function demoteRepeats<T>(
+  candidates: T[],
+  limit: number,
+  refOf: (item: T) => string,
+  deps: RecallContextDeps,
+): T[] {
+  const neutral = candidates.slice(0, limit);
+  // No candidates means no injection, so there is nothing to record and no
+  // reason to touch the sidecar: an idle project cannot accumulate history.
+  if (candidates.length === 0) return neutral;
+  let store: HitCountStore | null = null;
+  try {
+    store = deps.openHitCounts?.() ?? null;
+  } catch {
+    return neutral;
+  }
+  if (!store) return neutral;
+  try {
+    const refs = candidates.map(refOf);
+    const counts = store.read(refs);
+    const ranked = candidates
+      .map((item, index) => ({
+        item,
+        ref: refs[index]!,
+        rank: index + hitCountPenalty(counts.get(refs[index]!) ?? 0),
+      }))
+      .sort((a, b) => a.rank - b.rank);
+    const chosen = ranked.slice(0, limit);
+    store.bump(chosen.map((c) => c.ref));
+    return chosen.map((c) => c.item);
+  } catch {
+    return neutral;
+  } finally {
+    try { store.close(); } catch { /* already closed or never opened cleanly */ }
+  }
+}
+
+/**
+ * How many candidates to gather before demoting down to `topN`.
+ *
+ * Demotion can only work if there is something below the cut to promote, so the
+ * pool widens when — and only when — a history store is configured. Without one
+ * the enumeration cost stays exactly what it was before the penalty existed.
+ */
+function candidatePool(topN: number, deps: RecallContextDeps): number {
+  return deps.openHitCounts ? topN * 2 : topN;
+}
+
+/**
  * Build compact, project-scoped context. Automatic hooks never federate across
  * CWDs: global recall remains available only through the explicit CLI command.
  * Historical text is enclosed as untrusted data so it cannot impersonate hook
@@ -267,15 +405,26 @@ export function buildCwdContext(
 
     // Preferred path: enumerate this cwd's sessions from the index directly.
     // Falls through to the text-search path when the index is unavailable.
-    const direct = deps.listCwdSessions ? deps.listCwdSessions(cwd, topN) : null;
+    const direct = deps.listCwdSessions
+      ? deps.listCwdSessions(cwd, candidatePool(topN, deps))
+      : null;
     if (direct) {
+      // Rank BEFORE rendering, and only over sessions that would actually be
+      // shown: an empty excerpt renders nothing, so charging it an injection
+      // would record a hit the agent never saw.
+      const showable = direct.filter((session) => session.excerpt !== "");
+      const chosen = demoteRepeats(
+        showable,
+        topN,
+        (session) => hitCountRef(session.threadId, session.path),
+        deps,
+      );
       // Summaries are a bonus tier: loaded once, joined by thread id, and omitted
       // entirely for sessions that have none.
-      const summaries = direct.length > 0 && deps.loadSummaryIndex ? deps.loadSummaryIndex() : null;
+      const summaries = chosen.length > 0 && deps.loadSummaryIndex ? deps.loadSummaryIndex() : null;
       const sessions: string[][] = [];
       let latestDate = "";
-      for (const session of direct) {
-        if (session.excerpt === "") continue; // nothing worth showing for this session
+      for (const session of chosen) {
         const excerpt = clip(session.excerpt, budget.snippet);
         const entry = [`  \u2022 [${session.date}] ${quoteUntrusted(excerpt)}`];
         const summary = session.threadId ? summaries?.get(session.threadId) : undefined;
@@ -312,9 +461,19 @@ export function buildCwdContext(
       const key = hit.threadId ?? hit.ts;
       if (!seenThreads.has(key)) seenThreads.set(key, hit);
     }
+
+    // Nothing is recorded before this point: a CWD with no hits injects nothing
+    // and must leave no trace, so an unused project cannot accumulate history.
+    const chosenHits = demoteRepeats(
+      [...seenThreads.values()],
+      topN,
+      (hit) => hitCountRef(hit.threadId, hit.file),
+      deps,
+    );
+
     const sessions: string[][] = [];
     let latestDate = "";
-    for (const [, hit] of [...seenThreads.entries()].slice(0, topN)) {
+    for (const hit of chosenHits) {
       const date = hit.ts.slice(0, 10);
       const raw = (hit.title ?? hit.text).replace(/\n/g, " ").trim();
       sessions.push([`  \u2022 [${date}] ${quoteUntrusted(clip(raw, 60))}`]);

--- a/plugins/codexclaw/components/recall/src/index-db.ts
+++ b/plugins/codexclaw/components/recall/src/index-db.ts
@@ -26,6 +26,25 @@ export function indexPath(env: Record<string, string | undefined> = process.env)
   return join(codexclawHome(env), "recall", "index.sqlite");
 }
 
+/**
+ * How often a thread has already been auto-injected into a session. Written and
+ * read by the hook path ALONE (hook.ts) so explicit `cxc chat/memory search`
+ * stays deterministic; nothing in the search core touches this table.
+ *
+ * Appended to SCHEMA instead of bumping INDEX_SCHEMA_VERSION: a version bump
+ * would drop and re-parse the whole corpus (measured 12GB / 1.2M messages),
+ * whereas CREATE TABLE IF NOT EXISTS lets an existing index gain the table on
+ * its next read-write open. openIndexReadOnly never runs schema statements, so
+ * every reader must tolerate the table being absent.
+ */
+const HIT_COUNTS_DDL = `
+CREATE TABLE IF NOT EXISTS recall_hit_counts (
+  ref TEXT PRIMARY KEY,
+  hit_count INTEGER NOT NULL DEFAULT 0,
+  last_hit_at TEXT NOT NULL
+);
+`;
+
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
 CREATE TABLE IF NOT EXISTS files (
@@ -65,7 +84,7 @@ CREATE TRIGGER IF NOT EXISTS msgs_ad AFTER DELETE ON msgs BEGIN
   INSERT INTO msgs_fts(msgs_fts, rowid, text) VALUES ('delete', old.id, old.text);
   INSERT INTO msgs_tri(msgs_tri, rowid, text) VALUES ('delete', old.id, old.text);
 END;
-`;
+${HIT_COUNTS_DDL}`;
 
 /** Open (creating directories/schema as needed) the sidecar index read-write. */
 export function openIndex(path: string): RwDb {
@@ -86,6 +105,7 @@ export function openIndex(path: string): RwDb {
     db.exec("DROP TRIGGER IF EXISTS msgs_ai; DROP TRIGGER IF EXISTS msgs_ad;");
     db.exec("DROP TABLE IF EXISTS msgs_fts; DROP TABLE IF EXISTS msgs_tri;");
     db.exec("DROP TABLE IF EXISTS msgs; DROP TABLE IF EXISTS files; DROP TABLE IF EXISTS meta;");
+    db.exec("DROP TABLE IF EXISTS recall_hit_counts;");
     db.exec(SCHEMA);
     db.prepare("INSERT INTO meta (key, value) VALUES ('schema_version', ?)").run(INDEX_SCHEMA_VERSION);
   }
@@ -111,6 +131,43 @@ export type IndexStatus = {
   msgs: number;
   lastIngestAt: string | null;
 };
+
+// ─── recall_hit_counts accessors ────────────────────────────────────────────
+// Storage only: how often a ref was injected, never what that should cost. The
+// penalty policy lives in hook.ts so the search core cannot grow a dependency
+// on it. Both accessors tolerate a missing table — an index created before this
+// table existed only gains it on its next read-write open.
+
+/** Stable ref for a chat hit: its thread when known, else its rollout file. */
+export function hitCountRef(threadId: string | null, file: string): string {
+  return threadId ? `thread:${threadId}` : `file:${file}`;
+}
+
+/** Injection counts for the given refs; refs never injected are simply absent. */
+export function readHitCounts(db: RwDb, refs: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  if (refs.length === 0) return counts;
+  try {
+    const holes = refs.map(() => "?").join(",");
+    const rows = db
+      .prepare(`SELECT ref, hit_count FROM recall_hit_counts WHERE ref IN (${holes})`)
+      .all(...refs) as Array<{ ref: string; hit_count: number }>;
+    for (const row of rows) counts.set(String(row.ref), Number(row.hit_count));
+  } catch {
+    // Table absent (pre-existing index opened read-only) — no history, no penalty.
+  }
+  return counts;
+}
+
+/** Increment the injection count for each ref, stamping when it last happened. */
+export function bumpHitCounts(db: RwDb, refs: string[], atIso: string): void {
+  if (refs.length === 0) return;
+  const stmt = db.prepare(
+    `INSERT INTO recall_hit_counts (ref, hit_count, last_hit_at) VALUES (?, 1, ?)
+     ON CONFLICT(ref) DO UPDATE SET hit_count = hit_count + 1, last_hit_at = excluded.last_hit_at`,
+  );
+  for (const ref of refs) stmt.run(ref, atIso);
+}
 
 export function indexStatus(db: RwDb, path: string): IndexStatus {
   const files = (db.prepare("SELECT COUNT(*) AS n FROM files").get() as { n: number }).n;

--- a/plugins/codexclaw/components/recall/test/hit-count.test.ts
+++ b/plugins/codexclaw/components/recall/test/hit-count.test.ts
@@ -1,0 +1,361 @@
+/**
+ * hit-count.test.ts — WP5 repeat-injection penalty.
+ *
+ * Two halves. The policy half drives buildCwdContext with an in-memory store so
+ * the reordering rules are pinned without touching sqlite. The storage half uses
+ * a real sidecar index in an isolated temp home to pin the two properties the
+ * roadmap made non-negotiable: the schema version does not move, and deleting
+ * the table returns ranking to neutral.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildCwdContext,
+  hitCountPenalty,
+  FULL_BUDGET,
+  type HitCountStore,
+  type RecallContextDeps,
+} from "../src/hook.ts";
+import { searchChat } from "../src/chat-search.ts";
+import { buildCodexHome } from "./fixtures.ts";
+import type { ChatHit, ChatSearchResult } from "../src/chat-search.ts";
+import type { CwdSession } from "../src/cwd-context.ts";
+import {
+  INDEX_SCHEMA_VERSION,
+  bumpHitCounts,
+  hitCountRef,
+  openIndex,
+  openIndexReadOnly,
+  readHitCounts,
+} from "../src/index-db.ts";
+
+const CWD = "/repo/current";
+
+/** Newest-first candidates, one per thread, titled by their letter. */
+function hits(...names: string[]): ChatHit[] {
+  return names.map((name, i) => ({
+    ts: new Date(Date.parse("2026-09-09T00:00:00Z") - i * 3_600_000).toISOString(),
+    role: "user",
+    text: name,
+    title: name,
+    threadId: name,
+    cwd: CWD,
+    gitBranch: null,
+    source: "main" as const,
+    file: `${name}.jsonl`,
+    matchField: "content" as const,
+    context: [],
+  }));
+}
+
+function searchReturning(chatHits: ChatHit[]): RecallContextDeps["searchChat"] {
+  return (() => ({
+    hits: chatHits,
+    warnings: [],
+    scannedFiles: chatHits.length,
+    matchedFiles: chatHits.length,
+    totalFiles: chatHits.length,
+    elapsedMs: 1,
+    mode: "scan",
+  } satisfies ChatSearchResult)) as never;
+}
+
+/** In-memory store whose `bumped` list records exactly what the injection wrote. */
+function memoryStore(counts: Record<string, number>): HitCountStore & { bumped: string[] } {
+  const bumped: string[] = [];
+  return {
+    bumped,
+    read: (refs) => new Map(refs.filter((r) => r in counts).map((r) => [r, counts[r]!])),
+    bump: (refs) => void bumped.push(...refs),
+    close: () => {},
+  };
+}
+
+/** Injected thread names, in the order the context lists them. */
+function injected(context: string): string[] {
+  return [...context.matchAll(/\u2022 \[[\d-]+\] "([^"]+)"/g)].map((m) => m[1]!);
+}
+
+test("penalty is zero below the threshold, then half a position per repeat", () => {
+  assert.equal(hitCountPenalty(0), 0);
+  assert.equal(hitCountPenalty(2), 0, "a thread may recur across a working day for free");
+  assert.equal(hitCountPenalty(3), 0.5);
+  assert.equal(hitCountPenalty(4), 1);
+  assert.equal(hitCountPenalty(9), 3.5);
+});
+
+test("no store means the neutral time order — the property that survives deletion", () => {
+  const context = buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c", "d", "e", "f")),
+  });
+  assert.deepEqual(injected(context), ["a", "b", "c", "d", "e"]);
+});
+
+test("an empty history ranks identically to having no store at all", () => {
+  const context = buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c", "d", "e", "f")),
+    openHitCounts: () => memoryStore({}),
+  });
+  assert.deepEqual(injected(context), ["a", "b", "c", "d", "e"]);
+});
+
+test("a repeatedly injected thread sinks, and enough repeats push it off the page", () => {
+  const sunk = buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c", "d", "e", "f")),
+    // 7 injections = 2.5 positions of penalty, so `a` lands between `c` and `d`.
+    openHitCounts: () => memoryStore({ "thread:a": 7 }),
+  });
+  assert.deepEqual(injected(sunk), ["b", "c", "a", "d", "e"]);
+
+  const dropped = buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c", "d", "e", "f")),
+    // 13 injections outweigh the whole candidate list; `f` takes the free slot.
+    openHitCounts: () => memoryStore({ "thread:a": 13 }),
+  });
+  assert.deepEqual(injected(dropped), ["b", "c", "d", "e", "f"]);
+});
+
+test("only the threads actually injected are counted", () => {
+  const store = memoryStore({});
+  buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c", "d", "e", "f")),
+    openHitCounts: () => store,
+  });
+  assert.deepEqual(store.bumped, ["thread:a", "thread:b", "thread:c", "thread:d", "thread:e"]);
+  assert.ok(!store.bumped.includes("thread:f"), "a candidate that lost its slot is not charged");
+});
+
+test("an injection that produces nothing records nothing", () => {
+  let opened = 0;
+  const context = buildCwdContext(CWD, {
+    // Hits exist but all belong to another CWD, so nothing is injected.
+    searchChat: searchReturning(hits("a").map((h) => ({ ...h, cwd: "/repo/other" }))),
+    openHitCounts: () => {
+      opened += 1;
+      return memoryStore({});
+    },
+  });
+  assert.equal(context, "");
+  assert.equal(opened, 0, "no injection, no history — an idle project cannot accumulate counts");
+});
+
+test("a store that cannot open leaves the injection intact and unpenalized", () => {
+  const absent = buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c")),
+    openHitCounts: () => null,
+  });
+  assert.deepEqual(injected(absent), ["a", "b", "c"]);
+
+  const thrown = buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c")),
+    openHitCounts: () => {
+      throw new Error("sidecar locked");
+    },
+  });
+  assert.deepEqual(injected(thrown), ["a", "b", "c"]);
+});
+
+test("refs fall back to the rollout file when a hit has no thread id", () => {
+  assert.equal(hitCountRef("abc", "x.jsonl"), "thread:abc");
+  assert.equal(hitCountRef(null, "x.jsonl"), "file:x.jsonl");
+});
+
+// ─── the enumerated path (the one SessionStart actually takes) ──────────────
+// listCwdSessions is preferred over the basename search whenever an index
+// exists, so a penalty that only reached the fallback would be dead code on
+// every real machine. These pin it on the live path.
+
+/** Newest-first enumerated sessions, one per thread, titled by their letter. */
+function sessions(...names: string[]): CwdSession[] {
+  return names.map((name, i) => ({
+    path: `${name}.jsonl`,
+    threadId: name,
+    date: `2026-09-${String(9 - i).padStart(2, "0")}`,
+    excerpt: name,
+  }));
+}
+
+const throwingSearch = (() => {
+  throw new Error("searchChat must not run when direct enumeration succeeds");
+}) as never;
+
+test("the enumerated path demotes repeats too, not just the search fallback", () => {
+  const all = sessions("a", "b", "c", "d", "e", "f");
+  const sunk = buildCwdContext(CWD, {
+    searchChat: throwingSearch,
+    listCwdSessions: (_cwd, topN) => all.slice(0, topN),
+    // 7 injections = 2.5 positions, so `a` lands between `c` and `d`.
+    openHitCounts: () => memoryStore({ "thread:a": 7 }),
+  });
+  assert.deepEqual(injected(sunk), ["b", "c", "a", "d", "e"]);
+});
+
+test("demotion widens the enumeration pool only when a history store exists", () => {
+  // Nothing below the cut means nothing to promote into it, so the pool has to
+  // be wider than topN — but only when the penalty can actually use the extra.
+  const asked: number[] = [];
+  const listCwdSessions = (_cwd: string, topN: number) => {
+    asked.push(topN);
+    return sessions("a", "b", "c", "d", "e", "f", "g", "h", "i", "j").slice(0, topN);
+  };
+  buildCwdContext(CWD, { searchChat: throwingSearch, listCwdSessions });
+  assert.deepEqual(asked, [FULL_BUDGET.topN], "no store: enumeration cost is unchanged");
+
+  asked.length = 0;
+  const promoted = buildCwdContext(CWD, {
+    searchChat: throwingSearch,
+    listCwdSessions,
+    openHitCounts: () => memoryStore({ "thread:a": 40 }),
+  });
+  assert.deepEqual(asked, [FULL_BUDGET.topN * 2]);
+  assert.deepEqual(injected(promoted), ["b", "c", "d", "e", "f"], "the pool supplied the promotion");
+});
+
+test("a session with nothing to show is never charged an injection", () => {
+  const store = memoryStore({});
+  const context = buildCwdContext(CWD, {
+    searchChat: throwingSearch,
+    listCwdSessions: () => [
+      { path: "a.jsonl", threadId: "a", date: "2026-09-09", excerpt: "" },
+      { path: "b.jsonl", threadId: "b", date: "2026-09-08", excerpt: "b" },
+    ],
+    openHitCounts: () => store,
+  });
+  assert.deepEqual(injected(context), ["b"]);
+  assert.deepEqual(store.bumped, ["thread:b"], "an unrendered session was never seen, so never counted");
+});
+
+test("one history serves both paths: the same session refs either way", () => {
+  // A thread must not shed its count by arriving through the other door, which
+  // holds only because both paths key on hitCountRef(threadId, file|path).
+  const enumerated = memoryStore({});
+  buildCwdContext(CWD, {
+    searchChat: throwingSearch,
+    listCwdSessions: (_cwd, topN) => sessions("a", "b", "c").slice(0, topN),
+    openHitCounts: () => enumerated,
+  });
+  const searched = memoryStore({});
+  buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c")),
+    openHitCounts: () => searched,
+  });
+  assert.deepEqual(enumerated.bumped, searched.bumped);
+});
+
+// ─── storage: real sidecar index ────────────────────────────────────────────
+
+let home: string;
+let idx: string;
+
+test.before(() => {
+  home = mkdtempSync(join(tmpdir(), "recall-hits-"));
+  idx = join(home, "recall", "index.sqlite");
+});
+
+test.after(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+test("the table arrives without moving the schema version", () => {
+  assert.equal(INDEX_SCHEMA_VERSION, "2", "a bump re-parses the entire corpus (12GB measured)");
+  const db = openIndex(idx);
+  try {
+    const version = db.prepare("SELECT value FROM meta WHERE key = 'schema_version'").get() as
+      | { value: string }
+      | undefined;
+    assert.equal(version?.value, "2");
+    const table = db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'recall_hit_counts'")
+      .get();
+    assert.ok(table, "CREATE TABLE IF NOT EXISTS added it in place");
+  } finally {
+    db.close();
+  }
+});
+
+test("counts accumulate and are readable back", () => {
+  const db = openIndex(idx);
+  try {
+    bumpHitCounts(db, ["thread:a", "thread:b"], "2026-09-09T00:00:00Z");
+    bumpHitCounts(db, ["thread:a"], "2026-09-09T01:00:00Z");
+    const counts = readHitCounts(db, ["thread:a", "thread:b", "thread:missing"]);
+    assert.equal(counts.get("thread:a"), 2);
+    assert.equal(counts.get("thread:b"), 1);
+    assert.equal(counts.has("thread:missing"), false);
+    const row = db
+      .prepare("SELECT last_hit_at FROM recall_hit_counts WHERE ref = 'thread:a'")
+      .get() as { last_hit_at: string };
+    assert.equal(row.last_hit_at, "2026-09-09T01:00:00Z", "the stamp tracks the latest injection");
+  } finally {
+    db.close();
+  }
+});
+
+test("dropping the table returns ranking to neutral instead of failing", () => {
+  const drop = openIndex(idx);
+  try {
+    drop.exec("DROP TABLE recall_hit_counts");
+  } finally {
+    drop.close();
+  }
+
+  // A read-only handle never runs schema statements, so it sees the table gone —
+  // the same situation as an index built before this table existed.
+  const ro = openIndexReadOnly(idx);
+  try {
+    assert.deepEqual(readHitCounts(ro, ["thread:a"]), new Map(), "absent table reads as no history");
+  } finally {
+    ro.close();
+  }
+
+  const neutral = buildCwdContext(CWD, {
+    searchChat: searchReturning(hits("a", "b", "c", "d", "e", "f")),
+    openHitCounts: () => {
+      const db = openIndexReadOnly(idx);
+      return {
+        read: (refs: string[]) => readHitCounts(db, refs),
+        bump: () => {},
+        close: () => db.close(),
+      };
+    },
+  });
+  assert.deepEqual(injected(neutral), ["a", "b", "c", "d", "e"], "history erased, order restored");
+
+  // The next read-write open recreates it empty, so counting resumes from zero.
+  const again = openIndex(idx);
+  try {
+    assert.deepEqual(readHitCounts(again, ["thread:a"]), new Map());
+    bumpHitCounts(again, ["thread:a"], "2026-09-09T02:00:00Z");
+    assert.equal(readHitCounts(again, ["thread:a"]).get("thread:a"), 1);
+  } finally {
+    again.close();
+  }
+});
+
+test("explicit chat search is unaffected by injection history", () => {
+  const corpus = mkdtempSync(join(tmpdir(), "recall-hits-explicit-"));
+  const path = join(corpus, "sidecar", "index.sqlite");
+  try {
+    buildCodexHome(corpus);
+    const run = () => searchChat("trigram", { home: corpus, indexPath: path, source: "all" });
+    const before = run().hits.map((h) => `${h.ts}|${h.file}`);
+    assert.ok(before.length > 1, "the fixture corpus must give the ranking something to order");
+
+    // Saturate the history for every thread the query returns. If the penalty
+    // could reach the search core at all, this is the input that would move it.
+    const db = openIndex(path);
+    try {
+      const refs = run().hits.map((h) => hitCountRef(h.threadId, h.file));
+      for (let i = 0; i < 20; i += 1) bumpHitCounts(db, refs, "2026-09-09T00:00:00Z");
+    } finally {
+      db.close();
+    }
+
+    assert.deepEqual(run().hits.map((h) => `${h.ts}|${h.file}`), before);
+  } finally {
+    rmSync(corpus, { recursive: true, force: true });
+  }
+});

--- a/plugins/codexclaw/skills/recall/SKILL.md
+++ b/plugins/codexclaw/skills/recall/SKILL.md
@@ -134,3 +134,15 @@ alternate root covers the rare multi-root case without a registry or rerank laye
 The sidecar index self-refreshes on every query (changed files only). `cxc chat index
 --status` shows freshness; `--rebuild` drops and re-ingests after schema-level doubts.
 Deleting `~/.codexclaw/recall/index.sqlite` is always safe (rebuildable cache).
+
+## Automatic session-start injection
+
+Separate from these commands, the SessionStart hook injects a short CWD-scoped list of
+recent sessions, including the start that follows a compaction. That list rotates: a
+session already injected several times is pushed back so a start sees something it has
+not seen yet. Counts live in the same rebuildable sidecar, so deleting the index also
+resets the rotation to plain newest-first.
+
+The rotation applies to the automatic injection ALONE. `cxc chat search` and `cxc memory
+search` never consult it: the same query returns the same ranking however many times you
+run it.


### PR DESCRIPTION
## What this fixes

Automatic recall injection kept surfacing the same threads. `buildCwdContext` reduces its search to one hit per thread in newest-first order, so a thread that dominates recent history occupies a slot every session and crowds out anything else the CWD has to offer.

A `demoteRepeats` step now adds `hitCountPenalty(count)` to each candidate's index, re-sorts, and takes the top five. Because candidates arrive one position apart, jawcode's `(count - threshold + 1) * 0.5` reads directly as list positions: half a unit is half a place, and a thread needs several repeats past a free threshold of three before it actually loses a slot. The three free injections exist so a thread that genuinely is the current work is not punished for being right.

## Explicit search stays deterministic, structurally

`index-db.ts` gained storage only — `hitCountRef`, `readHitCounts`, `bumpHitCounts` — and none of it knows what a count should cost. Nothing in `chat-search.ts`, `index-search.ts` or `memory-search.ts` calls any of it, and there is no flag that could later expose the penalty through the CLI. A user repeating the same query gets the same answer.

The test for this saturates the history to 20 injections for every thread a fixture query returns, then asserts the explicit `searchChat` result is byte-identical before and after.

## The schema version does not move

`INDEX_SCHEMA_VERSION` stays `"2"`, verified three ways: the diff against the base branch contains no change to the assignment, the compiled `dist/index-db.js` still reads `= "2"`, and a test asserts the constant while also opening a real index to confirm `meta.schema_version` is `"2"` and `recall_hit_counts` exists. A future bump breaks a test instead of silently triggering a 12GB reparse. The table is appended to `SCHEMA` as `CREATE TABLE IF NOT EXISTS` and added to the drop list in the existing version-mismatch rebuild branch so that path stays consistent.

## Deleting the table returns ranking to neutral

`openIndexReadOnly` never runs schema statements, so both accessors treat a missing table as empty history. One test drops the table mid-run, reads through a read-only handle, confirms the original newest-first order, then reopens read-write and shows counting resumes from zero.

Writes are bounded: nothing is recorded before the injection is known to be non-empty, so a CWD with no hits leaves no trace, and only the five threads that made the page are charged.

## Note on stacking

This branch chains on top of #103, but this repo's `enforce-pr-target` workflow requires every PR to target `dev`, so the diff here also shows #103's two commits. Merging #103 first reduces this PR to `b28b409e` alone.

## Verification

Recall suite 92/92 (81 pre-existing plus new cases), `npm run gate` OK, `dist-freshness` passing after `npm run build`. Full `npm test` is 2714 pass with the pre-existing `gui/test/router.test.ts` failure — this worktree has no `node_modules` for `react`.
