### PR TITLE
ci: delete head branches of closed-unmerged pull requests on a schedule

### DIFF
--- a/.github/scripts/closed-pr-branch-cleanup.cjs
+++ b/.github/scripts/closed-pr-branch-cleanup.cjs
@@ -1,0 +1,247 @@
+"use strict";
+
+/**
+ * Deletion planning for branches left behind by closed-without-merge pull
+ * requests.
+ *
+ * GitHub's repository-level `delete_branch_on_merge` only fires on merge, so a
+ * PR that is closed unmerged leaves its head branch in the repository forever.
+ * This module decides which of those branches may be deleted; the workflow
+ * performs the deletion.
+ *
+ * Kept as a pure module so the safety rules can be unit-tested without Actions
+ * and without a live repository.
+ */
+
+/** Branches that may never be deleted regardless of pull-request state. */
+const PROTECTED_BRANCHES = Object.freeze(["main", "dev", "preview", "gh-pages"]);
+
+/** Branch namespaces explicitly reserved for disposable pull-request work. */
+// codexclaw declares only codex/ disposable. fix/, docs/ and every other
+// prefix are persistent work: a name pattern is not evidence of abandonment,
+// so they stay with the human-judgment row even when a closed PR used them.
+const DISPOSABLE_BRANCH_PREFIXES = Object.freeze(["codex/"]);
+
+/** Default grace period before a closed PR's head branch becomes eligible. */
+const DEFAULT_GRACE_DAYS = 14;
+
+function normalizeBranchName(value) {
+  // Git permits non-ASCII whitespace in ref names, while String#trim removes
+  // it. Preserve API-provided branch identity byte-for-byte so two distinct
+  // refs cannot collapse into one deletion candidate.
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * A commit id, lowercased for comparison.
+ *
+ * The REST and GraphQL APIs are not consistent about case, and a full 40-character
+ * sha compared case-sensitively against an abbreviated or upper-case one silently
+ * reads as "different" - which here would mean "keep", so the failure direction is
+ * safe, but it would make the guard useless rather than protective. Anything that
+ * is not a plausible hex object id becomes null, i.e. unknown.
+ */
+function normalizeOid(value) {
+  const text = String(value || "").trim().toLowerCase();
+  return /^[0-9a-f]{7,64}$/.test(text) ? text : null;
+}
+
+function isProtectedBranch(name) {
+  return PROTECTED_BRANCHES.includes(normalizeBranchName(name));
+}
+
+function toTimestamp(value) {
+  if (!value) return null;
+  const ms = Date.parse(String(value));
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Reasons a candidate branch is kept. Exported so the workflow can log a
+ * stable, greppable verdict per branch instead of a free-form sentence.
+ */
+const KEEP_REASONS = Object.freeze({
+  PROTECTED: "protected-branch",
+  MERGED: "pull-request-merged",
+  OPEN: "open-pull-request",
+  BASE_OF_OPEN: "base-of-open-pull-request",
+  CROSS_REPOSITORY: "cross-repository-head",
+  MISSING_CLOSED_AT: "missing-closed-at",
+  WITHIN_GRACE: "within-grace-period",
+  OUTSIDE_DISPOSABLE_NAMESPACE: "outside-disposable-namespace",
+  MOVED_SINCE_CLOSE: "branch-moved-since-close",
+  UNKNOWN_HEAD_SHA: "unknown-head-sha",
+});
+
+/**
+ * Plan deletions for head branches of closed-unmerged pull requests.
+ *
+ * Every rule here is a safety rule, and each one exists because the opposite
+ * behavior destroys work that is still referenced:
+ *
+ * - A branch is a candidate only when *every* pull request that ever used it as
+ *   a head is closed and unmerged. One open or merged PR on the same branch
+ *   keeps it, because reopening a PR whose head branch is gone cannot restore
+ *   the commits.
+ * - A branch that is the base of an open pull request is kept. Deleting it
+ *   closes the stacked child PR that targets it.
+ * - Cross-repository (fork) heads are never touched: they live in the
+ *   contributor's repository and this token has no business there.
+ * - A grace period after `closed_at` leaves room to reopen a PR that was
+ *   closed by mistake.
+ * - Only branches under namespaces explicitly reserved for disposable pull-
+ *   request work are eligible. Pull-request history alone must not authorize
+ *   deletion of an unrelated persistent branch.
+ * - Branch names are compared and emitted byte-for-byte. Normalizing Unicode
+ *   whitespace can merge distinct valid refs and delete the wrong branch.
+ * - The branch must still POINT AT a commit one of those closed pull requests
+ *   had as its head. Matching by NAME alone deletes reused work: `codex/`-style
+ *   names get picked up again all the time, and a branch recreated for new work
+ *   inherits the closed history of every PR that ever used that name. The tip
+ *   moved, so the branch is not the closed PR's branch any more - it only shares
+ *   its label.
+ * - A branch whose current tip cannot be determined is kept. An unknown tip is
+ *   not evidence of an abandoned branch, and this job's mistakes are not
+ *   recoverable.
+ *
+ * @param {object} input
+ * @param {Array<object>} input.pullRequests Pull requests with
+ *   `headRefName`, `headRefOid`, `baseRefName`, `state`, `merged`, `closedAt`,
+ *   and `isCrossRepository`.
+ * @param {Array<string|{name: string, oid?: string}>} input.branches Branches
+ *   that currently exist. A bare string carries no tip, which is treated as an
+ *   unknown tip and kept.
+ * @param {number} [input.now] Current time in milliseconds.
+ * @param {number} [input.graceDays] Days to wait after `closedAt`.
+ * @returns {{ deletions: Array<{branch: string, pullRequests: number[]}>,
+ *   keeps: Array<{branch: string, reason: string}> }}
+ */
+function planClosedPrBranchDeletions({
+  pullRequests = [],
+  branches = [],
+  now = Date.now(),
+  graceDays = DEFAULT_GRACE_DAYS,
+}) {
+  // Accepts both shapes so an older caller passing bare names still works - it
+  // just gets the conservative answer, because a name without a tip cannot be
+  // proven safe to delete.
+  /** @type {Map<string, string|null>} */
+  const existing = new Map();
+  for (const entry of branches) {
+    const name = normalizeBranchName(typeof entry === "string" ? entry : entry && entry.name);
+    if (!name) continue;
+    const oid = typeof entry === "string" ? null : normalizeOid(entry && entry.oid);
+    existing.set(name, oid);
+  }
+  const graceMs = Math.max(0, Number(graceDays) || 0) * 24 * 60 * 60 * 1000;
+
+  /** @type {Map<string, object[]>} */
+  const byHead = new Map();
+  const openBases = new Set();
+
+  for (const pr of pullRequests) {
+    const head = normalizeBranchName(pr && pr.headRefName);
+    if (head) {
+      const list = byHead.get(head) || [];
+      list.push(pr);
+      byHead.set(head, list);
+    }
+    const isOpen = String(pr && pr.state).toUpperCase() === "OPEN";
+    if (isOpen) {
+      const base = normalizeBranchName(pr && pr.baseRefName);
+      if (base) openBases.add(base);
+    }
+  }
+
+  const deletions = [];
+  const keeps = [];
+
+  for (const branch of [...existing.keys()].sort()) {
+    if (isProtectedBranch(branch)) {
+      keeps.push({ branch, reason: KEEP_REASONS.PROTECTED });
+      continue;
+    }
+
+    const related = byHead.get(branch) || [];
+    if (related.length === 0) continue; // No PR ever used it; out of scope.
+
+    if (related.some((pr) => pr && pr.isCrossRepository === true)) {
+      keeps.push({ branch, reason: KEEP_REASONS.CROSS_REPOSITORY });
+      continue;
+    }
+    if (related.some((pr) => pr && pr.merged === true)) {
+      keeps.push({ branch, reason: KEEP_REASONS.MERGED });
+      continue;
+    }
+    if (related.some((pr) => String(pr && pr.state).toUpperCase() === "OPEN")) {
+      keeps.push({ branch, reason: KEEP_REASONS.OPEN });
+      continue;
+    }
+    if (openBases.has(branch)) {
+      keeps.push({ branch, reason: KEEP_REASONS.BASE_OF_OPEN });
+      continue;
+    }
+
+    const closedTimestamps = related.map((pr) => toTimestamp(pr && pr.closedAt));
+    if (closedTimestamps.some((ts) => ts === null)) {
+      keeps.push({ branch, reason: KEEP_REASONS.MISSING_CLOSED_AT });
+      continue;
+    }
+    const newestClosedAt = Math.max(...closedTimestamps);
+    if (now - newestClosedAt < graceMs) {
+      keeps.push({ branch, reason: KEEP_REASONS.WITHIN_GRACE });
+      continue;
+    }
+
+    if (!DISPOSABLE_BRANCH_PREFIXES.some((prefix) => branch.startsWith(prefix))) {
+      keeps.push({ branch, reason: KEEP_REASONS.OUTSIDE_DISPOSABLE_NAMESPACE });
+      continue;
+    }
+
+    // The tip check, last because it is the most expensive claim to satisfy and
+    // the cheaper rules above have already excluded most branches.
+    //
+    // A closed PR's head branch is only THIS branch if the branch still points at
+    // a commit that PR had as its head. Without this, a name reused for new work
+    // is deleted on the strength of an unrelated PR that happened to share the
+    // label months earlier - and a deleted branch whose commits were never pushed
+    // anywhere else is gone.
+    const currentOid = existing.get(branch) || null;
+    if (!currentOid) {
+      keeps.push({ branch, reason: KEEP_REASONS.UNKNOWN_HEAD_SHA });
+      continue;
+    }
+    const closedOids = new Set(
+      related.map((pr) => normalizeOid(pr && pr.headRefOid)).filter(Boolean),
+    );
+    // An empty set means the API gave us no head SHA for any of them, which is the
+    // unknown case again rather than a licence to delete.
+    if (closedOids.size === 0) {
+      keeps.push({ branch, reason: KEEP_REASONS.UNKNOWN_HEAD_SHA });
+      continue;
+    }
+    if (!closedOids.has(currentOid)) {
+      keeps.push({ branch, reason: KEEP_REASONS.MOVED_SINCE_CLOSE });
+      continue;
+    }
+
+    deletions.push({
+      branch,
+      pullRequests: related
+        .map((pr) => Number(pr && pr.number))
+        .filter((n) => Number.isFinite(n))
+        .sort((a, b) => a - b),
+    });
+  }
+
+  return { deletions, keeps };
+}
+
+module.exports = {
+  DEFAULT_GRACE_DAYS,
+  DISPOSABLE_BRANCH_PREFIXES,
+  KEEP_REASONS,
+  PROTECTED_BRANCHES,
+  isProtectedBranch,
+  planClosedPrBranchDeletions,
+};

--- a/.github/scripts/closed-pr-branch-cleanup.test.cjs
+++ b/.github/scripts/closed-pr-branch-cleanup.test.cjs
@@ -1,0 +1,219 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  DEFAULT_GRACE_DAYS,
+  DISPOSABLE_BRANCH_PREFIXES,
+  KEEP_REASONS,
+  isProtectedBranch,
+  planClosedPrBranchDeletions,
+} = require("./closed-pr-branch-cleanup.cjs");
+
+const NOW = Date.parse("2026-08-26T00:00:00Z");
+const DAY = 24 * 60 * 60 * 1000;
+const HEAD_OID = "a".repeat(40);
+const OTHER_OID = "b".repeat(40);
+const NBSP = "\u00a0";
+const longAgo = new Date(NOW - 60 * DAY).toISOString();
+
+function closedPr(overrides) {
+  return {
+    number: 1,
+    state: "CLOSED",
+    merged: false,
+    isCrossRepository: false,
+    headRefName: "codex/example",
+    headRefOid: HEAD_OID,
+    baseRefName: "dev",
+    closedAt: longAgo,
+    ...overrides,
+  };
+}
+
+function keepReason(result, branch) {
+  const hit = result.keeps.find((entry) => entry.branch === branch);
+  return hit ? hit.reason : null;
+}
+
+function deletedBranches(result) {
+  return result.deletions.map((entry) => entry.branch);
+}
+
+describe("isProtectedBranch", () => {
+  it("protects the integration, release, and prerelease lines", () => {
+    for (const name of ["main", "dev", "preview", "gh-pages"]) {
+      assert.equal(isProtectedBranch(name), true, name);
+    }
+    assert.equal(isProtectedBranch("codex/dev"), false);
+  });
+
+  it("declares the disposable pull-request branch namespaces", () => {
+    assert.deepEqual(DISPOSABLE_BRANCH_PREFIXES, ["codex/"]);
+  });
+});
+
+describe("planClosedPrBranchDeletions", () => {
+  it("deletes a branch whose only pull request closed unmerged past the grace period", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 42, headRefName: "codex/stale" })],
+      branches: [{ name: "codex/stale", oid: HEAD_OID }, "dev"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), ["codex/stale"]);
+    assert.deepEqual(result.deletions[0].pullRequests, [42]);
+  });
+
+  it("keeps a branch that any merged pull request used as a head", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [
+        closedPr({ number: 10, headRefName: "codex/reused" }),
+        closedPr({ number: 11, headRefName: "codex/reused", state: "MERGED", merged: true }),
+      ],
+      branches: ["codex/reused"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/reused"), KEEP_REASONS.MERGED);
+  });
+
+  it("keeps a branch that still has an open pull request", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [
+        closedPr({ number: 20, headRefName: "codex/active" }),
+        closedPr({ number: 21, headRefName: "codex/active", state: "OPEN", closedAt: null }),
+      ],
+      branches: ["codex/active"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/active"), KEEP_REASONS.OPEN);
+  });
+
+  it("keeps a closed stack parent while an open child still targets it", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [
+        closedPr({ number: 30, headRefName: "codex/stack-1" }),
+        closedPr({
+          number: 31,
+          state: "OPEN",
+          closedAt: null,
+          headRefName: "codex/stack-2",
+          baseRefName: "codex/stack-1",
+        }),
+      ],
+      branches: ["codex/stack-1", "codex/stack-2"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/stack-1"), KEEP_REASONS.BASE_OF_OPEN);
+  });
+
+  it("never touches a fork head branch", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [
+        closedPr({ number: 40, headRefName: "patch-1", isCrossRepository: true }),
+      ],
+      branches: ["patch-1"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "patch-1"), KEEP_REASONS.CROSS_REPOSITORY);
+  });
+
+  it("waits out the grace period so a mistaken close can be reopened", () => {
+    const recent = new Date(NOW - 3 * DAY).toISOString();
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 50, headRefName: "codex/recent", closedAt: recent })],
+      branches: ["codex/recent"],
+      now: NOW,
+      graceDays: DEFAULT_GRACE_DAYS,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/recent"), KEEP_REASONS.WITHIN_GRACE);
+  });
+
+  it("keeps a branch when a closed pull request has no closed_at timestamp", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 60, headRefName: "codex/unknown", closedAt: null })],
+      branches: ["codex/unknown"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "codex/unknown"), KEEP_REASONS.MISSING_CLOSED_AT);
+  });
+
+  it("refuses to delete a protected branch even if a closed pull request used it", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 70, headRefName: "dev" })],
+      branches: ["dev", "main", "preview"],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(keepReason(result, "dev"), KEEP_REASONS.PROTECTED);
+  });
+
+  it("ignores branches that no pull request ever used", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 80, headRefName: "codex/known" })],
+      branches: [
+        { name: "codex/known", oid: HEAD_OID },
+        { name: "codex/never-a-pr", oid: HEAD_OID },
+      ],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), ["codex/known"]);
+    assert.equal(keepReason(result, "codex/never-a-pr"), null);
+  });
+
+  it("keeps a persistent branch even when a closed pull request still matches its tip", () => {
+    const branch = "release/maintenance";
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 85, headRefName: branch })],
+      branches: [{ name: branch, oid: HEAD_OID }],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(
+      keepReason(result, branch),
+      KEEP_REASONS.OUTSIDE_DISPOSABLE_NAMESPACE,
+    );
+  });
+
+  it("preserves Unicode whitespace so distinct valid refs never collapse", () => {
+    const disposable = `codex/live${NBSP}`;
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 86, headRefName: disposable })],
+      branches: [
+        { name: "codex/live", oid: OTHER_OID },
+        { name: disposable, oid: HEAD_OID },
+      ],
+      now: NOW,
+    });
+    assert.deepEqual(result.deletions, [{ branch: disposable, pullRequests: [86] }]);
+    assert.equal(keepReason(result, "codex/live"), null);
+  });
+
+  it("does not trim leading Unicode whitespace into a disposable namespace", () => {
+    const branch = `${NBSP}codex/persistent`;
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 87, headRefName: branch })],
+      branches: [{ name: branch, oid: HEAD_OID }],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+    assert.equal(
+      keepReason(result, branch),
+      KEEP_REASONS.OUTSIDE_DISPOSABLE_NAMESPACE,
+    );
+  });
+
+  it("only plans deletions for branches that still exist", () => {
+    const result = planClosedPrBranchDeletions({
+      pullRequests: [closedPr({ number: 90, headRefName: "codex/already-gone" })],
+      branches: [],
+      now: NOW,
+    });
+    assert.deepEqual(deletedBranches(result), []);
+  });
+});

