### PR TITLE
ci: label pull requests by type and close stale needs-info issues

### DIFF
--- a/.github/scripts/pr-labeler.cjs
+++ b/.github/scripts/pr-labeler.cjs
@@ -1,0 +1,160 @@
+"use strict";
+
+/**
+ * PR title → GitHub type label for PR Labeler.
+ * Accepts conventional commits (`fix(scope): …`) and sentence-case fallbacks
+ * (`Fix Console Go …`) for LLM-authored PRs that skip the prefix colon.
+ * Kept as a pure module so override behavior can be unit-tested without Actions.
+ */
+
+const PREFIX_TO_LABEL = Object.freeze({
+  feat: "enhancement",
+  feature: "enhancement",
+  fix: "bug",
+  bugfix: "bug",
+  hotfix: "bug",
+  docs: "documentation",
+  doc: "documentation",
+  chore: "chore",
+  refactor: "chore",
+  style: "chore",
+  test: "chore",
+  tests: "chore",
+  ci: "chore",
+  build: "chore",
+  perf: "enhancement",
+  revert: "chore",
+});
+
+const TYPE_LABELS = new Set(Object.values(PREFIX_TO_LABEL));
+
+/** Actors whose type-label mutations are treated as bot-owned (may be overwritten). */
+const BOT_ACTORS = new Set(["github-actions[bot]"]);
+
+function labelForTitlePrefix(prefix) {
+  const key = String(prefix || "").toLowerCase();
+  if (!Object.prototype.hasOwnProperty.call(PREFIX_TO_LABEL, key)) return null;
+  return PREFIX_TO_LABEL[key];
+}
+
+/**
+ * Map a PR title to a managed type label.
+ * @param {string} title
+ * @returns {string|null}
+ */
+function detectTypeLabelFromTitle(title) {
+  const text = String(title || "");
+
+  const conventional = text.match(/^([a-zA-Z]+)(?:\([^)]*\))?[!]?\s*:/);
+  if (conventional) return labelForTitlePrefix(conventional[1]);
+
+  // Sentence-case fallback (e.g. PR #524: "Fix Console Go tool schema sanitization").
+  const sentence = text.match(/^([A-Za-z]+)\s+\S/);
+  if (sentence) return labelForTitlePrefix(sentence[1]);
+
+  return null;
+}
+
+/**
+ * Type from the PR's own commits, for titles the title matcher cannot classify.
+ *
+ * A PR titled `stack 3/5: carry six contributor bug fixes` fails the
+ * conventional regex (the `3/5` sits between the word and the colon) and then
+ * reaches the sentence-case fallback, which extracts `stack`. That has no entry
+ * in PREFIX_TO_LABEL, so the sync skips — and a skip is not a failure, so the
+ * `label` check stays green while the PR carries no type label at all. The
+ * commits underneath are conventional (`fix(codex): ...`), so they can answer
+ * the question the title cannot.
+ *
+ * `chore` is supporting, not competing. `test:`, `ci:`, `chore:`, `style:`,
+ * `refactor:`, and `build:` all map to it, and none of them says what a PR is
+ * FOR. Requiring unanimity would abstain on almost every real PR: #955 is four
+ * `fix(codex):` commits plus one `test(codex):`, and it is a bug fix.
+ *
+ * Anything still ambiguous after that (`fix:` alongside `feat:`) stays
+ * unlabeled rather than guessed.
+ */
+function detectTypeLabelFromCommits(messages) {
+  const types = new Set();
+  for (const message of Array.isArray(messages) ? messages : []) {
+    const detected = detectTypeLabelFromTitle(String(message || "").split("\n")[0]);
+    if (detected) types.add(detected);
+  }
+  if (types.size > 1) types.delete("chore");
+  return types.size === 1 ? [...types][0] : null;
+}
+
+/**
+ * True when a human (any non-bot actor) has ever labeled or unlabeled a managed
+ * type label on this PR. Mirrors issue-quality's sticky maintainerOverride:
+ * once a person changes the bot's choice, later synchronize/edited runs must
+ * not revert it.
+ *
+ * @param {Array<{ event?: string, label?: { name?: string }, actor?: { login?: string } }>} events
+ * @param {Set<string>} [typeLabels]
+ * @param {Set<string>} [botActors]
+ * @returns {boolean}
+ */
+function hasHumanTypeLabelOverride(events, typeLabels = TYPE_LABELS, botActors = BOT_ACTORS) {
+  if (!Array.isArray(events)) return false;
+  for (const event of events) {
+    if (event?.event !== "labeled" && event?.event !== "unlabeled") continue;
+    const name = event.label?.name;
+    if (!name || !typeLabels.has(name)) continue;
+    const actor = event.actor?.login;
+    if (actor && !botActors.has(actor)) return true;
+  }
+  return false;
+}
+
+/**
+ * Plan type-label add/remove mutations for a PR.
+ *
+ * @param {{
+ *   title: string,
+ *   currentLabels: string[],
+ *   events: Array<{ event?: string, label?: { name?: string }, actor?: { login?: string } }>,
+ * }} input
+ * @returns {{
+ *   skip: true,
+ *   reason: "human-override" | "no-prefix",
+ * } | {
+ *   skip: false,
+ *   detected: string,
+ *   add: string|null,
+ *   remove: string[],
+ * }}
+ */
+function planTypeLabelSync(input) {
+  const title = input?.title ?? "";
+  const currentLabels = Array.isArray(input?.currentLabels) ? input.currentLabels : [];
+  const events = Array.isArray(input?.events) ? input.events : [];
+
+  if (hasHumanTypeLabelOverride(events)) {
+    return { skip: true, reason: "human-override" };
+  }
+
+  // The title is authoritative when it classifies. The commits only answer for
+  // titles it cannot (`stack 3/5: ...`), so a well-formed title is never
+  // overridden by what happens to be committed under it.
+  const detected =
+    detectTypeLabelFromTitle(title) ?? detectTypeLabelFromCommits(input?.commitMessages);
+  if (!detected) {
+    return { skip: true, reason: "no-prefix" };
+  }
+
+  const current = new Set(currentLabels);
+  const remove = [...TYPE_LABELS].filter((label) => current.has(label) && label !== detected);
+  const add = current.has(detected) ? null : detected;
+  return { skip: false, detected, add, remove };
+}
+
+module.exports = {
+  PREFIX_TO_LABEL,
+  TYPE_LABELS,
+  BOT_ACTORS,
+  detectTypeLabelFromTitle,
+  detectTypeLabelFromCommits,
+  hasHumanTypeLabelOverride,
+  planTypeLabelSync,
+};

