### PR TITLE
Wait for the attachment temp directory, not just the file

### DIFF
--- a/plugins/codexclaw/components/messenger-bridge/test/discord-adapter.test.ts
+++ b/plugins/codexclaw/components/messenger-bridge/test/discord-adapter.test.ts
@@ -265,7 +265,10 @@ async function settle() {
 }
 
 async function waitFor(predicate: () => boolean, label: string): Promise<void> {
-  const deadline = Date.now() + 1000;
+  // 1s was tight enough that a slow filesystem (WSL over ext4) could miss a
+  // cleanup that does complete. The wait still exits as soon as the predicate
+  // holds, so a healthy run costs nothing extra.
+  const deadline = Date.now() + 5000;
   while (Date.now() < deadline) {
     if (predicate()) return;
     await settle();
@@ -412,7 +415,13 @@ test("message attachments are downloaded, prefixed into prompt, and cleaned up",
       attachments: [{ id: "a1", filename: "note.txt", url: "https://cdn.example/note.txt", content_type: "text/plain", size: 5 }],
     });
     await settle();
-    await waitFor(() => Boolean(downloadedPath) && !existsSync(downloadedPath), "attachment temp file cleanup");
+    // cleanupTmpMedia removes the temp DIRECTORY recursively, so the file can be
+    // gone a beat before its parent is. Waiting only on the file left the parent
+    // assertion racing the same rm() call, which is how this went red on WSL.
+    await waitFor(
+      () => Boolean(downloadedPath) && !existsSync(downloadedPath) && !existsSync(dirname(downloadedPath)),
+      "attachment temp dir cleanup",
+    );
     adapter.stop();
 
     assert.ok(downloadedPath);


### PR DESCRIPTION
## The flake

`message attachments are downloaded, prefixed into prompt, and cleaned up` failed on `wsl` while ubuntu, macos and windows passed:

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  actual: true, expected: false
  at discord-adapter.test.ts:420
```

Line 420 is `assert.equal(existsSync(dirname(downloadedPath)), false)`.

## Why it raced

`cleanupTmpMedia` calls `rm(target, { recursive: true, force: true })` on the temp **directory** (`media-handler.ts:203`). The downloaded file therefore disappears a beat before its parent does.

The test waited only on the file:

```js
await waitFor(() => Boolean(downloadedPath) && !existsSync(downloadedPath), "attachment temp file cleanup");
```

and then asserted on the parent immediately after — racing the same `rm()` it had just waited on. On a slower filesystem the parent was still present and the assertion saw `true`.

## The fix

The wait now covers both paths, so the assertion runs after the cleanup it describes has actually finished. This is a test-only change; the adapter's cleanup behavior is unchanged and still correct.

`waitFor`'s deadline also moves from 1s to 5s. A second was tight enough that a slow filesystem could miss a cleanup that does complete, and the loop returns as soon as the predicate holds, so a healthy run pays nothing for the larger ceiling.

## Verification

`discord-adapter.test.ts` passes 23/23 locally. The real proof is the hosted `wsl` job on this PR, since that is the only environment where the race was observable.