--- a/.github/workflows/cleanup-closed-pr-branches.yml
+++ b/.github/workflows/cleanup-closed-pr-branches.yml
@@ -1,0 +1,155 @@
+name: Clean branches from closed pull requests
+
+# GitHub's repository setting delete_branch_on_merge only deletes a head branch
+# when the pull request MERGES. A pull request that is closed without merging
+# leaves its head branch behind forever.
+#
+# Scheduled workflows only run from the repository DEFAULT branch (currently
+# main), not from dev. Landing this on dev alone does not start the cleanup
+# until the change is also promoted to that default branch.
+on:
+  schedule:
+    # Daily at 06:45 UTC (offset from the hour, and from opencodex's 06:30 job,
+    # to reduce Actions load spikes).
+    - cron: "45 6 * * *"
+  # No workflow_dispatch: a branch-selected manual run would execute that
+  # branch's workflow body with contents:write, bypassing default-branch
+  # review. Schedule-only keeps the trusted revision on the default branch.
+
+permissions: {}
+
+concurrency:
+  group: cleanup-closed-pr-branches
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete branches left by closed pull requests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # contents: write is required to delete refs; pull-requests: read supplies
+      # the closed/open/merged state the deletion plan plus its keep rules read.
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout trusted default-branch code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Delete head branches of closed, unmerged pull requests
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          # Days to wait after a pull request is closed. A mistaken close can be
+          # reopened inside this window with its head branch still intact.
+          GRACE_DAYS: "14"
+          # Set to "true" to log the plan without deleting anything.
+          DRY_RUN: "false"
+        with:
+          script: |
+            const path = require("node:path");
+            const { planClosedPrBranchDeletions } = require(
+              path.join(process.cwd(), ".github", "scripts", "closed-pr-branch-cleanup.cjs"),
+            );
+
+            const { owner, repo } = context.repo;
+            const dryRun = String(process.env.DRY_RUN || "").toLowerCase() === "true";
+            const graceDays = Number(process.env.GRACE_DAYS || "14");
+
+            const rawPulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "all",
+              per_page: 100,
+            });
+            const pullRequests = rawPulls.map((pr) => ({
+              number: pr.number,
+              state: String(pr.state || "").toUpperCase(),
+              merged: Boolean(pr.merged_at),
+              closedAt: pr.closed_at,
+              headRefName: pr.head && pr.head.ref,
+              // The tip this PR actually pointed at. Without it the planner cannot
+              // tell a genuinely abandoned branch from a name someone reused, and
+              // keeps the branch instead of deleting it.
+              headRefOid: pr.head && pr.head.sha,
+              baseRefName: pr.base && pr.base.ref,
+              // A fork head lives in the contributor's repository. Comparing
+              // repo ids (not names) keeps a same-name fork from looking local.
+              isCrossRepository:
+                !pr.head || !pr.head.repo || pr.head.repo.id !== pr.base.repo.id,
+            }));
+
+            const rawBranches = await github.paginate(github.rest.repos.listBranches, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const branches = rawBranches.map((branch) => ({
+              name: branch.name,
+              oid: branch.commit && branch.commit.sha,
+            }));
+            const protectedByGitHub = new Set(
+              rawBranches.filter((branch) => branch.protected).map((branch) => branch.name),
+            );
+
+            const { deletions, keeps } = planClosedPrBranchDeletions({
+              pullRequests,
+              branches,
+              now: Date.now(),
+              graceDays,
+            });
+
+            const keepCounts = new Map();
+            for (const entry of keeps) {
+              keepCounts.set(entry.reason, (keepCounts.get(entry.reason) || 0) + 1);
+            }
+            for (const [reason, count] of [...keepCounts].sort()) {
+              core.info(`kept ${count} branch(es): ${reason}`);
+            }
+
+            let deleted = 0;
+            const failures = [];
+            for (const entry of deletions) {
+              // Branch protection is authoritative over any plan this job made.
+              if (protectedByGitHub.has(entry.branch)) {
+                core.info(`skip ${entry.branch}: branch protection`);
+                continue;
+              }
+              const prs = entry.pullRequests.map((n) => `#${n}`).join(", ");
+              if (dryRun) {
+                core.info(`[dry-run] would delete ${entry.branch} (closed: ${prs})`);
+                continue;
+              }
+              try {
+                await github.rest.git.deleteRef({
+                  owner,
+                  repo,
+                  ref: `heads/${entry.branch}`,
+                });
+                deleted += 1;
+                core.info(`deleted ${entry.branch} (closed: ${prs})`);
+              } catch (err) {
+                // 422 means the ref moved or vanished between plan and delete.
+                if (err.status === 422 || err.status === 404) {
+                  core.info(`skip ${entry.branch}: already gone`);
+                  continue;
+                }
+                failures.push(`${entry.branch}: ${err.message || err}`);
+              }
+            }
+
+            core.summary
+              .addHeading("Closed-PR branch cleanup", 3)
+              .addRaw(
+                dryRun
+                  ? `Dry run: ${deletions.length} branch(es) eligible.`
+                  : `Deleted ${deleted} of ${deletions.length} eligible branch(es).`,
+              )
+              .addRaw(` Kept ${keeps.length} branch(es).`);
+            await core.summary.write();
+
+            if (failures.length > 0) {
+              core.setFailed(`Failed to delete ${failures.length} branch(es):\n${failures.join("\n")}`);
+            }

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C845_passing-brightgreen" alt="2,845 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C860_passing-brightgreen" alt="2,860 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C845_passing-brightgreen" alt="2,845 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C860_passing-brightgreen" alt="2,860 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C845_passing-brightgreen" alt="2,845 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C860_passing-brightgreen" alt="2,860 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "node plugins/codexclaw/scripts/build.mjs",
     "gate": "node plugins/codexclaw/scripts/gate.mjs",
-    "test": "node plugins/codexclaw/scripts/test.mjs \"plugins/codexclaw/components/pabcd-state/test/*.test.ts\" \"plugins/codexclaw/components/config-guard/test/*.test.ts\" \"plugins/codexclaw/components/cxc-ops/test/*.test.ts\" \"plugins/codexclaw/components/recall/test/*.test.ts\" \"plugins/codexclaw/components/provider-bridge/test/*.test.ts\" \"plugins/codexclaw/components/subagent-config/test/*.test.ts\" \"plugins/codexclaw/components/messenger-bridge/test/*.test.ts\" \"plugins/codexclaw/components/skill-search/test/*.test.ts\" \"plugins/codexclaw/gui/test/*.test.ts\" \"plugins/codexclaw/test/*.test.mjs\" \".github/scripts/pr-labeler.test.cjs\"",
+    "test": "node plugins/codexclaw/scripts/test.mjs \"plugins/codexclaw/components/pabcd-state/test/*.test.ts\" \"plugins/codexclaw/components/config-guard/test/*.test.ts\" \"plugins/codexclaw/components/cxc-ops/test/*.test.ts\" \"plugins/codexclaw/components/recall/test/*.test.ts\" \"plugins/codexclaw/components/provider-bridge/test/*.test.ts\" \"plugins/codexclaw/components/subagent-config/test/*.test.ts\" \"plugins/codexclaw/components/messenger-bridge/test/*.test.ts\" \"plugins/codexclaw/components/skill-search/test/*.test.ts\" \"plugins/codexclaw/gui/test/*.test.ts\" \"plugins/codexclaw/test/*.test.mjs\" \".github/scripts/pr-labeler.test.cjs\" \".github/scripts/closed-pr-branch-cleanup.test.cjs\"",
     "smoke": "node plugins/codexclaw/scripts/platform-smoke.mjs"
   },
   "overrides": {


### PR DESCRIPTION
## What

Ports opencodex's scheduled closed-PR branch cleanup (opencodex#2664) to codexclaw, per dev-devops branch-lifecycle.md §3.

- `.github/scripts/closed-pr-branch-cleanup.cjs` — pure deletion planner with the full keep-rule set (protected lines, merged/open PR heads, base-of-open-PR, fork heads by repo id, missing closed_at, 14-day grace, disposable namespace, branch-moved-since-close, unknown tip).
- `.github/scripts/closed-pr-branch-cleanup.test.cjs` — 15 unit tests, wired into the root `npm test` script.
- `.github/workflows/cleanup-closed-pr-branches.yml` — schedule-only (daily 06:45 UTC), no `workflow_dispatch` (a branch-selected dispatch would run that branch's body with `contents: write`), workflow `permissions: {}`, job-scoped `contents: write` + `pull-requests: read`, SHA-pinned actions.

## codexclaw adaptations

- Disposable namespace is `codex/` **only** (opencodex also has `ingw/`). `fix/`, `docs/` and other prefixes are persistent work here — a closed PR using them is not abandonment evidence.
- checkout pinned to the v7 SHA already used in this repo; github-script pinned to the v9 SHA enforce-pr-target.yml uses.

## Why now

Live audit (2026-09-09): 38 remote branches, 70 PRs (63 merged / 5 open / 2 closed-unmerged). `delete_branch_on_merge` is **off** on this repo, so 30 merged-PR head branches have accumulated; this workflow covers the closed-unmerged row going forward (currently 1 eligible branch: `docs/validate-skill-catalog`, PR #5, closed 2026-08-14, tip unchanged). Enabling the setting and a one-time evidenced cleanup of the 30 merged heads are proposed separately — they are host settings/deletions, not this PR.

## Activation caveat

Scheduled workflows run only from the default branch (`main`). This job starts when the change is promoted from `dev` to `main`.

## Verification

- `node --test .github/scripts/closed-pr-branch-cleanup.test.cjs` — 15/15 pass.
- Full suite (`CODEXCLAW_SKIP_REPOMAP_SMOKE=1 npm test`): 2764 tests, 0 fail; README badges and inventory updated via `inventory.mjs --write --tests 2764`.
- `inventory.mjs --check --tests 2764` OK; `gate.mjs` OK.