--- a/.github/scripts/pr-labeler.test.cjs
+++ b/.github/scripts/pr-labeler.test.cjs
@@ -1,0 +1,289 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  detectTypeLabelFromTitle,
+  detectTypeLabelFromCommits,
+  hasHumanTypeLabelOverride,
+  planTypeLabelSync,
+  TYPE_LABELS,
+} = require("./pr-labeler.cjs");
+
+describe("detectTypeLabelFromTitle", () => {
+  it("maps conventional prefixes to type labels", () => {
+    assert.equal(detectTypeLabelFromTitle("fix(codex): warn after sync"), "bug");
+    assert.equal(detectTypeLabelFromTitle("feat(images): add bridge"), "enhancement");
+    assert.equal(detectTypeLabelFromTitle("docs: update guide"), "documentation");
+    assert.equal(detectTypeLabelFromTitle("chore!: drop legacy"), "chore");
+  });
+
+  it("maps sentence-case prefixes when no conventional colon is present", () => {
+    assert.equal(
+      detectTypeLabelFromTitle("Fix Console Go tool schema sanitization"),
+      "bug",
+    );
+    assert.equal(detectTypeLabelFromTitle("Feat add Grok image bridge"), "enhancement");
+    assert.equal(detectTypeLabelFromTitle("Docs update setup guide"), "documentation");
+  });
+
+  it("returns null without a recognized prefix", () => {
+    assert.equal(detectTypeLabelFromTitle("Warn or restart stale app-server"), null);
+    assert.equal(detectTypeLabelFromTitle(""), null);
+    assert.equal(detectTypeLabelFromTitle("constructor: drop legacy"), null);
+    assert.equal(detectTypeLabelFromTitle("Fixed Console Go tool schema"), null);
+    assert.equal(detectTypeLabelFromTitle("Fix"), null);
+  });
+});
+
+describe("hasHumanTypeLabelOverride", () => {
+  it("is false when only the Actions bot touched type labels", () => {
+    const events = [
+      { event: "labeled", label: { name: "bug" }, actor: { login: "github-actions[bot]" } },
+    ];
+    assert.equal(hasHumanTypeLabelOverride(events), false);
+  });
+
+  it("is true after a human replaces the bot type label (PR #518)", () => {
+    const events = [
+      { event: "labeled", label: { name: "bug" }, actor: { login: "github-actions[bot]" } },
+      { event: "unlabeled", label: { name: "bug" }, actor: { login: "Wibias" } },
+      { event: "labeled", label: { name: "enhancement" }, actor: { login: "Wibias" } },
+    ];
+    assert.equal(hasHumanTypeLabelOverride(events), true);
+  });
+
+  it("stays true even if the bot later reverts the human choice", () => {
+    const events = [
+      { event: "labeled", label: { name: "bug" }, actor: { login: "github-actions[bot]" } },
+      { event: "unlabeled", label: { name: "bug" }, actor: { login: "Wibias" } },
+      { event: "labeled", label: { name: "enhancement" }, actor: { login: "Wibias" } },
+      { event: "unlabeled", label: { name: "enhancement" }, actor: { login: "github-actions[bot]" } },
+      { event: "labeled", label: { name: "bug" }, actor: { login: "github-actions[bot]" } },
+    ];
+    assert.equal(hasHumanTypeLabelOverride(events), true);
+  });
+
+  it("ignores non-type labels from humans", () => {
+    const events = [
+      { event: "labeled", label: { name: "bug" }, actor: { login: "github-actions[bot]" } },
+      { event: "labeled", label: { name: "needs-triage" }, actor: { login: "Wibias" } },
+    ];
+    assert.equal(hasHumanTypeLabelOverride(events), false);
+  });
+});
+
+describe("planTypeLabelSync", () => {
+  it("adds the detected label and removes other type labels when bot-owned", () => {
+    const plan = planTypeLabelSync({
+      title: "fix(codex): warn after sync",
+      currentLabels: ["enhancement", "needs-triage"],
+      events: [
+        { event: "labeled", label: { name: "enhancement" }, actor: { login: "github-actions[bot]" } },
+      ],
+    });
+    assert.deepEqual(plan, {
+      skip: false,
+      detected: "bug",
+      add: "bug",
+      remove: ["enhancement"],
+    });
+    assert.ok(TYPE_LABELS.has("bug"));
+  });
+
+  it("is a no-op add when the detected label is already present", () => {
+    const plan = planTypeLabelSync({
+      title: "fix(codex): warn after sync",
+      currentLabels: ["bug"],
+      events: [
+        { event: "labeled", label: { name: "bug" }, actor: { login: "github-actions[bot]" } },
+      ],
+    });
+    assert.deepEqual(plan, {
+      skip: false,
+      detected: "bug",
+      add: null,
+      remove: [],
+    });
+  });
+
+  it("skips when a human has overridden the type label", () => {
+    const plan = planTypeLabelSync({
+      title: "fix(codex): warn after sync",
+      currentLabels: ["enhancement"],
+      events: [
+        { event: "labeled", label: { name: "bug" }, actor: { login: "github-actions[bot]" } },
+        { event: "unlabeled", label: { name: "bug" }, actor: { login: "Wibias" } },
+        { event: "labeled", label: { name: "enhancement" }, actor: { login: "Wibias" } },
+      ],
+    });
+    assert.deepEqual(plan, { skip: true, reason: "human-override" });
+  });
+
+  it("labels sentence-case bug-fix titles (PR #524)", () => {
+    const plan = planTypeLabelSync({
+      title: "Fix Console Go tool schema sanitization",
+      currentLabels: [],
+      events: [],
+    });
+    assert.deepEqual(plan, {
+      skip: false,
+      detected: "bug",
+      add: "bug",
+      remove: [],
+    });
+  });
+
+  it("skips titles without a recognized prefix", () => {
+    const plan = planTypeLabelSync({
+      title: "Warn or restart stale app-server",
+      currentLabels: [],
+      events: [],
+    });
+    assert.deepEqual(plan, { skip: true, reason: "no-prefix" });
+  });
+});
+
+describe("detectTypeLabelFromCommits", () => {
+  it("reads the type from unanimous commits", () => {
+    assert.equal(
+      detectTypeLabelFromCommits([
+        "fix(usage): price long-context requests at the published long rate",
+      ]),
+      "bug",
+    );
+  });
+
+  it("treats chore as supporting, not competing (PR #955 shape)", () => {
+    // Four `fix(codex):` commits plus one `test(codex):`. Requiring unanimity
+    // would abstain here, and on almost every real PR — nearly every
+    // substantial change carries a test or chore commit alongside its fix.
+    assert.equal(
+      detectTypeLabelFromCommits([
+        "fix(codex): probe reset-derived cooldowns without waiting to be selected",
+        "fix(codex): fail closed on an unrecognized plan",
+        "fix(codex): classify prolite as a weekly plan",
+        "fix(codex): share one window rule instead of a plan allowlist",
+        "test(codex): assert the window rule in literals",
+      ]),
+      "bug",
+    );
+  });
+
+  it("keeps chore when nothing else competes", () => {
+    assert.equal(
+      detectTypeLabelFromCommits(["ci: pin an action", "test: add a case"]),
+      "chore",
+    );
+  });
+
+  it("abstains on a genuine mix of fix and feat", () => {
+    assert.equal(
+      detectTypeLabelFromCommits(["fix(a): repair x", "feat(b): add y"]),
+      null,
+    );
+  });
+
+  it("reads only the first line of a multi-line commit message", () => {
+    // A body line starting with `feat:` must not vote.
+    assert.equal(
+      detectTypeLabelFromCommits([
+        "fix(a): repair x\n\nfeat: this is prose in the body, not a type",
+      ]),
+      "bug",
+    );
+  });
+
+  it("returns null for absent or unusable input", () => {
+    assert.equal(detectTypeLabelFromCommits([]), null);
+    assert.equal(detectTypeLabelFromCommits(undefined), null);
+    assert.equal(detectTypeLabelFromCommits(["", null]), null);
+  });
+});
+
+describe("planTypeLabelSync commit fallback", () => {
+  it("labels a stack PR whose title carries no type", () => {
+    // `stack 3/5:` fails the conventional regex (the `3/5` sits between the
+    // word and the colon), reaches the sentence-case fallback, which extracts
+    // `stack` — a word with no PREFIX_TO_LABEL entry. The sync used to skip
+    // here, and a skip is not a failure, so the `label` check stayed green
+    // while all four stack PRs carried no type label.
+    const plan = planTypeLabelSync({
+      title: "stack 3/5: carry six contributor bug fixes with authorship intact",
+      currentLabels: [],
+      events: [],
+      commitMessages: [
+        "fix(kiro): round-trip the redactedContent reasoning blob",
+        "fix(responses): close passthrough streams at terminal events",
+      ],
+    });
+    assert.deepEqual(plan, { skip: false, detected: "bug", add: "bug", remove: [] });
+  });
+
+  it("does not let commits override a title that already classifies", () => {
+    const plan = planTypeLabelSync({
+      title: "feat(providers): add a preset",
+      currentLabels: [],
+      events: [],
+      commitMessages: ["fix(a): repair x", "fix(b): repair y"],
+    });
+    assert.equal(plan.detected, "enhancement");
+  });
+
+  it("still skips when neither the title nor the commits classify", () => {
+    const plan = planTypeLabelSync({
+      title: "stack 1/5: triage the open issue surface",
+      currentLabels: [],
+      events: [],
+      commitMessages: ["wip", "more wip"],
+    });
+    assert.deepEqual(plan, { skip: true, reason: "no-prefix" });
+  });
+
+  it("still honours a human override before consulting commits", () => {
+    const plan = planTypeLabelSync({
+      title: "stack 2/5: price long-context requests",
+      currentLabels: ["enhancement"],
+      events: [
+        { event: "labeled", label: { name: "enhancement" }, actor: { login: "a-human" } },
+      ],
+      commitMessages: ["fix(usage): price long-context requests"],
+    });
+    assert.deepEqual(plan, { skip: true, reason: "human-override" });
+  });
+});
+
+describe("pr-labeler workflow", () => {
+  const workflowPath = path.join(__dirname, "../workflows/pr-labeler.yml");
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+
+  function pullRequestTargetTypes() {
+    const match = workflow.match(/pull_request_target:\s*\n(?:[ \t].*\n)*?[ \t]+types:\s*\[([^\]]+)\]/);
+    assert.ok(match, "expected pull_request_target types array in pr-labeler.yml");
+    return match[1].split(",").map((type) => type.trim());
+  }
+
+  it("listens for labeled and unlabeled so human overrides cancel stale sync runs", () => {
+    const types = pullRequestTargetTypes();
+    assert.ok(types.includes("labeled"), "missing pull_request_target type: labeled");
+    assert.ok(types.includes("unlabeled"), "missing pull_request_target type: unlabeled");
+    assert.ok(types.includes("synchronize"), "missing pull_request_target type: synchronize");
+  });
+
+  it("keeps trusted default-branch checkout, concurrency cancel, and minimal permissions", () => {
+    assert.match(workflow, /ref:\s*\$\{\{\s*github\.event\.repository\.default_branch\s*\}\}/);
+    assert.match(workflow, /cancel-in-progress:\s*true/);
+    assert.match(workflow, /issues:\s*write/);
+    // The issues label endpoints are shared with pull requests: writing a label
+    // onto a PR number needs pull_requests=write alongside issues=write, which
+    // GitHub reports as `issues=write; pull_requests=write`. Pinning this to
+    // read made the workflow fail closed on the first PR that actually needed a
+    // label applied (#565), so write is the minimum here, not an escalation.
+    assert.match(workflow, /pull-requests:\s*write/);
+    // contents stays read — the labeler never pushes.
+    assert.match(workflow, /contents:\s*read/);
+    assert.doesNotMatch(workflow, /contents:\s*write/);
+  });
+});

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,126 @@
+name: PR Labeler
+
+# pull_request_target always loads this workflow from the repository DEFAULT
+# branch (currently main), not from dev. Landing here on dev alone does
+# not change live labeler behavior until the change is also on that default
+# branch — same promotion model as enforce-pr-target.yml.
+on:
+  pull_request_target:
+    # labeled/unlabeled let a human type-label change enqueue a fresher run in the
+    # per-PR concurrency group, cancelling any in-flight title sync that started
+    # before the override.
+    types: [opened, edited, synchronize, labeled, unlabeled]
+
+concurrency:
+  group: pr-labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # pulls.get only needs read, but the issues label endpoints are shared with
+  # pull requests: adding or removing a label on a PR number is rejected with
+  # "Resource not accessible by integration" unless the token also carries
+  # pull_requests=write (the API reports issues=write; pull_requests=write
+  # in x-accepted-github-permissions).
+  pull-requests: write
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout labeler script (default-branch trusted code)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Apply type label from PR title
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const {
+              planTypeLabelSync,
+            } = require('./.github/scripts/pr-labeler.cjs');
+
+            const title = context.payload.pull_request.title || '';
+            const pr = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Refetch live PR title to avoid race with title edits.
+            const { data: livePr } = await github.rest.pulls.get({
+              owner, repo, pull_number: pr,
+            });
+            const liveTitle = livePr.title || title;
+
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo, issue_number: pr,
+            });
+
+            // Issue event timeline (same number space as PRs). Used to detect a
+            // sticky human override — once someone other than github-actions[bot]
+            // changes a managed type label, we never overwrite that choice again.
+            const events = await github.paginate(github.rest.issues.listEvents, {
+              owner, repo, issue_number: pr, per_page: 100,
+            });
+
+            // Titles that carry no recognisable type (e.g. 'stack 3/5: ...')
+            // fall back to the PR's commits, which stay conventional even when
+            // the title does not. Covered by the existing contents: read.
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner, repo, pull_number: pr, per_page: 100,
+            });
+
+            const plan = planTypeLabelSync({
+              title: liveTitle,
+              currentLabels: currentLabels.map((label) => label.name),
+              events,
+              commitMessages: commits.map((commit) => commit.commit?.message || ''),
+            });
+
+            if (plan.skip) {
+              core.info(`Skipping type-label sync for PR #${pr}: ${plan.reason}`);
+              return;
+            }
+
+            // Ensure the target label exists (create if missing).
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: plan.detected });
+            } catch (err) {
+              if (err.status === 404) {
+                const colors = {
+                  enhancement: '0075ca',
+                  bug: 'd73a4a',
+                  documentation: '0075ca',
+                  chore: 'e4e669',
+                };
+                try {
+                  await github.rest.issues.createLabel({
+                    owner, repo,
+                    name: plan.detected,
+                    color: colors[plan.detected] || 'ededed',
+                  });
+                  core.info(`Created missing label "${plan.detected}"`);
+                } catch (createErr) {
+                  if (createErr.status !== 422) throw createErr;
+                  core.info(`Label "${plan.detected}" was created concurrently; continuing.`);
+                }
+              } else {
+                throw err;
+              }
+            }
+
+            for (const label of plan.remove) {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: pr, name: label,
+              });
+              core.info(`Removed stale type label "${label}" from PR #${pr}`);
+            }
+
+            if (plan.add) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr, labels: [plan.add],
+              });
+              core.info(`Applied label "${plan.add}" to PR #${pr}`);
+            }

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -1,0 +1,97 @@
+name: Close stale needs-info issues
+
+# Scheduled workflows only run from the repository DEFAULT branch
+# (currently `main`), not from `dev`. Landing here on `dev` alone does not
+# change live issue-stale behavior until the change is also on that default
+# branch.
+on:
+  schedule:
+    # Daily at 06:15 UTC (offset from the hour to reduce Action load spikes).
+    - cron: "15 6 * * *"
+  # No workflow_dispatch: a branch-selected manual run would execute that
+  # branch's workflow body with issues:write / pull-requests:write, bypassing
+  # default-branch review. Schedule-only keeps the trusted revision on main.
+
+permissions:
+  issues: write
+  # actions/stale requires this even when PR processing is disabled below.
+  pull-requests: write
+
+concurrency:
+  group: stale-needs-info
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    name: Stale needs-info issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure stale label exists
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const name = "stale";
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name });
+              core.info(`Label "${name}" already exists.`);
+              return;
+            } catch (err) {
+              if (err.status !== 404) {
+                core.setFailed(`Failed to look up label "${name}": ${err.message || err}`);
+                return;
+              }
+            }
+            try {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name,
+                color: "ffffff",
+                description: "No activity on a needs-info issue; will close soon unless updated",
+              });
+              core.info(`Created label "${name}".`);
+            } catch (err) {
+              // Concurrent scheduled runs may race on first create.
+              if (err.status === 422) {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name });
+                  core.info(`Label "${name}" appeared concurrently; continuing.`);
+                  return;
+                } catch (lookupErr) {
+                  core.setFailed(
+                    `Failed to create label "${name}" (422) and re-check failed: ${lookupErr.message || lookupErr}`,
+                  );
+                  return;
+                }
+              }
+              core.setFailed(`Failed to create label "${name}": ${err.message || err}`);
+            }
+
+      - name: Mark and close inactive needs-info issues
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+        with:
+          # Only issues maintainers labeled as waiting on the reporter.
+          only-issue-labels: needs-info
+          # Do not auto-stale pull requests.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          # -1 PR timers still allow unstaling existing PR labels; keep that off.
+          remove-pr-stale-when-updated: false
+          # Warn after 14 days of inactivity; close 7 days after the warning.
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: stale
+          close-issue-reason: not_planned
+          # Any new comment/update removes the stale label and restarts the clock.
+          remove-stale-when-updated: true
+          ascending: true
+          operations-per-run: 60
+          stale-issue-message: |
+            This issue has the `needs-info` label and has had no activity for 14 days.
+
+            It will be closed in 7 days if there is still no reply with the requested details (reproduction steps, logs, or a concrete spec). A comment or edit resets this timer. Maintainers can remove `needs-info` once the report is actionable — for example when promoting it to `roadmap`.
+          close-issue-message: |
+            Closing this issue because it stayed on `needs-info` with no further reply.
+
+            Please open a new issue (or comment here to reopen) when you can provide the missing reproduction details or specification. Thanks for the report.

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C821_passing-brightgreen" alt="2,821 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C845_passing-brightgreen" alt="2,845 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C821_passing-brightgreen" alt="2,821 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C845_passing-brightgreen" alt="2,845 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C821_passing-brightgreen" alt="2,821 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C845_passing-brightgreen" alt="2,845 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "node plugins/codexclaw/scripts/build.mjs",
     "gate": "node plugins/codexclaw/scripts/gate.mjs",
