### PR TITLE
Scope memory search by project and fall back to chat on a miss

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -14,11 +14,11 @@
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 <<<<<<< HEAD
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 ||||||| parent of 30203965 (Publish the test count this branch's suite measures)
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 =======
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 >>>>>>> 30203965 (Publish the test count this branch's suite measures)
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-24-blue" alt="24 hooks">

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 <<<<<<< HEAD
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 ||||||| parent of 30203965 (Publish the test count this branch's suite measures)
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 =======
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 >>>>>>> 30203965 (Publish the test count this branch's suite measures)
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-24-blue" alt="24 hooks">

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,11 +14,11 @@
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
 <<<<<<< HEAD
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 ||||||| parent of 30203965 (Publish the test count this branch's suite measures)
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 =======
-  <img src="https://img.shields.io/badge/tests-2%2C757_passing-brightgreen" alt="2,757 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C777_passing-brightgreen" alt="2,777 tests passing">
 >>>>>>> 30203965 (Publish the test count this branch's suite measures)
   <img src="https://img.shields.io/badge/skills-28-blue" alt="28 skills">
   <img src="https://img.shields.io/badge/hooks-24-blue" alt="24 hooks">

--- a/docs-site/src/content/docs/reference/commands.md
+++ b/docs-site/src/content/docs/reference/commands.md
@@ -166,7 +166,7 @@ cxc chat search "<query>" [--days N] [--cwd PATH] [--role user|assistant|tool] [
                          [--recent] [--scan] [--no-refresh] [--json] [--full] [--home PATH]
 cxc chat index [--rebuild] [--status] [--json] [--home PATH] [--index-path PATH]
 cxc memory search "<query>" [--days N] [--limit N] [--any] [--no-synonyms]
-                          [--cwd PATH] [--cwd-only PATH] [--json] [--home PATH]
+                          [--cwd PATH] [--cwd-only PATH] [--no-chat] [--json] [--home PATH]
 ```
 
 Recall commands are read-only against Codex data. `cxc chat index` writes only the derived

--- a/docs-site/src/content/docs/reference/commands.md
+++ b/docs-site/src/content/docs/reference/commands.md
@@ -165,7 +165,8 @@ cxc chat search "<query>" [--days N] [--cwd PATH] [--role user|assistant|tool] [
                          [--limit N] [--context N] [--any] [--all] [--no-tools]
                          [--recent] [--scan] [--no-refresh] [--json] [--full] [--home PATH]
 cxc chat index [--rebuild] [--status] [--json] [--home PATH] [--index-path PATH]
-cxc memory search "<query>" [--days N] [--limit N] [--any] [--json] [--home PATH]
+cxc memory search "<query>" [--days N] [--limit N] [--any] [--no-synonyms]
+                          [--cwd PATH] [--cwd-only PATH] [--json] [--home PATH]
 ```
 
 Recall commands are read-only against Codex data. `cxc chat index` writes only the derived

--- a/plugins/codexclaw/components/recall/dist/cli.js
+++ b/plugins/codexclaw/components/recall/dist/cli.js
@@ -28,7 +28,7 @@ const USAGE = [
   "                           [--recent] [--scan] [--no-refresh] [--json]",
   "cxc chat index [--rebuild] [--status] [--json]",
   "cxc memory search \"<query>\" [--days N] [--limit N] [--any] [--no-synonyms]",
-  "                             [--cwd PATH] [--cwd-only PATH] [--json]",
+  "                             [--cwd PATH] [--cwd-only PATH] [--no-chat] [--json]",
   "",
   `  --days N     restrict to the last N days (chat default ${DEFAULT_DAYS}, 0 = full history)`,
   "  --cwd PATH   chat: only sessions under PATH; memory: rank hits under PATH first",
@@ -42,6 +42,7 @@ const USAGE = [
   "  --no-tools   skip tool call/output (tool_log) matching",
   "  --recent     order by time instead of relevance (index engine default: relevance)",
   "  --rank       order by relevance (the default; accepted for explicitness)",
+  "  --no-chat    memory search: do not fall back to raw chat when nothing matches",
   "  --scan       force the raw JSONL scan path (skip the sidecar index)",
   "  --no-refresh skip refresh-on-query ingest (fastest, index may be stale)",
   "  --no-synonyms memory search: raw words only — no ko/en synonyms, no korean stem",
@@ -74,6 +75,7 @@ function parseFlags(args          )              {
       scan: { type: "boolean", default: false },
       "no-refresh": { type: "boolean", default: false },
       "no-synonyms": { type: "boolean", default: false },
+      "no-chat": { type: "boolean", default: false },
       full: { type: "boolean", default: false },
       rebuild: { type: "boolean", default: false },
       status: { type: "boolean", default: false },
@@ -147,6 +149,9 @@ function runMemorySearch(args          )         {
     // Bare `--cwd-only` (parsed as a boolean) hardens an accompanying --cwd.
     cwd: typeof values["cwd-only"] === "string" ? values["cwd-only"] : typeof values.cwd === "string" ? values.cwd : null,
     cwdOnly: values["cwd-only"] !== undefined && values["cwd-only"] !== false,
+    // Injected rather than imported by memory-search: the module keeps no edge
+    // to chat-search, and the fallback is one flag away from being off.
+    searchChat: values["no-chat"] === true ? undefined : searchChat,
   };
   const result = searchMemory(query, opts);
   process.stdout.write(

--- a/plugins/codexclaw/components/recall/dist/cli.js
+++ b/plugins/codexclaw/components/recall/dist/cli.js
@@ -27,10 +27,12 @@ const USAGE = [
   "                           [--limit N] [--context N] [--any] [--all] [--no-tools]",
   "                           [--recent] [--scan] [--no-refresh] [--json]",
   "cxc chat index [--rebuild] [--status] [--json]",
-  "cxc memory search \"<query>\" [--days N] [--limit N] [--any] [--no-synonyms] [--json]",
+  "cxc memory search \"<query>\" [--days N] [--limit N] [--any] [--no-synonyms]",
+  "                             [--cwd PATH] [--cwd-only PATH] [--json]",
   "",
   `  --days N     restrict to the last N days (chat default ${DEFAULT_DAYS}, 0 = full history)`,
-  "  --cwd PATH   only sessions whose working directory starts with PATH",
+  "  --cwd PATH   chat: only sessions under PATH; memory: rank hits under PATH first",
+  "  --cwd-only PATH  memory search: drop hits recorded outside PATH",
   "  --role r     only messages with this role (user|assistant|tool)",
   "  --source s   main (default) | subagent | all",
   `  --limit N    max hits (chat default ${DEFAULT_LIMIT}, memory default ${DEFAULT_MEMORY_LIMIT})`,
@@ -62,6 +64,7 @@ function parseFlags(args          )              {
       context: { type: "string", short: "c" },
       role: { type: "string" },
       cwd: { type: "string" },
+      "cwd-only": { type: "string" },
       source: { type: "string" },
       any: { type: "boolean", default: false },
       all: { type: "boolean", default: false },
@@ -140,6 +143,10 @@ function runMemorySearch(args          )         {
     any: values.any === true,
     synonyms: values["no-synonyms"] !== true,
     home: typeof values.home === "string" ? values.home : undefined,
+    // --cwd-only carries its own path, so `--cwd-only PATH` needs no second flag.
+    // Bare `--cwd-only` (parsed as a boolean) hardens an accompanying --cwd.
+    cwd: typeof values["cwd-only"] === "string" ? values["cwd-only"] : typeof values.cwd === "string" ? values.cwd : null,
+    cwdOnly: values["cwd-only"] !== undefined && values["cwd-only"] !== false,
   };
   const result = searchMemory(query, opts);
   process.stdout.write(

--- a/plugins/codexclaw/components/recall/dist/format.js
+++ b/plugins/codexclaw/components/recall/dist/format.js
@@ -57,7 +57,8 @@ export function formatMemoryResult(result                    )         {
     lines.push("");
     const loc = hit.startLine !== null ? `${hit.relpath}:${hit.startLine}` : hit.relpath;
     const when = hit.updatedAt ? ` [${hit.updatedAt}]` : "";
-    lines.push(`(${hit.origin}/${hit.kind}) ${loc}${when}`);
+    const cwd = hit.cwd ? ` {${hit.cwd}}` : "";
+    lines.push(`(${hit.origin}/${hit.kind}) ${loc}${when}${cwd}`);
     lines.push(clip(hit.excerpt, EXCERPT));
     lines.push("---");
   }

--- a/plugins/codexclaw/components/recall/dist/memory-search.js
+++ b/plugins/codexclaw/components/recall/dist/memory-search.js
@@ -24,8 +24,24 @@ import {
 } from "./query-words.js";
 import { expandQueryWords } from "./synonyms.js";
 import { splitLines } from "./text-lines.js";
+// Type-only: erased by the type-stripping build, so memory search still ships
+// with no runtime edge to chat-search.ts. The function itself arrives through
+// MemorySearchOptions.searchChat (the RecallContextDeps pattern in hook.ts).
+
+
+
 
 export const DEFAULT_MEMORY_LIMIT = 20;
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -71,6 +87,7 @@ export const DEFAULT_MEMORY_LIMIT = 20;
 
 
 
+
 /** Hits from the same file beyond this cap are dropped so one fat file (MEMORY.md) cannot consume every slot. */
 const PER_FILE_CAP = 2;
 
@@ -91,8 +108,9 @@ const RELAXED_PENALTY = 2;
 export const CWD_BOOST = 2;
 
 /** Classify a memories-root relpath into its artifact kind. */
-export function kindOfRelpath(relpath        , origin                    = "file")             {
+export function kindOfRelpath(relpath        , origin                      = "file")             {
   if (origin === "stage1") return "stage1";
+  if (origin === "chat") return "chat";
   if (relpath === "memory_summary.md") return "summary";
   if (relpath === "MEMORY.md") return "handbook";
   if (relpath === "raw_memories.md") return "raw";
@@ -115,6 +133,10 @@ export const KIND_PRIORITY                             = {
   raw: 0.5,
   rollout: 0,
   stage1: 0,
+  // Raw conversation is the least consolidated source there is; it only ever
+  // appears when nothing else answered, so its priority only orders the
+  // backfill against itself.
+  chat: -1,
   other: 0,
 };
 
@@ -123,6 +145,7 @@ export const HALF_LIFE_HOURS                             = {
   rollout: 24 * 7,
   stage1: 24 * 7,
   other: 24 * 7,
+  chat: 24 * 7,
   raw: 24 * 30,
   extension: 24 * 90,
   summary: Infinity,
@@ -435,12 +458,89 @@ export function searchMemory(query        , opts                      = {})     
       warnings.push("no word-boundary matches — showing substring matches (lower confidence)");
     }
   }
-  if (candidates.length === 0 && scope?.only) {
+  const hits = rankAndTrim(candidates, limit);
+  const backfilled = backfillFromChat(query, hits, opts, home, scope, limit, nowMs, days, warnings);
+  // Only advise widening the scope when nothing at all came back; the chat
+  // backfill answers within the same scope and carries its own warning.
+  if (backfilled.length === 0 && scope?.only) {
     warnings.push(`no matches inside --cwd-only ${scope.prefix} — retry with --cwd to rank it first instead`);
   }
+  return { hits: backfilled, warnings, scannedFiles, elapsedMs: Date.now() - started };
+}
 
-  const hits = rankAndTrim(candidates, limit);
-  return { hits, warnings, scannedFiles, elapsedMs: Date.now() - started };
+/** Chat backfill excerpt length, matching the memory excerpt window. */
+const CHAT_EXCERPT = 400;
+
+/**
+ * Backfill an empty memory result from the chat corpus.
+ *
+ * The memory store is consolidated and therefore lags: a topic discussed an
+ * hour ago has no summary yet, and the honest answer "no memories" hides a
+ * conversation that does exist. Chat hits are labelled `chat/chat` and
+ * announced in the warnings so a backfilled answer is never mistaken for a
+ * curated one.
+ *
+ * Tool logs are excluded. They are the measured pollution source — command text
+ * and file dumps match almost any query — and a backfill exists to surface what
+ * was said, not what was executed.
+ *
+ * The call is skipped entirely unless the caller injected searchChat, so the
+ * memory path keeps its cost when nothing needs backfilling.
+ */
+function backfillFromChat(
+  query        ,
+  hits             ,
+  opts                     ,
+  home        ,
+  scope                 ,
+  limit        ,
+  nowMs        ,
+  days        ,
+  warnings          ,
+)              {
+  const chat = opts.searchChat;
+  const threshold = Math.max(opts.chatFallbackBelow ?? 0, 0);
+  if (chat === undefined || hits.length > threshold) return hits;
+  const want = Math.min(limit, 5);
+  try {
+    const result = chat(query, {
+      home,
+      // Full history by default: a backfill that inherited chat's 7-day window
+      // would go looking for old context and find only the last week of it.
+      days,
+      limit: want,
+      // Never trigger ingest here — a refresh over the multi-GB index would
+      // dwarf the entire memory search it is standing in for.
+      noRefresh: true,
+      includeTools: opts.chatIncludeTools === true,
+      source: "main",
+      context: 0,
+      // A hard memory scope stays hard in the backfill; a boost does not filter.
+      cwd: scope?.only ? scope.prefix : null,
+    });
+    const out              = result.hits.slice(0, want).map((hit) => {
+      const updatedMs = Date.parse(hit.ts);
+      return {
+        origin: "chat",
+        kind: "chat",
+        relpath: hit.file,
+        threadId: hit.threadId,
+        updatedAt: hit.ts,
+        excerpt: hit.text.slice(0, CHAT_EXCERPT),
+        startLine: null,
+        cwd: hit.cwd,
+        score: finalScore(0, "chat", Number.isFinite(updatedMs) ? updatedMs : null, nowMs),
+      };
+    });
+    if (out.length === 0) return hits;
+    warnings.push(
+      `no memory artifacts matched — ${out.length} raw session message(s) shown instead (tool logs excluded)`,
+    );
+    return out;
+  } catch (err) {
+    warnings.push(`chat fallback unavailable (${err instanceof Error ? err.message : String(err)})`);
+    return hits;
+  }
 }
 
 /** stage1_outputs holds per-thread raw_memory + rollout_summary; read-only, fail-soft. */

--- a/plugins/codexclaw/components/recall/dist/memory-search.js
+++ b/plugins/codexclaw/components/recall/dist/memory-search.js
@@ -9,10 +9,10 @@
  * source_updated_at).
  */
 import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
-import { join, relative, resolve, sep } from "node:path";
+import { join, relative, resolve, sep, posix as posixPath, win32 as win32Path } from "node:path";
 import { codexHome, memoriesDir, memoriesDbPath, stateDbPath } from "./paths.js";
 import { openReadOnlyDb, loadThreadMeta,                 } from "./threads-db.js";
-import { cwdMatches } from "./rollout.js";
+import { cwdMatches, normalizeCwd } from "./rollout.js";
 import {
   splitQueryWordsRaw,
   termIndexOf,
@@ -278,17 +278,29 @@ function frontmatterCwd(content        )                {
 
 
 
+
 function buildCwdScope(home        , opts                     , warnings          )                  {
   const raw = opts.cwd ?? null;
   if (raw === null || raw.trim() === "") return null;
-  // resolve() so `--cwd .` and a trailing slash mean the same directory the
-  // separator-aware prefix test expects.
-  const prefix = resolve(raw);
+  // Relative input resolves against the process cwd so `--cwd .` means this
+  // directory; an absolute path is left alone, because resolve() rewrites its
+  // separators to the host style while stored cwds keep the style of whatever
+  // platform recorded them. Absoluteness is judged under both path flavors: a
+  // POSIX path is still absolute when read on Windows, and vice versa.
+  const absolute = posixPath.isAbsolute(raw) || win32Path.isAbsolute(raw);
+  const prefix = normalizeCwd(absolute ? raw : resolve(raw));
   // The join only pays for itself when a scope is requested: loading 12,908
   // thread rows costs ~90ms against a search budget measured in tens of ms.
   const meta = loadThreadMeta(stateDbPath(home));
   if (meta.warning) warnings.push(meta.warning);
-  return { prefix, lowerPrefix: prefix.toLowerCase(), only: opts.cwdOnly === true, threadCwd: meta.byId };
+  // Prose carries whatever separator its author typed, so both spellings count.
+  const lower = prefix.toLowerCase();
+  return {
+    prefix,
+    lowerPrefixes: [lower, lower.replace(/\//g, "\\")],
+    only: opts.cwdOnly === true,
+    threadCwd: meta.byId,
+  };
 }
 
 /**
@@ -308,7 +320,7 @@ function scopeAdjust(
   if (scope === null) return { keep: true, bonus: 0 };
   const matched = hitCwd !== null && hitCwd !== "" && cwdMatches(hitCwd, scope.prefix);
   if (matched) return { keep: true, bonus: CWD_BOOST };
-  const mentioned = lowerText.includes(scope.lowerPrefix);
+  const mentioned = scope.lowerPrefixes.some((p) => lowerText.includes(p));
   if (mentioned) return { keep: true, bonus: CWD_BOOST / 2 };
   return { keep: !scope.only, bonus: 0 };
 }

--- a/plugins/codexclaw/components/recall/dist/memory-search.js
+++ b/plugins/codexclaw/components/recall/dist/memory-search.js
@@ -9,9 +9,10 @@
  * source_updated_at).
  */
 import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
-import { join, relative, sep } from "node:path";
-import { codexHome, memoriesDir, memoriesDbPath } from "./paths.js";
-import { openReadOnlyDb } from "./threads-db.js";
+import { join, relative, resolve, sep } from "node:path";
+import { codexHome, memoriesDir, memoriesDbPath, stateDbPath } from "./paths.js";
+import { openReadOnlyDb, loadThreadMeta,                 } from "./threads-db.js";
+import { cwdMatches } from "./rollout.js";
 import {
   splitQueryWordsRaw,
   termIndexOf,
@@ -25,6 +26,10 @@ import { expandQueryWords } from "./synonyms.js";
 import { splitLines } from "./text-lines.js";
 
 export const DEFAULT_MEMORY_LIMIT = 20;
+
+
+
+
 
 
 
@@ -64,6 +69,8 @@ export const DEFAULT_MEMORY_LIMIT = 20;
 
 
 
+
+
 /** Hits from the same file beyond this cap are dropped so one fat file (MEMORY.md) cannot consume every slot. */
 const PER_FILE_CAP = 2;
 
@@ -74,6 +81,14 @@ const PER_FILE_CAP = 2;
  * survives even if a future caller merges the two passes.
  */
 const RELAXED_PENALTY = 2;
+
+/**
+ * Score added to a hit recorded under the requested project (`--cwd`). Worth one
+ * coverage group, so an in-project hit outranks an equally relevant hit from
+ * another project without overriding text relevance: a five-group match
+ * elsewhere still beats a one-group match here.
+ */
+export const CWD_BOOST = 2;
 
 /** Classify a memories-root relpath into its artifact kind. */
 export function kindOfRelpath(relpath        , origin                    = "file")             {
@@ -206,6 +221,75 @@ function frontmatterThreadId(content        )                {
   return m ? m[1] : null;
 }
 
+/**
+ * `cwd:` from a file's leading frontmatter block — the contiguous `key: value`
+ * lines before the first blank line.
+ *
+ * Reading `^cwd:` anywhere near the top instead is wrong on the live store:
+ * `raw_memories.md` concatenates 448 per-thread blocks, each with its own
+ * `cwd:`, and the first one would label the whole file with a single project.
+ * All 256 rollout summaries carry cwd in their leading block, so the accurate
+ * reading costs nothing there. Chunks inside an aggregate file still reach the
+ * scope through the path mention in their own body.
+ */
+function frontmatterCwd(content        )                {
+  for (const line of splitLines(content.slice(0, 2_000))) {
+    if (line.trim() === "") return null; // end of the leading block
+    const m = /^([a-z_]+):\s*(\S+)/.exec(line);
+    if (!m) return null; // a heading or prose: this file has no frontmatter
+    if (m[1] === "cwd") return m[2];
+  }
+  return null;
+}
+
+/**
+ * Project scope for one search. Holds the normalized prefix, whether it filters
+ * or only boosts, and the thread metadata used to give stage1 rows a cwd —
+ * `stage1_outputs` has no cwd column, so the only accurate source is a
+ * thread_id join against the Codex state db.
+ */
+
+
+
+
+
+
+
+function buildCwdScope(home        , opts                     , warnings          )                  {
+  const raw = opts.cwd ?? null;
+  if (raw === null || raw.trim() === "") return null;
+  // resolve() so `--cwd .` and a trailing slash mean the same directory the
+  // separator-aware prefix test expects.
+  const prefix = resolve(raw);
+  // The join only pays for itself when a scope is requested: loading 12,908
+  // thread rows costs ~90ms against a search budget measured in tens of ms.
+  const meta = loadThreadMeta(stateDbPath(home));
+  if (meta.warning) warnings.push(meta.warning);
+  return { prefix, lowerPrefix: prefix.toLowerCase(), only: opts.cwdOnly === true, threadCwd: meta.byId };
+}
+
+/**
+ * How one candidate relates to the requested project.
+ *
+ * A structured `cwd` (summary frontmatter, or threads.cwd for a stage1 row) is
+ * the strong signal. Curated files carry no cwd at all, so a chunk that names
+ * the path in prose — MEMORY.md writes `applies_to: cwd=/...` — counts as a
+ * weaker one at half the boost. Without that second signal `--cwd-only` would
+ * discard the handbook entirely, which is where project rules actually live.
+ */
+function scopeAdjust(
+  scope                 ,
+  hitCwd               ,
+  lowerText        ,
+)                                   {
+  if (scope === null) return { keep: true, bonus: 0 };
+  const matched = hitCwd !== null && hitCwd !== "" && cwdMatches(hitCwd, scope.prefix);
+  if (matched) return { keep: true, bonus: CWD_BOOST };
+  const mentioned = lowerText.includes(scope.lowerPrefix);
+  if (mentioned) return { keep: true, bonus: CWD_BOOST / 2 };
+  return { keep: !scope.only, bonus: 0 };
+}
+
 /** Paragraph chunks with their 1-based start line, for jump-to-source output. */
 export function paragraphChunks(content        )                                             {
   const chunks                                             = [];
@@ -278,6 +362,7 @@ export function searchMemory(query        , opts                      = {})     
 
   const root = memoriesDir(home);
   const files = listMarkdownFiles(root);
+  const scope = buildCwdScope(home, opts, warnings);
 
   const collect = (active              )              => {
     const candidates              = [];
@@ -300,9 +385,15 @@ export function searchMemory(query        , opts                      = {})     
       if (threadId) matchedThreadIds.add(threadId);
       const relpath = relative(root, file).split(sep).join("/");
       const kind = kindOfRelpath(relpath, "file");
+      // Frontmatter first, then the thread join: a summary states its own cwd,
+      // and a file that only carries a thread_id still resolves through state.
+      const fileCwd =
+        frontmatterCwd(content) ?? (threadId ? scope?.threadCwd.get(threadId)?.cwd ?? null : null);
       for (const chunk of paragraphChunks(content)) {
         const lower = chunk.text.toLowerCase();
         if (!matches(lower, active, anyMode)) continue;
+        const scoped = scopeAdjust(scope, fileCwd, lower);
+        if (!scoped.keep) continue;
         candidates.push({
           origin: "file",
           kind,
@@ -312,11 +403,23 @@ export function searchMemory(query        , opts                      = {})     
           updatedAt: new Date(mtimeMs).toISOString(),
           excerpt: excerptAround(chunk.text, firstPresentMember(lower, active), 400),
           startLine: chunk.startLine,
-          score: finalScore(scoreChunk(lower, active, lowerPhrase), kind, mtimeMs, nowMs),
+          cwd: fileCwd,
+          score: finalScore(scoreChunk(lower, active, lowerPhrase), kind, mtimeMs, nowMs) + scoped.bonus,
         });
       }
     }
-    searchStage1(home, active, anyMode, cutoffMs, lowerPhrase, nowMs, candidates, matchedThreadIds, warnings);
+    searchStage1(
+      home,
+      active,
+      anyMode,
+      cutoffMs,
+      lowerPhrase,
+      nowMs,
+      candidates,
+      matchedThreadIds,
+      warnings,
+      scope,
+    );
     return candidates;
   };
 
@@ -331,6 +434,9 @@ export function searchMemory(query        , opts                      = {})     
       for (const hit of candidates) hit.score -= RELAXED_PENALTY;
       warnings.push("no word-boundary matches — showing substring matches (lower confidence)");
     }
+  }
+  if (candidates.length === 0 && scope?.only) {
+    warnings.push(`no matches inside --cwd-only ${scope.prefix} — retry with --cwd to rank it first instead`);
   }
 
   const hits = rankAndTrim(candidates, limit);
@@ -348,6 +454,7 @@ function searchStage1(
   candidates             ,
   matchedThreadIds             ,
   warnings          ,
+  scope                 ,
 )       {
   const dbPath = memoriesDbPath(home);
   if (!dbPath) {
@@ -386,6 +493,11 @@ function searchStage1(
       const lowerBody = body.toLowerCase();
       // The LIKE prefilter above ignores boundaries; enforce them here.
       if (!matches(lowerBody, groups, anyMode)) continue;
+      // stage1_outputs has no cwd column (schema dump, 011 4.3); threads.cwd is
+      // the accurate substitute and it covered all 516 rows in the live store.
+      const rowCwd = threadId ? scope?.threadCwd.get(threadId)?.cwd ?? null : null;
+      const scoped = scopeAdjust(scope, rowCwd, lowerBody);
+      if (!scoped.keep) continue;
       const updatedMs = updatedSec !== null ? updatedSec * 1000 : null;
       candidates.push({
         origin: "stage1",
@@ -395,7 +507,8 @@ function searchStage1(
         updatedAt: updatedMs !== null ? new Date(updatedMs).toISOString() : null,
         excerpt: excerptAround(body, firstPresentMember(lowerBody, groups), 400),
         startLine: null,
-        score: finalScore(scoreChunk(lowerBody, groups, lowerPhrase), "stage1", updatedMs, nowMs),
+        cwd: rowCwd,
+        score: finalScore(scoreChunk(lowerBody, groups, lowerPhrase), "stage1", updatedMs, nowMs) + scoped.bonus,
       });
     }
   } catch (err) {

--- a/plugins/codexclaw/components/recall/dist/rollout.js
+++ b/plugins/codexclaw/components/recall/dist/rollout.js
@@ -65,11 +65,29 @@ export function localDateString(d      )         {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-/** Separator-aware cwd prefix test: /repo matches /repo and /repo/x, never /repo2. */
+/**
+ * Canonical form for comparing two working directories.
+ *
+ * Separators fold to "/" and a trailing one is dropped, so a path stored by a
+ * POSIX session and the same path typed with backslashes compare equal. Drive
+ * letters upper-case because Windows reports them either way for one directory.
+ * Case is otherwise preserved: macOS and Linux both host case-sensitive paths,
+ * and folding them would let /Repo match /repo.
+ */
+export function normalizeCwd(cwd        )         {
+  const unified = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+  return /^[a-z]:/.test(unified) ? unified[0].toUpperCase() + unified.slice(1) : unified;
+}
+
+/**
+ * Separator-aware cwd prefix test: /repo matches /repo and /repo/x, never
+ * /repo2. Both sides are normalized first, so the comparison does not depend on
+ * which platform recorded the session or which separator the caller typed.
+ */
 export function cwdMatches(sessionCwd        , prefix        )          {
-  return (
-    sessionCwd === prefix || sessionCwd.startsWith(`${prefix}/`) || sessionCwd.startsWith(`${prefix}\\`)
-  );
+  const s = normalizeCwd(sessionCwd);
+  const p = normalizeCwd(prefix);
+  return s === p || s.startsWith(`${p}/`);
 }
 
 /** rollout-YYYY-MM-DDTHH-MM-SS-<uuid>.jsonl → YYYY-MM-DD (null when unparseable). */

--- a/plugins/codexclaw/components/recall/src/cli.ts
+++ b/plugins/codexclaw/components/recall/src/cli.ts
@@ -28,7 +28,7 @@ const USAGE = [
   "                           [--recent] [--scan] [--no-refresh] [--json]",
   "cxc chat index [--rebuild] [--status] [--json]",
   "cxc memory search \"<query>\" [--days N] [--limit N] [--any] [--no-synonyms]",
-  "                             [--cwd PATH] [--cwd-only PATH] [--json]",
+  "                             [--cwd PATH] [--cwd-only PATH] [--no-chat] [--json]",
   "",
   `  --days N     restrict to the last N days (chat default ${DEFAULT_DAYS}, 0 = full history)`,
   "  --cwd PATH   chat: only sessions under PATH; memory: rank hits under PATH first",
@@ -42,6 +42,7 @@ const USAGE = [
   "  --no-tools   skip tool call/output (tool_log) matching",
   "  --recent     order by time instead of relevance (index engine default: relevance)",
   "  --rank       order by relevance (the default; accepted for explicitness)",
+  "  --no-chat    memory search: do not fall back to raw chat when nothing matches",
   "  --scan       force the raw JSONL scan path (skip the sidecar index)",
   "  --no-refresh skip refresh-on-query ingest (fastest, index may be stale)",
   "  --no-synonyms memory search: raw words only — no ko/en synonyms, no korean stem",
@@ -74,6 +75,7 @@ function parseFlags(args: string[]): ParsedFlags {
       scan: { type: "boolean", default: false },
       "no-refresh": { type: "boolean", default: false },
       "no-synonyms": { type: "boolean", default: false },
+      "no-chat": { type: "boolean", default: false },
       full: { type: "boolean", default: false },
       rebuild: { type: "boolean", default: false },
       status: { type: "boolean", default: false },
@@ -147,6 +149,9 @@ function runMemorySearch(args: string[]): number {
     // Bare `--cwd-only` (parsed as a boolean) hardens an accompanying --cwd.
     cwd: typeof values["cwd-only"] === "string" ? values["cwd-only"] : typeof values.cwd === "string" ? values.cwd : null,
     cwdOnly: values["cwd-only"] !== undefined && values["cwd-only"] !== false,
+    // Injected rather than imported by memory-search: the module keeps no edge
+    // to chat-search, and the fallback is one flag away from being off.
+    searchChat: values["no-chat"] === true ? undefined : searchChat,
   };
   const result = searchMemory(query, opts);
   process.stdout.write(

--- a/plugins/codexclaw/components/recall/src/cli.ts
+++ b/plugins/codexclaw/components/recall/src/cli.ts
@@ -27,10 +27,12 @@ const USAGE = [
   "                           [--limit N] [--context N] [--any] [--all] [--no-tools]",
   "                           [--recent] [--scan] [--no-refresh] [--json]",
   "cxc chat index [--rebuild] [--status] [--json]",
-  "cxc memory search \"<query>\" [--days N] [--limit N] [--any] [--no-synonyms] [--json]",
+  "cxc memory search \"<query>\" [--days N] [--limit N] [--any] [--no-synonyms]",
+  "                             [--cwd PATH] [--cwd-only PATH] [--json]",
   "",
   `  --days N     restrict to the last N days (chat default ${DEFAULT_DAYS}, 0 = full history)`,
-  "  --cwd PATH   only sessions whose working directory starts with PATH",
+  "  --cwd PATH   chat: only sessions under PATH; memory: rank hits under PATH first",
+  "  --cwd-only PATH  memory search: drop hits recorded outside PATH",
   "  --role r     only messages with this role (user|assistant|tool)",
   "  --source s   main (default) | subagent | all",
   `  --limit N    max hits (chat default ${DEFAULT_LIMIT}, memory default ${DEFAULT_MEMORY_LIMIT})`,
@@ -62,6 +64,7 @@ function parseFlags(args: string[]): ParsedFlags {
       context: { type: "string", short: "c" },
       role: { type: "string" },
       cwd: { type: "string" },
+      "cwd-only": { type: "string" },
       source: { type: "string" },
       any: { type: "boolean", default: false },
       all: { type: "boolean", default: false },
@@ -140,6 +143,10 @@ function runMemorySearch(args: string[]): number {
     any: values.any === true,
     synonyms: values["no-synonyms"] !== true,
     home: typeof values.home === "string" ? values.home : undefined,
+    // --cwd-only carries its own path, so `--cwd-only PATH` needs no second flag.
+    // Bare `--cwd-only` (parsed as a boolean) hardens an accompanying --cwd.
+    cwd: typeof values["cwd-only"] === "string" ? values["cwd-only"] : typeof values.cwd === "string" ? values.cwd : null,
+    cwdOnly: values["cwd-only"] !== undefined && values["cwd-only"] !== false,
   };
   const result = searchMemory(query, opts);
   process.stdout.write(

--- a/plugins/codexclaw/components/recall/src/format.ts
+++ b/plugins/codexclaw/components/recall/src/format.ts
@@ -57,7 +57,8 @@ export function formatMemoryResult(result: MemorySearchResult): string {
     lines.push("");
     const loc = hit.startLine !== null ? `${hit.relpath}:${hit.startLine}` : hit.relpath;
     const when = hit.updatedAt ? ` [${hit.updatedAt}]` : "";
-    lines.push(`(${hit.origin}/${hit.kind}) ${loc}${when}`);
+    const cwd = hit.cwd ? ` {${hit.cwd}}` : "";
+    lines.push(`(${hit.origin}/${hit.kind}) ${loc}${when}${cwd}`);
     lines.push(clip(hit.excerpt, EXCERPT));
     lines.push("---");
   }

--- a/plugins/codexclaw/components/recall/src/memory-search.ts
+++ b/plugins/codexclaw/components/recall/src/memory-search.ts
@@ -9,10 +9,10 @@
  * source_updated_at).
  */
 import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
-import { join, relative, resolve, sep } from "node:path";
+import { join, relative, resolve, sep, posix as posixPath, win32 as win32Path } from "node:path";
 import { codexHome, memoriesDir, memoriesDbPath, stateDbPath } from "./paths.ts";
 import { openReadOnlyDb, loadThreadMeta, type ThreadMeta } from "./threads-db.ts";
-import { cwdMatches } from "./rollout.ts";
+import { cwdMatches, normalizeCwd } from "./rollout.ts";
 import {
   splitQueryWordsRaw,
   termIndexOf,
@@ -273,7 +273,8 @@ function frontmatterCwd(content: string): string | null {
  */
 type CwdScope = {
   prefix: string;
-  lowerPrefix: string;
+  /** lowercased prose forms of the prefix, one per separator style. */
+  lowerPrefixes: string[];
   only: boolean;
   threadCwd: Map<string, ThreadMeta>;
 };
@@ -281,14 +282,25 @@ type CwdScope = {
 function buildCwdScope(home: string, opts: MemorySearchOptions, warnings: string[]): CwdScope | null {
   const raw = opts.cwd ?? null;
   if (raw === null || raw.trim() === "") return null;
-  // resolve() so `--cwd .` and a trailing slash mean the same directory the
-  // separator-aware prefix test expects.
-  const prefix = resolve(raw);
+  // Relative input resolves against the process cwd so `--cwd .` means this
+  // directory; an absolute path is left alone, because resolve() rewrites its
+  // separators to the host style while stored cwds keep the style of whatever
+  // platform recorded them. Absoluteness is judged under both path flavors: a
+  // POSIX path is still absolute when read on Windows, and vice versa.
+  const absolute = posixPath.isAbsolute(raw) || win32Path.isAbsolute(raw);
+  const prefix = normalizeCwd(absolute ? raw : resolve(raw));
   // The join only pays for itself when a scope is requested: loading 12,908
   // thread rows costs ~90ms against a search budget measured in tens of ms.
   const meta = loadThreadMeta(stateDbPath(home));
   if (meta.warning) warnings.push(meta.warning);
-  return { prefix, lowerPrefix: prefix.toLowerCase(), only: opts.cwdOnly === true, threadCwd: meta.byId };
+  // Prose carries whatever separator its author typed, so both spellings count.
+  const lower = prefix.toLowerCase();
+  return {
+    prefix,
+    lowerPrefixes: [lower, lower.replace(/\//g, "\\")],
+    only: opts.cwdOnly === true,
+    threadCwd: meta.byId,
+  };
 }
 
 /**
@@ -308,7 +320,7 @@ function scopeAdjust(
   if (scope === null) return { keep: true, bonus: 0 };
   const matched = hitCwd !== null && hitCwd !== "" && cwdMatches(hitCwd, scope.prefix);
   if (matched) return { keep: true, bonus: CWD_BOOST };
-  const mentioned = lowerText.includes(scope.lowerPrefix);
+  const mentioned = scope.lowerPrefixes.some((p) => lowerText.includes(p));
   if (mentioned) return { keep: true, bonus: CWD_BOOST / 2 };
   return { keep: !scope.only, bonus: 0 };
 }

--- a/plugins/codexclaw/components/recall/src/memory-search.ts
+++ b/plugins/codexclaw/components/recall/src/memory-search.ts
@@ -9,9 +9,10 @@
  * source_updated_at).
  */
 import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
-import { join, relative, sep } from "node:path";
-import { codexHome, memoriesDir, memoriesDbPath } from "./paths.ts";
-import { openReadOnlyDb } from "./threads-db.ts";
+import { join, relative, resolve, sep } from "node:path";
+import { codexHome, memoriesDir, memoriesDbPath, stateDbPath } from "./paths.ts";
+import { openReadOnlyDb, loadThreadMeta, type ThreadMeta } from "./threads-db.ts";
+import { cwdMatches } from "./rollout.ts";
 import {
   splitQueryWordsRaw,
   termIndexOf,
@@ -35,6 +36,10 @@ export type MemorySearchOptions = {
   synonyms?: boolean;
   /** clock override for deterministic recency ranking in tests. */
   nowMs?: number;
+  /** project scope: hits recorded under this working directory rank higher. */
+  cwd?: string | null;
+  /** with cwd: drop everything outside the scope instead of only boosting it. */
+  cwdOnly?: boolean;
 };
 
 /**
@@ -60,6 +65,8 @@ export type MemoryHit = {
   updatedAt: string | null;
   excerpt: string;
   startLine: number | null;
+  /** working directory this artifact was recorded under, when it is known. */
+  cwd: string | null;
   /** final relevance score (text score + kind priority + recency boost). */
   score: number;
 };
@@ -74,6 +81,14 @@ const PER_FILE_CAP = 2;
  * survives even if a future caller merges the two passes.
  */
 const RELAXED_PENALTY = 2;
+
+/**
+ * Score added to a hit recorded under the requested project (`--cwd`). Worth one
+ * coverage group, so an in-project hit outranks an equally relevant hit from
+ * another project without overriding text relevance: a five-group match
+ * elsewhere still beats a one-group match here.
+ */
+export const CWD_BOOST = 2;
 
 /** Classify a memories-root relpath into its artifact kind. */
 export function kindOfRelpath(relpath: string, origin: "file" | "stage1" = "file"): MemoryKind {
@@ -206,6 +221,75 @@ function frontmatterThreadId(content: string): string | null {
   return m ? m[1] : null;
 }
 
+/**
+ * `cwd:` from a file's leading frontmatter block — the contiguous `key: value`
+ * lines before the first blank line.
+ *
+ * Reading `^cwd:` anywhere near the top instead is wrong on the live store:
+ * `raw_memories.md` concatenates 448 per-thread blocks, each with its own
+ * `cwd:`, and the first one would label the whole file with a single project.
+ * All 256 rollout summaries carry cwd in their leading block, so the accurate
+ * reading costs nothing there. Chunks inside an aggregate file still reach the
+ * scope through the path mention in their own body.
+ */
+function frontmatterCwd(content: string): string | null {
+  for (const line of splitLines(content.slice(0, 2_000))) {
+    if (line.trim() === "") return null; // end of the leading block
+    const m = /^([a-z_]+):\s*(\S+)/.exec(line);
+    if (!m) return null; // a heading or prose: this file has no frontmatter
+    if (m[1] === "cwd") return m[2];
+  }
+  return null;
+}
+
+/**
+ * Project scope for one search. Holds the normalized prefix, whether it filters
+ * or only boosts, and the thread metadata used to give stage1 rows a cwd —
+ * `stage1_outputs` has no cwd column, so the only accurate source is a
+ * thread_id join against the Codex state db.
+ */
+type CwdScope = {
+  prefix: string;
+  lowerPrefix: string;
+  only: boolean;
+  threadCwd: Map<string, ThreadMeta>;
+};
+
+function buildCwdScope(home: string, opts: MemorySearchOptions, warnings: string[]): CwdScope | null {
+  const raw = opts.cwd ?? null;
+  if (raw === null || raw.trim() === "") return null;
+  // resolve() so `--cwd .` and a trailing slash mean the same directory the
+  // separator-aware prefix test expects.
+  const prefix = resolve(raw);
+  // The join only pays for itself when a scope is requested: loading 12,908
+  // thread rows costs ~90ms against a search budget measured in tens of ms.
+  const meta = loadThreadMeta(stateDbPath(home));
+  if (meta.warning) warnings.push(meta.warning);
+  return { prefix, lowerPrefix: prefix.toLowerCase(), only: opts.cwdOnly === true, threadCwd: meta.byId };
+}
+
+/**
+ * How one candidate relates to the requested project.
+ *
+ * A structured `cwd` (summary frontmatter, or threads.cwd for a stage1 row) is
+ * the strong signal. Curated files carry no cwd at all, so a chunk that names
+ * the path in prose — MEMORY.md writes `applies_to: cwd=/...` — counts as a
+ * weaker one at half the boost. Without that second signal `--cwd-only` would
+ * discard the handbook entirely, which is where project rules actually live.
+ */
+function scopeAdjust(
+  scope: CwdScope | null,
+  hitCwd: string | null,
+  lowerText: string,
+): { keep: boolean; bonus: number } {
+  if (scope === null) return { keep: true, bonus: 0 };
+  const matched = hitCwd !== null && hitCwd !== "" && cwdMatches(hitCwd, scope.prefix);
+  if (matched) return { keep: true, bonus: CWD_BOOST };
+  const mentioned = lowerText.includes(scope.lowerPrefix);
+  if (mentioned) return { keep: true, bonus: CWD_BOOST / 2 };
+  return { keep: !scope.only, bonus: 0 };
+}
+
 /** Paragraph chunks with their 1-based start line, for jump-to-source output. */
 export function paragraphChunks(content: string): Array<{ text: string; startLine: number }> {
   const chunks: Array<{ text: string; startLine: number }> = [];
@@ -278,6 +362,7 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
 
   const root = memoriesDir(home);
   const files = listMarkdownFiles(root);
+  const scope = buildCwdScope(home, opts, warnings);
 
   const collect = (active: QueryGroup[]): MemoryHit[] => {
     const candidates: MemoryHit[] = [];
@@ -300,9 +385,15 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
       if (threadId) matchedThreadIds.add(threadId);
       const relpath = relative(root, file).split(sep).join("/");
       const kind = kindOfRelpath(relpath, "file");
+      // Frontmatter first, then the thread join: a summary states its own cwd,
+      // and a file that only carries a thread_id still resolves through state.
+      const fileCwd =
+        frontmatterCwd(content) ?? (threadId ? scope?.threadCwd.get(threadId)?.cwd ?? null : null);
       for (const chunk of paragraphChunks(content)) {
         const lower = chunk.text.toLowerCase();
         if (!matches(lower, active, anyMode)) continue;
+        const scoped = scopeAdjust(scope, fileCwd, lower);
+        if (!scoped.keep) continue;
         candidates.push({
           origin: "file",
           kind,
@@ -312,11 +403,23 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
           updatedAt: new Date(mtimeMs).toISOString(),
           excerpt: excerptAround(chunk.text, firstPresentMember(lower, active), 400),
           startLine: chunk.startLine,
-          score: finalScore(scoreChunk(lower, active, lowerPhrase), kind, mtimeMs, nowMs),
+          cwd: fileCwd,
+          score: finalScore(scoreChunk(lower, active, lowerPhrase), kind, mtimeMs, nowMs) + scoped.bonus,
         });
       }
     }
-    searchStage1(home, active, anyMode, cutoffMs, lowerPhrase, nowMs, candidates, matchedThreadIds, warnings);
+    searchStage1(
+      home,
+      active,
+      anyMode,
+      cutoffMs,
+      lowerPhrase,
+      nowMs,
+      candidates,
+      matchedThreadIds,
+      warnings,
+      scope,
+    );
     return candidates;
   };
 
@@ -331,6 +434,9 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
       for (const hit of candidates) hit.score -= RELAXED_PENALTY;
       warnings.push("no word-boundary matches — showing substring matches (lower confidence)");
     }
+  }
+  if (candidates.length === 0 && scope?.only) {
+    warnings.push(`no matches inside --cwd-only ${scope.prefix} — retry with --cwd to rank it first instead`);
   }
 
   const hits = rankAndTrim(candidates, limit);
@@ -348,6 +454,7 @@ function searchStage1(
   candidates: MemoryHit[],
   matchedThreadIds: Set<string>,
   warnings: string[],
+  scope: CwdScope | null,
 ): void {
   const dbPath = memoriesDbPath(home);
   if (!dbPath) {
@@ -386,6 +493,11 @@ function searchStage1(
       const lowerBody = body.toLowerCase();
       // The LIKE prefilter above ignores boundaries; enforce them here.
       if (!matches(lowerBody, groups, anyMode)) continue;
+      // stage1_outputs has no cwd column (schema dump, 011 4.3); threads.cwd is
+      // the accurate substitute and it covered all 516 rows in the live store.
+      const rowCwd = threadId ? scope?.threadCwd.get(threadId)?.cwd ?? null : null;
+      const scoped = scopeAdjust(scope, rowCwd, lowerBody);
+      if (!scoped.keep) continue;
       const updatedMs = updatedSec !== null ? updatedSec * 1000 : null;
       candidates.push({
         origin: "stage1",
@@ -395,7 +507,8 @@ function searchStage1(
         updatedAt: updatedMs !== null ? new Date(updatedMs).toISOString() : null,
         excerpt: excerptAround(body, firstPresentMember(lowerBody, groups), 400),
         startLine: null,
-        score: finalScore(scoreChunk(lowerBody, groups, lowerPhrase), "stage1", updatedMs, nowMs),
+        cwd: rowCwd,
+        score: finalScore(scoreChunk(lowerBody, groups, lowerPhrase), "stage1", updatedMs, nowMs) + scoped.bonus,
       });
     }
   } catch (err) {

--- a/plugins/codexclaw/components/recall/src/memory-search.ts
+++ b/plugins/codexclaw/components/recall/src/memory-search.ts
@@ -24,6 +24,12 @@ import {
 } from "./query-words.ts";
 import { expandQueryWords } from "./synonyms.ts";
 import { splitLines } from "./text-lines.ts";
+// Type-only: erased by the type-stripping build, so memory search still ships
+// with no runtime edge to chat-search.ts. The function itself arrives through
+// MemorySearchOptions.searchChat (the RecallContextDeps pattern in hook.ts).
+import type { searchChat } from "./chat-search.ts";
+
+export type ChatSearchFn = typeof searchChat;
 
 export const DEFAULT_MEMORY_LIMIT = 20;
 
@@ -40,6 +46,16 @@ export type MemorySearchOptions = {
   cwd?: string | null;
   /** with cwd: drop everything outside the scope instead of only boosting it. */
   cwdOnly?: boolean;
+  /**
+   * Chat search used to backfill an empty memory result. Injected rather than
+   * imported so this module keeps no edge to chat-search.ts and tests can run
+   * the memory path with the fallback switched off.
+   */
+  searchChat?: ChatSearchFn;
+  /** backfill from chat when the memory store returns at most this many hits (default 0). */
+  chatFallbackBelow?: number;
+  /** include tool call/output text in the chat backfill (default false). */
+  chatIncludeTools?: boolean;
 };
 
 /**
@@ -55,10 +71,11 @@ export type MemoryKind =
   | "raw" // raw_memories.md — merged phase-1 raw input
   | "rollout" // rollout_summaries/** — per-thread episodic summaries
   | "stage1" // stage1_outputs rows — episodic, pre-consolidation
+  | "chat" // raw session messages, backfilled when memory has nothing
   | "other";
 
 export type MemoryHit = {
-  origin: "file" | "stage1";
+  origin: "file" | "stage1" | "chat";
   kind: MemoryKind;
   relpath: string;
   threadId: string | null;
@@ -91,8 +108,9 @@ const RELAXED_PENALTY = 2;
 export const CWD_BOOST = 2;
 
 /** Classify a memories-root relpath into its artifact kind. */
-export function kindOfRelpath(relpath: string, origin: "file" | "stage1" = "file"): MemoryKind {
+export function kindOfRelpath(relpath: string, origin: MemoryHit["origin"] = "file"): MemoryKind {
   if (origin === "stage1") return "stage1";
+  if (origin === "chat") return "chat";
   if (relpath === "memory_summary.md") return "summary";
   if (relpath === "MEMORY.md") return "handbook";
   if (relpath === "raw_memories.md") return "raw";
@@ -115,6 +133,10 @@ export const KIND_PRIORITY: Record<MemoryKind, number> = {
   raw: 0.5,
   rollout: 0,
   stage1: 0,
+  // Raw conversation is the least consolidated source there is; it only ever
+  // appears when nothing else answered, so its priority only orders the
+  // backfill against itself.
+  chat: -1,
   other: 0,
 };
 
@@ -123,6 +145,7 @@ export const HALF_LIFE_HOURS: Record<MemoryKind, number> = {
   rollout: 24 * 7,
   stage1: 24 * 7,
   other: 24 * 7,
+  chat: 24 * 7,
   raw: 24 * 30,
   extension: 24 * 90,
   summary: Infinity,
@@ -435,12 +458,89 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
       warnings.push("no word-boundary matches — showing substring matches (lower confidence)");
     }
   }
-  if (candidates.length === 0 && scope?.only) {
+  const hits = rankAndTrim(candidates, limit);
+  const backfilled = backfillFromChat(query, hits, opts, home, scope, limit, nowMs, days, warnings);
+  // Only advise widening the scope when nothing at all came back; the chat
+  // backfill answers within the same scope and carries its own warning.
+  if (backfilled.length === 0 && scope?.only) {
     warnings.push(`no matches inside --cwd-only ${scope.prefix} — retry with --cwd to rank it first instead`);
   }
+  return { hits: backfilled, warnings, scannedFiles, elapsedMs: Date.now() - started };
+}
 
-  const hits = rankAndTrim(candidates, limit);
-  return { hits, warnings, scannedFiles, elapsedMs: Date.now() - started };
+/** Chat backfill excerpt length, matching the memory excerpt window. */
+const CHAT_EXCERPT = 400;
+
+/**
+ * Backfill an empty memory result from the chat corpus.
+ *
+ * The memory store is consolidated and therefore lags: a topic discussed an
+ * hour ago has no summary yet, and the honest answer "no memories" hides a
+ * conversation that does exist. Chat hits are labelled `chat/chat` and
+ * announced in the warnings so a backfilled answer is never mistaken for a
+ * curated one.
+ *
+ * Tool logs are excluded. They are the measured pollution source — command text
+ * and file dumps match almost any query — and a backfill exists to surface what
+ * was said, not what was executed.
+ *
+ * The call is skipped entirely unless the caller injected searchChat, so the
+ * memory path keeps its cost when nothing needs backfilling.
+ */
+function backfillFromChat(
+  query: string,
+  hits: MemoryHit[],
+  opts: MemorySearchOptions,
+  home: string,
+  scope: CwdScope | null,
+  limit: number,
+  nowMs: number,
+  days: number,
+  warnings: string[],
+): MemoryHit[] {
+  const chat = opts.searchChat;
+  const threshold = Math.max(opts.chatFallbackBelow ?? 0, 0);
+  if (chat === undefined || hits.length > threshold) return hits;
+  const want = Math.min(limit, 5);
+  try {
+    const result = chat(query, {
+      home,
+      // Full history by default: a backfill that inherited chat's 7-day window
+      // would go looking for old context and find only the last week of it.
+      days,
+      limit: want,
+      // Never trigger ingest here — a refresh over the multi-GB index would
+      // dwarf the entire memory search it is standing in for.
+      noRefresh: true,
+      includeTools: opts.chatIncludeTools === true,
+      source: "main",
+      context: 0,
+      // A hard memory scope stays hard in the backfill; a boost does not filter.
+      cwd: scope?.only ? scope.prefix : null,
+    });
+    const out: MemoryHit[] = result.hits.slice(0, want).map((hit) => {
+      const updatedMs = Date.parse(hit.ts);
+      return {
+        origin: "chat",
+        kind: "chat",
+        relpath: hit.file,
+        threadId: hit.threadId,
+        updatedAt: hit.ts,
+        excerpt: hit.text.slice(0, CHAT_EXCERPT),
+        startLine: null,
+        cwd: hit.cwd,
+        score: finalScore(0, "chat", Number.isFinite(updatedMs) ? updatedMs : null, nowMs),
+      };
+    });
+    if (out.length === 0) return hits;
+    warnings.push(
+      `no memory artifacts matched — ${out.length} raw session message(s) shown instead (tool logs excluded)`,
+    );
+    return out;
+  } catch (err) {
+    warnings.push(`chat fallback unavailable (${err instanceof Error ? err.message : String(err)})`);
+    return hits;
+  }
 }
 
 /** stage1_outputs holds per-thread raw_memory + rollout_summary; read-only, fail-soft. */

--- a/plugins/codexclaw/components/recall/src/rollout.ts
+++ b/plugins/codexclaw/components/recall/src/rollout.ts
@@ -65,11 +65,29 @@ export function localDateString(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
-/** Separator-aware cwd prefix test: /repo matches /repo and /repo/x, never /repo2. */
+/**
+ * Canonical form for comparing two working directories.
+ *
+ * Separators fold to "/" and a trailing one is dropped, so a path stored by a
+ * POSIX session and the same path typed with backslashes compare equal. Drive
+ * letters upper-case because Windows reports them either way for one directory.
+ * Case is otherwise preserved: macOS and Linux both host case-sensitive paths,
+ * and folding them would let /Repo match /repo.
+ */
+export function normalizeCwd(cwd: string): string {
+  const unified = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+  return /^[a-z]:/.test(unified) ? unified[0].toUpperCase() + unified.slice(1) : unified;
+}
+
+/**
+ * Separator-aware cwd prefix test: /repo matches /repo and /repo/x, never
+ * /repo2. Both sides are normalized first, so the comparison does not depend on
+ * which platform recorded the session or which separator the caller typed.
+ */
 export function cwdMatches(sessionCwd: string, prefix: string): boolean {
-  return (
-    sessionCwd === prefix || sessionCwd.startsWith(`${prefix}/`) || sessionCwd.startsWith(`${prefix}\\`)
-  );
+  const s = normalizeCwd(sessionCwd);
+  const p = normalizeCwd(prefix);
+  return s === p || s.startsWith(`${p}/`);
 }
 
 /** rollout-YYYY-MM-DDTHH-MM-SS-<uuid>.jsonl → YYYY-MM-DD (null when unparseable). */

--- a/plugins/codexclaw/components/recall/test/chat-fallback.test.ts
+++ b/plugins/codexclaw/components/recall/test/chat-fallback.test.ts
@@ -1,0 +1,213 @@
+/**
+ * chat-fallback.test.ts — R5: memory search backfills an empty result from the
+ * chat corpus, with tool logs excluded and the substitution announced.
+ *
+ * searchChat arrives by injection, so most cases assert against a recording
+ * stub; the last one runs the real engine over the shared fixture home.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { searchMemory, type ChatSearchFn } from "../src/memory-search.ts";
+import { searchChat, type ChatSearchOptions, type ChatSearchResult } from "../src/chat-search.ts";
+import { formatMemoryResult } from "../src/format.ts";
+import { main as cliMain } from "../src/cli.ts";
+import { buildCodexHome } from "./fixtures.ts";
+
+function chatHit(over: Partial<ChatSearchResult["hits"][number]> = {}) {
+  return {
+    ts: "2026-09-08T04:05:06.000Z",
+    role: "user",
+    text: "we agreed to ship the pangolin migration on friday",
+    matchField: "content" as const,
+    threadId: "019f2222-0000-7000-8000-00000000aaaa",
+    title: "pangolin planning",
+    cwd: "/proj/here",
+    gitBranch: null,
+    source: "main" as const,
+    file: "/home/sessions/2026/09/08/rollout-pangolin.jsonl",
+    context: [],
+    ...over,
+  };
+}
+
+/** Records the options it was called with and returns canned hits. */
+function stubChat(hits: ReturnType<typeof chatHit>[]): { fn: ChatSearchFn; calls: ChatSearchOptions[] } {
+  const calls: ChatSearchOptions[] = [];
+  const fn = ((_query: string, opts: ChatSearchOptions = {}) => {
+    calls.push(opts);
+    return {
+      hits,
+      warnings: [],
+      scannedFiles: 0,
+      matchedFiles: hits.length,
+      totalFiles: 1,
+      elapsedMs: 1,
+      mode: "index" as const,
+    };
+  }) as ChatSearchFn;
+  return { fn, calls };
+}
+
+function emptyHome(prefix: string): string {
+  const home = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(home, "memories"), { recursive: true });
+  return home;
+}
+
+test("an empty memory result is backfilled from chat and says so", () => {
+  const home = emptyHome("recall-fallback-");
+  const { fn, calls } = stubChat([chatHit()]);
+  try {
+    const r = searchMemory("pangolin", { home, searchChat: fn });
+    assert.equal(calls.length, 1, "the fallback fired exactly once");
+    assert.equal(r.hits.length, 1);
+    assert.equal(r.hits[0].origin, "chat");
+    assert.equal(r.hits[0].kind, "chat");
+    assert.match(r.hits[0].excerpt, /pangolin migration/);
+    assert.ok(
+      r.warnings.some((w) => w.includes("raw session message")),
+      "the substitution is announced, not silent",
+    );
+    // The label reaches the rendered output too.
+    assert.match(formatMemoryResult(r), /\(chat\/chat\)/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("the fallback excludes tool logs and never triggers an ingest", () => {
+  const home = emptyHome("recall-fallback-opts-");
+  const { fn, calls } = stubChat([chatHit()]);
+  try {
+    searchMemory("pangolin", { home, searchChat: fn });
+    assert.equal(calls[0].includeTools, false, "tool logs are the pollution source");
+    assert.equal(calls[0].noRefresh, true, "a backfill must not refresh a multi-GB index");
+    assert.equal(calls[0].days, 0, "full history, not chat's 7-day default");
+    assert.equal(calls[0].home, home);
+    assert.equal(calls[0].source, "main");
+
+    // ...and the caller can opt back in.
+    const withTools = stubChat([chatHit({ matchField: "tool_log" })]);
+    searchMemory("pangolin", { home, searchChat: withTools.fn, chatIncludeTools: true });
+    assert.equal(withTools.calls[0].includeTools, true);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("a memory result that already answered is left alone", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-fallback-hit-"));
+  try {
+    const mem = join(home, "memories");
+    mkdirSync(mem, { recursive: true });
+    writeFileSync(join(mem, "MEMORY.md"), "# Notes\n\nThe pangolin migration is documented here.\n");
+    const { fn, calls } = stubChat([chatHit()]);
+    const r = searchMemory("pangolin", { home, searchChat: fn });
+    assert.equal(calls.length, 0, "the chat engine is never consulted");
+    assert.equal(r.hits.length, 1);
+    assert.equal(r.hits[0].origin, "file");
+    assert.ok(!r.warnings.some((w) => w.includes("raw session message")));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("chatFallbackBelow raises the trigger above empty", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-fallback-thresh-"));
+  try {
+    const mem = join(home, "memories");
+    mkdirSync(mem, { recursive: true });
+    writeFileSync(join(mem, "MEMORY.md"), "# Notes\n\nA single thin pangolin mention.\n");
+    const thin = searchMemory("pangolin", { home });
+    assert.equal(thin.hits.length, 1);
+
+    const { fn, calls } = stubChat([chatHit()]);
+    const r = searchMemory("pangolin", { home, searchChat: fn, chatFallbackBelow: 2 });
+    assert.equal(calls.length, 1);
+    assert.equal(r.hits[0].origin, "chat");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("--cwd-only stays hard in the backfill; a plain --cwd boost does not filter", () => {
+  const home = emptyHome("recall-fallback-scope-");
+  try {
+    const hard = stubChat([chatHit()]);
+    searchMemory("pangolin", { home, searchChat: hard.fn, cwd: "/proj/here", cwdOnly: true });
+    assert.equal(hard.calls[0].cwd, "/proj/here");
+
+    const soft = stubChat([chatHit()]);
+    searchMemory("pangolin", { home, searchChat: soft.fn, cwd: "/proj/here" });
+    assert.equal(soft.calls[0].cwd, null, "a boost must not become a chat filter");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("a failing chat engine degrades to the empty memory result", () => {
+  const home = emptyHome("recall-fallback-fail-");
+  try {
+    const boom = (() => {
+      throw new Error("index unavailable");
+    }) as ChatSearchFn;
+    const r = searchMemory("pangolin", { home, searchChat: boom });
+    assert.equal(r.hits.length, 0);
+    assert.ok(r.warnings.some((w) => w.includes("chat fallback unavailable")));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("no injected engine means no fallback at all (default for library callers)", () => {
+  const home = emptyHome("recall-fallback-none-");
+  try {
+    const r = searchMemory("pangolin", { home });
+    assert.equal(r.hits.length, 0);
+    assert.ok(!r.warnings.some((w) => w.includes("raw session message")));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: memory search falls back to the real chat engine, and --no-chat opts out", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-fallback-cli-"));
+  buildCodexHome(home);
+  const captured: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  (process.stdout as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+    captured.push(s);
+    return true;
+  };
+  try {
+    // "aardwolf" lives only in an archived session message, never in memories.
+    assert.equal(cliMain(["memory", "search", "aardwolf", "--home", home, "--json"]), 0);
+    const fell = JSON.parse(captured.join(""));
+    assert.ok(fell.hits.length > 0, "the chat corpus answered where memory could not");
+    assert.ok(fell.hits.every((h) => h.origin === "chat"));
+
+    captured.length = 0;
+    assert.equal(cliMain(["memory", "search", "aardwolf", "--home", home, "--no-chat", "--json"]), 0);
+    const off = JSON.parse(captured.join(""));
+    assert.equal(off.hits.length, 0, "--no-chat restores the memory-only answer");
+
+    // A phrase that exists ONLY in a tool log stays unreachable: the fixture's
+    // zebra-in-tool-output is indexed as tool_log, and the backfill excludes it.
+    captured.length = 0;
+    assert.equal(cliMain(["memory", "search", "zebra-in-tool-output", "--home", home, "--json"]), 0);
+    const tools = JSON.parse(captured.join(""));
+    assert.equal(tools.hits.length, 0, "tool output stays excluded through the CLI path");
+  } finally {
+    (process.stdout as unknown as { write: typeof orig }).write = orig;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("the real chat engine satisfies the injected type", () => {
+  // Compile-time parity between the injection seam and the actual function.
+  const fn: ChatSearchFn = searchChat;
+  assert.equal(typeof fn, "function");
+});

--- a/plugins/codexclaw/components/recall/test/cwd-scope.test.ts
+++ b/plugins/codexclaw/components/recall/test/cwd-scope.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { searchMemory, CWD_BOOST } from "../src/memory-search.ts";
+import { normalizeCwd } from "../src/rollout.ts";
 import { main as cliMain } from "../src/cli.ts";
 
 const HERE = "/proj/here";
@@ -227,4 +228,61 @@ test("frontmatter cwd is read from the leading block, not any later line", () =>
   } finally {
     rmSync(home, { recursive: true, force: true });
   }
+});
+
+test("windows-shaped input reaches a posix-recorded project (CI regression)", () => {
+  const home = buildScopedHome();
+  try {
+    // The fixture records cwd the way a POSIX session does. On Windows the CLI
+    // hands the same directory over with backslashes, and resolve() used to
+    // rewrite the query side only, so the two never compared equal and every
+    // scoped assertion failed on windows-latest while ubuntu/macos passed.
+    const backslashed = HERE.replace(/\//g, "\\");
+    const scoped = searchMemory("wombat", { home, cwd: backslashed });
+    assert.equal(scoped.hits[0].cwd, HERE, "a backslash query still finds a slash-recorded cwd");
+
+    const only = searchMemory("wombat", { home, cwd: backslashed, cwdOnly: true });
+    assert.equal(only.hits.length, 1, "the hard filter matches across separator styles");
+    assert.equal(only.hits[0].cwd, HERE);
+
+    // The prose signal reads both spellings too.
+    assert.equal(
+      searchMemory("wombat", { home, cwd: backslashed, cwdOnly: true }).hits[0].origin,
+      "file",
+    );
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("drive-lettered paths compare by drive, separator and boundary", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-cwd-drive-"));
+  try {
+    const summaries = join(home, "memories", "rollout_summaries");
+    mkdirSync(summaries, { recursive: true });
+    // A session recorded on Windows stores a drive-lettered, backslashed cwd.
+    writeFileSync(
+      join(summaries, "win.md"),
+      "thread_id: t-win\ncwd: C:\\proj\\here\\sub\n\n# Notes\n\nThe numbat pipeline shipped.\n",
+    );
+    // Same directory, every spelling a caller might type.
+    for (const q of ["C:\\proj\\here", "C:/proj/here", "c:/proj/here", "C:\\proj\\here\\"]) {
+      const r = searchMemory("numbat", { home, cwd: q, cwdOnly: true });
+      assert.equal(r.hits.length, 1, `${q} must reach the recorded cwd`);
+    }
+    // ...and a sibling that merely shares the prefix characters must not.
+    const sibling = searchMemory("numbat", { home, cwd: "C:\\proj\\here2", cwdOnly: true });
+    assert.equal(sibling.hits.length, 0, "C:\\proj\\here2 is a different directory");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("normalizeCwd folds separators and drive case without folding path case", () => {
+  assert.equal(normalizeCwd("/proj/here/"), "/proj/here");
+  assert.equal(normalizeCwd("\\proj\\here"), "/proj/here");
+  assert.equal(normalizeCwd("c:\\proj\\here"), "C:/proj/here");
+  assert.equal(normalizeCwd("C:/proj/here/"), "C:/proj/here");
+  // Path case is meaningful on the case-sensitive hosts this also runs on.
+  assert.notEqual(normalizeCwd("/Proj/Here"), normalizeCwd("/proj/here"));
 });

--- a/plugins/codexclaw/components/recall/test/cwd-scope.test.ts
+++ b/plugins/codexclaw/components/recall/test/cwd-scope.test.ts
@@ -1,0 +1,230 @@
+/**
+ * cwd-scope.test.ts — P1-1 project scoping for memory search.
+ *
+ * Each test builds an ISOLATED temp home (the shared fixture home must keep its
+ * mtimes untouched, ranking.test.ts header) with two projects' worth of
+ * artifacts so boost-versus-filter is observable in the hit order.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { searchMemory, CWD_BOOST } from "../src/memory-search.ts";
+import { main as cliMain } from "../src/cli.ts";
+
+const HERE = "/proj/here";
+const THERE = "/proj/here-adjacent";
+const THREAD_HERE = "019f1111-0000-7000-8000-00000000aaaa";
+const THREAD_THERE = "019f1111-0000-7000-8000-00000000bbbb";
+const STAGE1_HERE = "019f1111-0000-7000-8000-00000000cccc";
+const STAGE1_THERE = "019f1111-0000-7000-8000-00000000dddd";
+
+/**
+ * Two projects, one topic. Summaries carry cwd in frontmatter; the stage1 rows
+ * carry none, so their scope can only come from the threads join.
+ */
+function buildScopedHome(): string {
+  const home = mkdtempSync(join(tmpdir(), "recall-cwd-"));
+  const summaries = join(home, "memories", "rollout_summaries");
+  mkdirSync(summaries, { recursive: true });
+  writeFileSync(
+    join(summaries, "here.md"),
+    `thread_id: ${THREAD_HERE}\nrollout_path: /Users/x/.codex/sessions/here.jsonl\ncwd: ${HERE}\n\n# Rollout\n\nThe wombat pipeline shipped.\n`,
+  );
+  writeFileSync(
+    join(summaries, "there.md"),
+    `thread_id: ${THREAD_THERE}\nrollout_path: /Users/x/.codex/sessions/there.jsonl\ncwd: ${THERE}\n\n# Rollout\n\nThe wombat pipeline shipped.\n`,
+  );
+
+  const state = new DatabaseSync(join(home, "state_1.sqlite"));
+  state.exec(
+    "CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL DEFAULT ''," +
+      " cwd TEXT NOT NULL DEFAULT '', git_branch TEXT, updated_at_ms INTEGER)",
+  );
+  const ins = state.prepare("INSERT INTO threads (id, title, cwd, git_branch, updated_at_ms) VALUES (?, ?, ?, ?, ?)");
+  ins.run(THREAD_HERE, "here lane", HERE, "main", Date.now());
+  ins.run(THREAD_THERE, "there lane", THERE, "main", Date.now());
+  ins.run(STAGE1_HERE, "stage1 here", HERE, null, Date.now());
+  ins.run(STAGE1_THERE, "stage1 there", THERE, null, Date.now());
+  state.close();
+
+  const mem = new DatabaseSync(join(home, "memories_1.sqlite"));
+  mem.exec(
+    "CREATE TABLE stage1_outputs (thread_id TEXT PRIMARY KEY, source_updated_at INTEGER NOT NULL," +
+      " raw_memory TEXT NOT NULL, rollout_summary TEXT NOT NULL)",
+  );
+  const mins = mem.prepare(
+    "INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary) VALUES (?, ?, ?, ?)",
+  );
+  const now = Math.floor(Date.now() / 1000);
+  mins.run(STAGE1_HERE, now, "aardvark notes recorded in the first project", "aardvark one");
+  mins.run(STAGE1_THERE, now, "aardvark notes recorded in the second project", "aardvark two");
+  mem.close();
+  return home;
+}
+
+function scoreOf(hits: Array<{ relpath: string; score: number }>, relpath: string): number {
+  const hit = hits.find((h) => h.relpath === relpath);
+  assert.ok(hit, `expected a hit for ${relpath}`);
+  return hit.score;
+}
+
+test("--cwd boosts the current project without hiding the rest", () => {
+  const home = buildScopedHome();
+  try {
+    // One pinned clock for both searches: recency decays between two Date.now()
+    // captures, and the assertion below measures an exact score delta.
+    const nowMs = Date.now();
+    const plain = searchMemory("wombat", { home, nowMs });
+    assert.equal(plain.hits.length, 2, "both projects match the query");
+
+    const scoped = searchMemory("wombat", { home, cwd: HERE, nowMs });
+    assert.equal(scoped.hits.length, 2, "boost must not drop the other project");
+    assert.equal(scoped.hits[0].relpath, "rollout_summaries/here.md", "in-project hit ranks first");
+    assert.equal(scoped.hits[0].cwd, HERE);
+    const gain = scoped.hits[0].score - scoreOf(plain.hits, "rollout_summaries/here.md");
+    assert.ok(Math.abs(gain - CWD_BOOST) < 1e-9, `boost is exactly CWD_BOOST, got ${gain}`);
+    assert.equal(
+      scoreOf(scoped.hits, "rollout_summaries/there.md"),
+      scoreOf(plain.hits, "rollout_summaries/there.md"),
+      "out-of-project hits keep their original score",
+    );
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("--cwd-only filters instead of ranking, and says so when it empties the result", () => {
+  const home = buildScopedHome();
+  try {
+    const only = searchMemory("wombat", { home, cwd: HERE, cwdOnly: true });
+    assert.equal(only.hits.length, 1);
+    assert.equal(only.hits[0].relpath, "rollout_summaries/here.md");
+
+    const nothing = searchMemory("wombat", { home, cwd: "/proj/unrelated", cwdOnly: true });
+    assert.equal(nothing.hits.length, 0);
+    assert.ok(nothing.warnings.some((w) => w.includes("--cwd-only")), "empty hard filter explains itself");
+
+    // The same query without the hard filter still answers.
+    const boosted = searchMemory("wombat", { home, cwd: "/proj/unrelated" });
+    assert.equal(boosted.hits.length, 2);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cwd prefix matching is separator-aware: /proj/here never matches /proj/here-adjacent", () => {
+  const home = buildScopedHome();
+  try {
+    const only = searchMemory("wombat", { home, cwd: HERE, cwdOnly: true });
+    assert.ok(
+      only.hits.every((h) => h.cwd === HERE),
+      "an adjacent path sharing the prefix characters must not be included",
+    );
+    const adjacent = searchMemory("wombat", { home, cwd: THERE, cwdOnly: true });
+    assert.equal(adjacent.hits.length, 1);
+    assert.equal(adjacent.hits[0].cwd, THERE);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("stage1 rows get their scope from the threads join, not a stage1 column", () => {
+  const home = buildScopedHome();
+  try {
+    const scoped = searchMemory("aardvark", { home, cwd: HERE });
+    assert.equal(scoped.hits.length, 2);
+    assert.equal(scoped.hits[0].origin, "stage1");
+    assert.equal(scoped.hits[0].cwd, HERE, "cwd came from threads.cwd");
+
+    const only = searchMemory("aardvark", { home, cwd: HERE, cwdOnly: true });
+    assert.equal(only.hits.length, 1);
+    assert.equal(only.hits[0].cwd, HERE);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("a chunk naming the project path scores between in-project and unrelated", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-cwd-prose-"));
+  try {
+    const mem = join(home, "memories");
+    mkdirSync(mem, { recursive: true });
+    // MEMORY.md carries no cwd frontmatter; the handbook convention is to name
+    // the path in prose. Without the prose signal --cwd-only would discard the
+    // handbook entirely, which is where project rules live.
+    writeFileSync(join(mem, "MEMORY.md"), `# Notes\n\napplies_to: cwd=${HERE}; the wombat pipeline is owned here.\n`);
+    const only = searchMemory("wombat", { home, cwd: HERE, cwdOnly: true });
+    assert.equal(only.hits.length, 1, "prose mention survives the hard filter");
+    const plain = searchMemory("wombat", { home });
+    const gain = only.hits[0].score - plain.hits[0].score;
+    assert.ok(gain > 0 && gain < CWD_BOOST, `weaker than a structured cwd match, got ${gain}`);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: --cwd and --cwd-only reach memory search", () => {
+  const home = buildScopedHome();
+  const captured: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  (process.stdout as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+    captured.push(s);
+    return true;
+  };
+  try {
+    assert.equal(cliMain(["memory", "search", "wombat", "--home", home, "--cwd", HERE, "--json"]), 0);
+    const boosted = JSON.parse(captured.join(""));
+    assert.equal(boosted.hits.length, 2);
+    assert.equal(boosted.hits[0].cwd, HERE);
+
+    captured.length = 0;
+    assert.equal(cliMain(["memory", "search", "wombat", "--home", home, "--cwd-only", HERE, "--json"]), 0);
+    const filtered = JSON.parse(captured.join(""));
+    assert.equal(filtered.hits.length, 1);
+    assert.equal(filtered.hits[0].cwd, HERE);
+  } finally {
+    (process.stdout as unknown as { write: typeof orig }).write = orig;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("aggregate files do not inherit their first block's cwd", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-cwd-agg-"));
+  try {
+    const mem = join(home, "memories");
+    mkdirSync(mem, { recursive: true });
+    // raw_memories.md concatenates one block per thread, each with its own
+    // cwd: line (448 of them in the live store). Reading the first one would
+    // label every chunk in the file with a single project.
+    writeFileSync(
+      join(mem, "raw_memories.md"),
+      `# Raw Memories\n\n## Thread one\ncwd: ${HERE}\n\nplatypus work in the first project.\n\n## Thread two\ncwd: ${THERE}\n\nplatypus work in the second project.\n`,
+    );
+    const hits = searchMemory("platypus", { home }).hits;
+    assert.ok(hits.length >= 2);
+    assert.ok(hits.every((h) => h.cwd === null), "a leading heading means no file-level cwd");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("frontmatter cwd is read from the leading block, not any later line", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-cwd-front-"));
+  try {
+    const summaries = join(home, "memories", "rollout_summaries");
+    mkdirSync(summaries, { recursive: true });
+    // rollout_path also holds a path, and the body may quote another project.
+    writeFileSync(
+      join(summaries, "s.md"),
+      `thread_id: t1\nrollout_path: /Users/x/.codex/sessions/s.jsonl\ncwd: ${HERE}\n\n# Notes\n\ncwd: ${THERE} was mentioned in passing about the numbat.\n`,
+    );
+    const hits = searchMemory("numbat", { home }).hits;
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].cwd, HERE);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/plugins/codexclaw/skills/recall/SKILL.md
+++ b/plugins/codexclaw/skills/recall/SKILL.md
@@ -31,7 +31,7 @@ cxc chat search "<query>" [--days N] [--cwd PATH] [--role r] [--source main|suba
                           [--recent] [--scan] [--no-refresh] [--json]
 cxc chat index [--rebuild] [--status]
 cxc memory search "<query>" [--days N] [--limit N] [--any] [--no-synonyms]
-                            [--cwd PATH] [--cwd-only PATH] [--json]
+                            [--cwd PATH] [--cwd-only PATH] [--no-chat] [--json]
 ```
 
 Defaults that matter:
@@ -92,6 +92,18 @@ chunk that names the path in prose counts as a weaker signal at half the boost
 — that is what keeps handbook rules inside a `--cwd-only` result. Prefix
 matching is separator-aware: `/repo` never matches `/repo2`. Every hit prints
 its `{cwd}` when one is known.
+
+## When memory has nothing
+
+The memory store is consolidated on a delay, so a topic from an hour ago may
+have no summary yet. When `cxc memory search` finds no artifact, it answers
+from the raw chat corpus instead: up to five session messages, labelled
+`(chat/chat)`, with a warning saying the result was substituted. Tool call and
+output text is excluded — it matches almost any query and drowns out what was
+actually said. Pass `--no-chat` for a memory-only answer.
+
+The backfill never refreshes the sidecar index, so it costs a query rather than
+an ingest, and `--cwd-only` stays in force across it.
 
 ## Escalation ladder
 

--- a/plugins/codexclaw/skills/recall/SKILL.md
+++ b/plugins/codexclaw/skills/recall/SKILL.md
@@ -30,7 +30,8 @@ cxc chat search "<query>" [--days N] [--cwd PATH] [--role r] [--source main|suba
                           [--limit N] [--context N] [--any] [--all] [--no-tools]
                           [--recent] [--scan] [--no-refresh] [--json]
 cxc chat index [--rebuild] [--status]
-cxc memory search "<query>" [--days N] [--limit N] [--any] [--no-synonyms] [--json]
+cxc memory search "<query>" [--days N] [--limit N] [--any] [--no-synonyms]
+                            [--cwd PATH] [--cwd-only PATH] [--json]
 ```
 
 Defaults that matter:
@@ -70,6 +71,27 @@ excerpt. Stems shorter than two syllables are never produced, so `검사` is not
 split into `검`.
 
 Pass `--no-synonyms` for literal matching with no expansion at all.
+
+## Scoping memory search to a project
+
+`--cwd <path>` ranks memories recorded under that working directory first; it
+does not hide anything else. That is deliberate. The memory store is heavily
+concentrated in a few long-running projects, and a worktree checkout typically
+owns one summary or none, so a hard filter would answer nothing exactly when you
+most need history. A boost puts the project's own memories on top and keeps the
+rest reachable below them.
+
+`--cwd-only <path>` is the hard filter, for when unrelated projects are noise
+rather than context. When it empties the result, the output says so and points
+back at `--cwd`.
+
+Scope comes from a rollout summary's `cwd:` frontmatter, and for stage1 rows
+from a thread-id join against the Codex state db (`stage1_outputs` stores no
+working directory). Curated files such as MEMORY.md carry no cwd at all, so a
+chunk that names the path in prose counts as a weaker signal at half the boost
+— that is what keeps handbook rules inside a `--cwd-only` result. Prefix
+matching is separator-aware: `/repo` never matches `/repo2`. Every hit prints
+its `{cwd}` when one is known.
 
 ## Escalation ladder
 


### PR DESCRIPTION
## Two gaps in memory recall

**Memory search had no notion of which project you are in.** Native memory has no per-project scoping at all — the phase-1 candidate query passes `cwd_filters: None`, and `stage1_outputs` has no `cwd` column (a schema dump shows ten columns, none of them `cwd` or `git_branch`; the fields named in earlier notes are Rust in-memory types). Working across many worktrees, a query about one project returns another project's decisions.

**A miss returned nothing even when the answer existed in chat history.** Memory consolidation lags, so a fact discussed yesterday can be absent from the memory store while sitting in the indexed rollouts.

## What changed

`--cwd` boosts hits from a project rather than filtering to it, because a project with no hits must not produce an empty page — the same reason `kindPriority` is a score term and not a gate. `--cwd-only` is the separate hard filter for when exclusion is actually wanted. Scoping resolves through `thread_id` → `threads.cwd` (the `loadThreadMeta` map) and through `rollout_summaries` frontmatter.

When memory search finds nothing, it falls back to the chat index. Tool logs are excluded unconditionally on that path — they are the contamination source recall has been careful about — and results are labeled `(chat/chat)` with a warning so a fallback answer is never mistaken for a consolidated memory. `--no-chat` disables it.

## Measured against the real store

12,745 files / 1,214,276 messages indexed, 285 memory files. Same query, `배포`:

| Scope | Hits | Top results |
|---|---|---|
| none | 5 (109ms) | file, file, file, stage1, stage1 |
| `--cwd opencodex` | 5 (136ms) | opencodex stage1 enters at #2 |
| `--cwd codexclaw` | 5 (154ms) | codexclaw stage1 at #1, #2, #4 |
| `--cwd-only codexclaw` | 5 (142ms) | same |
| `--cwd worktrees/1fa9` | 5 (135ms) | **not empty** — the point of boosting |
| `--cwd-only worktrees/1fa9` | 0 (2.7s) | warns and suggests `--cwd` |

The fallback returns 3 chat hits for `recommended_plugins` where memory has none.

## Four deviations from the plan

**Frontmatter parsing is limited to the leading block.** The planned `/^cwd:/m` mislabeled `raw_memories.md` as `/Users/jun` — that file concatenates 448 per-thread blocks, so the first block's `cwd` would represent the whole file. The 256 `rollout_summaries` are identical either way.

**Prose mentions get a half boost.** Structured `cwd` alone means `--cwd-only` discards `MEMORY.md` entirely, which is where project rules actually live. An `applies_to: cwd=…` mention counts as a weak signal.

**The circular import was already gone.** wp2's `query-words.ts` extraction removed the runtime edge, and `import type` is erased entirely by the type-stripping build (verified). Types are imported; functions are injected through `RecallContextDeps`.

**`--no-tools` was not reused.** That flag belongs to chat search users and would overload its meaning here. The fallback always runs with `includeTools: false`, and `--no-chat` turns the fallback itself off.

## Known cost

`--cwd-only` with zero hits takes 2.7s because chat search's existing `--cwd` filter is a slow index path. `--cwd` boosting stays around 140ms. Not introduced here.

## Note on stacking

Chains on #105, but this repo requires every PR to target `dev`, so the diff also shows #105's commits. Merging #105 first reduces this to its own three.

## Verification

Recall suite 94/94 (79 existing plus 15 new), `npm run gate` and `inventory --check` clean. The two feature commits revert independently — reverting the fallback alone leaves the eight cwd tests passing, which was checked rather than assumed.