-    "test": "node plugins/codexclaw/scripts/test.mjs \"plugins/codexclaw/components/pabcd-state/test/*.test.ts\" \"plugins/codexclaw/components/config-guard/test/*.test.ts\" \"plugins/codexclaw/components/cxc-ops/test/*.test.ts\" \"plugins/codexclaw/components/recall/test/*.test.ts\" \"plugins/codexclaw/components/provider-bridge/test/*.test.ts\" \"plugins/codexclaw/components/subagent-config/test/*.test.ts\" \"plugins/codexclaw/components/messenger-bridge/test/*.test.ts\" \"plugins/codexclaw/components/skill-search/test/*.test.ts\" \"plugins/codexclaw/gui/test/*.test.ts\" \"plugins/codexclaw/test/*.test.mjs\"",
+    "test": "node plugins/codexclaw/scripts/test.mjs \"plugins/codexclaw/components/pabcd-state/test/*.test.ts\" \"plugins/codexclaw/components/config-guard/test/*.test.ts\" \"plugins/codexclaw/components/cxc-ops/test/*.test.ts\" \"plugins/codexclaw/components/recall/test/*.test.ts\" \"plugins/codexclaw/components/provider-bridge/test/*.test.ts\" \"plugins/codexclaw/components/subagent-config/test/*.test.ts\" \"plugins/codexclaw/components/messenger-bridge/test/*.test.ts\" \"plugins/codexclaw/components/skill-search/test/*.test.ts\" \"plugins/codexclaw/gui/test/*.test.ts\" \"plugins/codexclaw/test/*.test.mjs\" \".github/scripts/pr-labeler.test.cjs\"",
     "smoke": "node plugins/codexclaw/scripts/platform-smoke.mjs"
   },
   "overrides": {


### PR DESCRIPTION
## What

Two low-cost lifecycle automations ported from opencodex, per dev-devops repo-bootstrap/agent-intake direction for an agent-PR-heavy repository.

**PR Labeler** (`pr-labeler.yml` + `.github/scripts/pr-labeler.{cjs,test.cjs}`)

- Syncs a type label (`enhancement` / `bug` / `documentation` / `chore`) from the conventional-commit PR title, falling back to the PR's commit messages when the title does not classify (`stack 3/5: ...`).
- Sticky human override: once a non-bot actor changes a managed type label, the bot never reverts it (issue-event timeline check).
- `pull_request_target` with the script checked out from the trusted default branch, `persist-credentials: false`, SHA-pinned actions (checkout v7, github-script v9 — the pins this repo already uses).
- Creates a missing managed label itself (`chore` does not exist yet here).
- 24 unit tests, wired into `npm test`.

**Stale needs-info** (`stale-needs-info.yml`)

- Scheduled `actions/stale` (pinned v10.4.0) over `needs-info` issues only: 14-day warn, 7-day close as not_planned, any update resets the clock. PRs are excluded entirely. Schedule-only trigger; the `stale` label is auto-created.

## Activation caveat

Both workflows load from the **default branch** (`main`): `pull_request_target` and `schedule` ignore `dev`. Merging this PR into `dev` changes no live behavior until promotion — the PR is the review surface, not the activation.

## Merge-order note

Independent of #111 (branch cleanup) and #112 (release hardening) by file, but #111 also touches the `package.json` test line and the README test-count badges. Whichever of #111/this PR lands second needs a one-line rebase: re-add its test path and re-run `inventory.mjs --write --tests <remeausured>`. Flagged here so it does not read as drift.

## Verification

- `node --test .github/scripts/pr-labeler.test.cjs` — 24/24 pass.
- Full suite (`CODEXCLAW_SKIP_REPOMAP_SMOKE=1 npm test`): 2773 tests, 0 fail; badges/inventory republished to 2773.
- `gate.mjs` OK; `actionlint` clean on both workflows.
