### PR TITLE
Wake the agent when a background task finishes

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,9 +13,9 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C902_passing-brightgreen" alt="2,902 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C941_passing-brightgreen" alt="2,941 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
-  <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
+  <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C902_passing-brightgreen" alt="2,902 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C941_passing-brightgreen" alt="2,941 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
-  <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
+  <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT"></a>
 </p>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,9 +13,9 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C902_passing-brightgreen" alt="2,902 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C941_passing-brightgreen" alt="2,941 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
-  <img src="https://img.shields.io/badge/hooks-25-blue" alt="25 hooks">
+  <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT"></a>
 </p>

--- a/bin/codexclaw.mjs
+++ b/bin/codexclaw.mjs
@@ -242,6 +242,16 @@ function runMessengerBridge(args) {
   return typeof res.status === "number" ? res.status : 1;
 }
 
+/** Delegate to the compiled bg-wake CLI (background task registry + completion wake). */
+function runBgWake(args) {
+  // providerBridgeCli ends in .../components/provider-bridge/dist/cli.js, so two levels
+  // up is components/. One was missing here and every root "cxc bg" call — including
+  // the off switch — failed to spawn.
+  const cli = join(dirname(providerBridgeCli), "..", "..", "bg-wake", "dist", "cli.js");
+  const res = spawnSync(process.execPath, [cli, ...args], { stdio: "inherit" });
+  return res.status ?? 1;
+}
+
 /** Delegate to the compiled provider-bridge CLI in detect mode (read-only status). */
 function runProvider() {
   const res = spawnSync(process.execPath, [providerBridgeCli, "detect"], { stdio: "inherit" });
@@ -286,6 +296,7 @@ const TOP_LEVEL_HELP = [
   "Operations:",
   "  subagents                      read/write per-role subagent model+prompt config",
   "  provider                       show read-only opencodex provider status",
+  "  bg run|list|get|off            background tasks + completion wake (cxc bg removal to uninstall)",
   "  serve                          run the bridge server",
   "  service                        install/uninstall/status the serve daemon",
   "  gui                            launch the web dashboard",
@@ -589,6 +600,9 @@ if (isMain) switch (cmd) {
     break;
   case "provider":
     process.exit(runProvider());
+    break;
+  case "bg":
+    process.exit(runBgWake(process.argv.slice(3)));
     break;
   default:
     console.error(renderUnknownTopLevelCommand(cmd));

--- a/devlog/_plan/260909_background_run_suspension_research/000_plan.md
+++ b/devlog/_plan/260909_background_run_suspension_research/000_plan.md
@@ -1,0 +1,81 @@
+# 260909 — 백그라운드 런 서스펜션 / 대기-추적 리서치 로드맵
+
+상태: wp1 (docs-first 로드맵). 구현 없음. 이 문서는 이후 wp2~wp4가 무엇을 증명해야 하는지 고정한다.
+감사 1회차(FAIL) 반영 개정본. 반영 내용: 능력 질문을 한 축으로 좁히지 않음, 서스펜션 정의를 실제 구현에 맞춤, 누락된 대기 표면 추가, 부재 증거 규칙 강화.
+
+## 사용자 질문 (원문 취지)
+
+"~/Developer/codex 에, Claude의 백그라운드 서브에이전트나 세션처럼 **현재 런을 중지하고 대기한 채로 추적**할 수 있는 기능이 있나?
+하트비트나 스케줄 말고. 그건 좀 불편하다. goal 상태와도 충돌이 있을 것 같은데."
+
+두 개의 분리된 질문으로 읽는다.
+
+1. 능력 질문 — Codex에서 외부/자식 작업의 완료를 기다리는 방법이 무엇이고, 그중 "런을 중지한 채 추적"에 해당하는 1급 메커니즘이 있는가. 이 질문을 하나의 축으로 좁히지 않는다. 아래 용어 절의 네 범주(백그라운드 병행, 블로킹 대기, 턴 종료 후 재진입, 서스펜션)를 모두 후보로 놓고 각각 판정한다. 서스펜션도 후보에 포함한다. 워커 핸드오프용으로 만들어진 프리미티브가 사용자가 원하는 용도로 전용될 수 있는지는 별도 판정 대상이다.
+2. 충돌 질문 — 그런 대기 모델이 host goal(HOTL 자동 연속)과 어떻게 부딪히는가.
+
+heartbeat automation과 cron은 사용자가 명시적으로 배제했으므로 대안 후보로 제시하지 않는다. 다만 분류 대상에서까지 빼지는 않는다. 무엇이 그 범주인지 정확히 말해야 나머지가 무엇인지 말할 수 있다.
+
+## 용어 고정
+
+- **턴(turn)** — 하나의 모델 실행 단위. 시작-도구호출-최종메시지로 끝난다.
+- **런 중지 후 대기** — 턴이 종료되지도, CPU를 태우지도 않으면서, 외부 이벤트가 오면 같은 맥락에서 재개되는 상태.
+- **블로킹 대기** — 턴이 살아 있는 채로 도구 호출 안에서 기다리는 것. 컨텍스트와 워커를 계속 점유한다. 내부적으로 폴링을 하더라도 턴이 살아 있으면 이쪽이다.
+- **턴 종료 후 재진입** — 턴을 끝내고 외부 트리거(스케줄러, 사용자, 자동 연속)가 새 턴을 여는 것. heartbeat/cron이 여기 속한다.
+- **서스펜션(suspension)** — 미완료 루트 턴을 종료 이벤트 없이 멈추고, 같은 turn ID를 다른 워커가 회수할 수 있게 상태를 영속화하는 것. in-process 태스크 자체는 취소되고, pending input과 interactive waiter는 버려진다. 즉 워커 핸드오프 프리미티브이며 자동으로 "외부 이벤트를 기다렸다가 같은 맥락에서 이어가기"를 뜻하지 않는다.
+
+wp3는 이 네 범주 각각이 Codex에 어떤 모습으로 존재하는지 코드로 판정한다. 어느 것이 사용자가 원하는 것인지 미리 정해 놓지 않는다.
+
+## 작업 단계
+
+### wp2 — Claude 쪽 기준선
+
+무엇이 "Claude의 백그라운드 서브에이전트/세션"인지 먼저 확정한다. 후보:
+
+- Bash 도구의 백그라운드 실행과 타임아웃 auto-background, 출력 회수/중지 도구, `/tasks`(구 `/bashes`)
+- Monitor 도구 — 백그라운드 명령의 출력 스트림을 줄 단위 이벤트로 추적. 사용자가 말한 "대기한 채로 추적"의 직접 기준선이므로 반드시 포함한다. Bash 프롬프트가 sleep 폴링을 금지하고 이쪽으로 유도하는지도 확인한다
+- Agent 도구(구 Task) 서브에이전트의 전경/백그라운드 구분과 부모 턴 블로킹 여부
+- 완료 알림이 부모 대화에 어떻게 들어오는가 (같은 턴인가, 턴 사이인가)
+- detached background session (agent view, `--bg`, `/background`)
+- Agent SDK의 session 저장 / resume / fork / streaming input / `interrupt()`
+- hook 기반 제어: Stop hook의 계속 지시, PreToolUse defer 후 프로세스 재개
+
+증거: `/Users/jun/Developer/codex/150_claude_code` 소스 path:line + 공식 문서 URL.
+도구 이름은 이동 표적이다. 로컬 소스 스냅샷과 현재 공식 문서가 어긋나면 둘 다 적고, 현재 동작 판정은 공식 문서를 우선한다.
+판정해야 할 것: 각 기능이 부모 턴을 블로킹하는가, 턴 종료 후에도 살아남는가, 나중에 다시 붙을 수 있는가.
+
+### wp3 — Codex 쪽 대응면
+
+`/Users/jun/Developer/codex/121_openai-codex/codex-rs`에서 다음을 path:line으로 확인한다. 대기 표면을 빠뜨리면 "없다"는 결론이 거짓 음성이 되므로 목록을 닫아 둔다.
+
+1. `core/src/unified_exec/` — 백그라운드 셸 세션의 수명, yield 상한, 빈 stdin 폴링
+2. `core/src/tools/handlers/multi_agents{,_v2}/` + `core/src/agent/` — 스폰/대기/재개, 부모 턴과의 동시성, 완료 알림 주입 경로
+3. `core/src/agent/role.rs` + `core/assets/agent/builtins/awaiter.toml` — 전용 대기 역할이 왜 비활성인지 (음수 증거)
+4. `core/src/tools/handlers/sleep.rs` — clock.sleep의 블로킹 성격과 기본 on/off
+5. `core/src/tools/handlers/wait_for_environment.rs` — 다른 도구 호출을 막는다고 명시한 대기
+6. `code-mode-runtime/src/service.rs` + `code-mode-protocol` — exec 셀 yield와 `wait` 재부착
+7. `core/src/session/turn_suspension.rs` + `core/src/codex_thread.rs` — 서스펜션과 회수. `Op::SuspendTurnAndShutdown`, `Op::RecoverTurn`, `recover_turn_if_idle`, `SuspendTurnOutcome::HasLiveDescendants`를 이름으로 확인한다
+8. `ext/goal/` + `state/src/runtime/goals.rs` + `state/goals_migrations/` — goal 자동 연속, 상태 집합, continuation deferral
+9. app-server 프로토콜 — `turn/start`, `turn/steer`, `turn/interrupt`, `thread/resume`, `thread/fork`, 그리고 `thread/backgroundTerminals/` 계열 전체(list/clean/terminate)
+10. `cloud-tasks/` 와 앱 MCP `wait_threads`(`tui/src/dynamic_tools.rs`) — 원격 제출 후 조회, 다른 태스크 완료를 현재 턴에서 대기. 대안 추천이 아니라 분류 대상이다.
+
+각 표면마다 네 가지를 반드시 기록한다. (a) 모델에게 보이는 도구인가, 호스트 `Op`인가, 클라이언트 RPC인가. (b) 기본으로 켜져 있는가. (c) 호출자가 누구인가(모델/app-server/워커/사용자). (d) 대기 중 부모 턴이 살아 있는가.
+
+### wp4 — 매핑, 충돌 분석, 설계 옵션
+
+Claude 기능 ↔ Codex 대응/부재를 1:1 표로 만들고, "런 중지 후 대기 추적"의 가능 여부를 명시적으로 결론낸다.
+wp3에서 확인한 10개 표면을 빠짐없이 네 범주로 분류한 표를 함께 싣는다. Claude에 대응물이 없는 Codex 전용 표면(clock.sleep, 비활성 awaiter, 서스펜션, durable sleep 훅)이 1:1 표 밖으로 떨어지지 않게 하기 위해서다.
+이어서 goal 활성 상태에서 대기 모델이 어떻게 깨지는지 코드 근거로 쓰고, 실현 가능한 설계를 weak/medium/strong 세 단계로 제시한다.
+구현은 이 goal의 범위가 아니다.
+
+## 증거 규칙
+
+모든 핵심 주장은 절대경로:라인 또는 공식 URL을 단다. 서브에이전트가 가져온 인용은 메인이 직접 재확인한 것만 본문에 단정형으로 올리고, 재확인하지 않은 것은 "미검증"으로 표시한다.
+
+부재 주장은 검색어와 함께 적는다. 무엇을 어떤 이름으로 찾았는데 없었는지를 쓰지 않은 "없음"은 증거로 치지 않는다. 제거되거나 비활성화된 기능은 강한 음수 증거이므로 따로 기록한다.
+
+goal 충돌은 네 질문을 고정한다. (1) 블로킹 대기가 턴을 붙잡고 있는 동안 idle 훅이 돌지 않는가. (2) 턴이 끝나면 continuation이 곧바로 새 턴을 켜는가. (3) 서스펜션이 세션을 내리고 thread stop을 낼 때 goal runtime은 어떻게 되는가. (4) goal이 활성 턴에 steering을 주입하는 경로가 블로킹 대기(wait_agent, clock.sleep)를 깨우는가. 네 답이 합쳐져야 대기 모델과 goal이 왜 부딪히는지가 나온다.
+
+## 범위 밖
+
+Codex 본체나 codexclaw 제품 코드 수정, git push, PR, merge, deploy, 외부 메시지, heartbeat/automation 생성.
+

--- a/devlog/_plan/260909_background_run_suspension_research/001_research_ledger.md
+++ b/devlog/_plan/260909_background_run_suspension_research/001_research_ledger.md
@@ -1,0 +1,67 @@
+# 001 — 리서치 원장 (레인 파견과 검증 상태)
+
+wp1 빌드 산출물. 어떤 증거가 어디서 왔고, 메인이 무엇을 직접 재확인했는지 기록한다.
+로드맵의 증거 규칙에 따라, 메인이 재확인하지 않은 서브에이전트 주장은 본문에서 "미검증"으로 표시한다.
+
+## 파견한 레인
+
+xai/grok-4.6 서브에이전트 8개 + Aside 브라우저 4개, 사용자 승인에 따른 무제한 병렬 파견.
+
+| 레인 | 범위 | 상태 |
+|---|---|---|
+| L1 | 150_claude_code 소스 — 백그라운드 실행, Agent 도구, 세션/sidechain, resume | 완료 |
+| L2 | codex-rs unified_exec — 세션 수명, yield, 폴링, compaction 영향 | 완료 |
+| L3 | codex-rs multi_agents V1/V2 — 스폰/대기/알림/재개/동시성 | 완료 |
+| L4 | codex-rs app-server + goal + Stop-continuation + 서스펜션 | 완료 |
+| L5 | 하네스 비교 문서 코퍼스 (005_subagents-collab, 003_tool-runtime) | 완료 |
+| L6 | 타 하네스 백그라운드 추적 패턴 (opencode, hermes, oh-my-*, openclaw, gemini-cli, cli-jaw) | 완료 |
+| L7 | Claude 공식 문서 웹 조사 | 완료 |
+| L8 | Codex 공식 문서 웹 조사 | 완료 |
+| A1~A4 | Aside 브라우저 레인 (Claude docs, Agent SDK, Codex docs, 커뮤니티) | 실행됨. 출력 회수 실패 — 폴링 시 토큰 상한으로 잘렸고 세션이 이미 종료됨. L7/L8이 같은 축을 커버하므로 증거로 쓰지 않는다 |
+| RV | 독립 감사(explorer) — 로드맵 2라운드 | 완료 (1R fail → 2R near-pass) |
+
+Aside 레인의 실패는 기록해 둔다. 결론에 쓰지 않았으므로 결론에 영향은 없지만, "무제한 병렬 파견"이 곧 회수 성공은 아니라는 운영상의 사실이다.
+
+## 메인이 직접 재확인한 인용
+
+아래는 서브에이전트 보고를 받은 뒤 메인이 codex-rs에서 직접 실행해 확인한 것이다. 본문에 단정형으로 쓸 수 있는 근거다.
+
+- core/src/session/turn_suspension.rs:13-119 — suspend_turn_and_shutdown 전체
+- core/src/session/turn_suspension.rs:37 — HasLiveDescendants 조기 반환
+- protocol/src/turn_input.rs:20-28 — SuspendTurnOutcome 열거형
+- core/src/agent/status.rs:26-31 — is_final (PendingInit/Running/Interrupted 제외)
+- core/src/codex_thread.rs:617-618 — inject_fragment_without_turn
+- core/src/session/mod.rs:2299 — 자식 종료 알림의 trigger_turn false
+- core/src/tools/handlers/multi_agents_spec.rs:283 — V2 wait_agent 설명
+- core/src/context/turn_aborted.rs:10-11 — interrupt 후 unified exec 프로세스 생존 안내
+- core/src/unified_exec/process_manager.rs:567 — 초기 yield 전에 세션을 저장하는 이유
+- core/src/tools/handlers/sleep.rs:1-160 — clock.sleep, 최대 12시간, 새 입력으로 조기 종료
+- core/src/config/mod.rs:1258-1276 — CurrentTimeReminderConfig.sleep_tool 기본 false
+- core/src/tools/handlers/wait_for_environment.rs:19 — "blocks other tool calls"
+- core/src/agent/role.rs:383 — "Awaiter is temp removed"
+- core/assets/agent/builtins/awaiter.toml — 대기 전용 역할 프롬프트 원문
+- code-mode-runtime/src/service.rs:121-160 — wait / begin_wait
+- core/src/tasks/mod.rs:412-418, 439-450 — has_outstanding_durable_sleep와 pending-work 턴 시작
+- state/goals_migrations/0001_thread_goals.sql:1-17 — goal 상태 집합
+- state/goals_migrations/0002_thread_goal_continuation_deferrals.sql — continuation deferral 테이블
+- state/src/runtime/goals.rs:100-152 — deferral 삽입/조회/삭제
+- ext/goal/src/runtime.rs:398-458 — continue_if_idle와 start_turn_if_idle
+- ext/goal/src/extension.rs:225-236 — 턴 시작 시 deferral 해제
+- ext/goal/src/tool.rs:244 — update_goal이 pause/resume을 거부
+- app-server-protocol/src/protocol/v2/turn.rs:32-38 — TurnStatus에 Paused 없음
+- tui/src/chatwidget/interaction.rs — interrupt 시 클라이언트가 goal을 Paused로 전환
+- core/src/config/mod.rs:233-243 — 동시성/깊이 기본값
+
+## 메인이 재확인하지 않은 주장 (미검증)
+
+- L1의 Claude 소스 라인 인용 전체. 로컬 스냅샷이며 현재 배포본과 도구 이름이 다르다(L7이 확인).
+- L6의 타 하네스 인용 전체. 설계 참고용이며 결론의 근거로는 쓰지 않는다.
+- L5 문서 코퍼스의 라인 인용. 코퍼스 자체가 2차 자료이고, 같은 코퍼스 안에서도 시점 충돌이 있다고 L5가 스스로 보고했다.
+- L7/L8의 공식 문서 URL 인용. 문서 URL은 확인 가능하지만 메인이 재방문하지 않았다.
+
+## 감사 이력
+
+1라운드 VERDICT: fail. 블로커 — 능력 질문을 서스펜션 한 축으로 선점, 서스펜션 정의가 실제 구현과 불일치, 대기 표면 누락(clock.sleep, wait_for_environment, code-mode wait, awaiter, turn/steer, thread/fork, cloud-tasks, wait_threads), 부재 증거 규칙 부족.
+
+2라운드 VERDICT: near-pass. 잔여 5건 — 능력 질문과 4범주 정합, goal 충돌 질문에 서스펜션/steering 누락, 닫힌 목록의 회수·형제 RPC 이름 누락, wp2에 Monitor 누락, wp4에 4범주 분류표 강제 없음. 전부 접었고 rebut은 없다.
+

--- a/devlog/_plan/260909_background_run_suspension_research/010_claude_baseline.md
+++ b/devlog/_plan/260909_background_run_suspension_research/010_claude_baseline.md
@@ -1,0 +1,129 @@
+# 010 — Claude 쪽 기준선 (wp2)
+
+사용자가 말한 "Claude의 백그라운드 서브에이전트나 세션"이 정확히 무엇인지 확정한다.
+표면마다 다음을 기록한다. 부모 턴을 블로킹하는가, 턴 종료 후에도 사는가, 나중에 다시 붙을 수 있는가.
+
+증거 등급: [S] = 로컬 소스 스냅샷 150_claude_code (2026-03경, 메인 미검증), [D] = 공식 문서 code.claude.com (L7 회수, 메인 재방문 안 함).
+도구 이름은 이동 표적이다. 소스 스냅샷과 현재 문서가 다르면 현재 동작 판정은 문서를 따른다.
+
+## 1. 셸 백그라운드
+
+**Bash `run_in_background`** [S][D] — 명령을 백그라운드 태스크로 띄우고 즉시 task ID를 반환한다. 출력은 파일로 나가고 나중에 `Read`로 읽는다. 타임아웃에 걸린 전경 명령은 죽이지 않고 자동으로 백그라운드로 옮긴다(BashTool.tsx:967-971). 자동 전환 예외는 소스 기준으로 `DISALLOWED_AUTO_BACKGROUND_COMMANDS = ['sleep']` 하나뿐이고 첫 토큰만 본다(BashTool.tsx:220-221, 307-314). 감사에서 정정: git은 자동 백그라운드 예외가 아니라 별도 검증 경로다.
+소스: `src/tools/BashTool/BashTool.tsx:989-1000`이 `spawnBackgroundTask()` 후 빈 stdout과 `backgroundTaskId`만 돌려준다 [S].
+턴 관계: 부모 턴을 블로킹하지 않는다. 완료는 `<task-notification>`으로 큐에 들어간다.
+
+**Ctrl+B** [D] — 이미 돌고 있는 전경 Bash와 에이전트를 백그라운드로 보낸다. 2025-08-07 1.0.71에 Bash용으로 들어왔고 2026-01 2.1.x에서 에이전트까지 통합됐다. `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`로 전부 끌 수 있다.
+
+**출력 회수와 중지** [D] — 현재 공식 도구 표에 `BashOutput`/`KillShell`은 없다. `TaskOutput`은 출력 파일을 `Read`하라며 deprecated이고 중지는 `TaskStop`이다. `/bashes`는 `/tasks`의 별칭으로만 남았다.
+소스 스냅샷도 같은 방향이다. `TaskOutputTool`이 `aliases: ['AgentOutputTool','BashOutputTool']`, `TaskStopTool`이 `aliases: ['KillShell']` [S].
+
+**Monitor** [D, 소스 좌표 없음] — 이 스냅샷 트리에 `src/tools/MonitorTool` 경로가 없어 코드로 대조할 수 없다. 문서 기준으로는 백그라운드 명령의 stdout을 줄 단위 또는 WebSocket 프레임 단위 이벤트로 밀어 넣어, 폴링 없이 진행 중에 반응하게 한다. 사용자가 말한 "대기한 채로 추적"에 가장 직접적으로 대응하는 표면이다.
+
+**`TaskOutput(block=true)`** [S] — 100ms 폴링으로 완료를 기다리는 별도 도구 호출이다. 부모 런을 서스펜드하는 것이 아니라 모델이 스스로 고른 블로킹 대기다. 현재 문서에서는 deprecated.
+
+## 2. 서브에이전트
+
+**Agent 도구(구 Task)** [S][D] — 2.1.63에서 `Task`가 `Agent`로 개명, 별칭 유지. 자식은 자기 컨텍스트에서 돌고 부모에게는 최종 텍스트만 돌려준다.
+
+**동기 vs 비동기** [S] — `shouldRunAsync`가 갈림길이다. `run_in_background === true`이거나 에이전트 정의가 `background: true`이거나 코디네이터/fork/assistant 모드이거나 `proactiveModule?.isProactiveActive()`면 비동기다(AgentTool.tsx:567).
+비동기: `void runAsyncAgentLifecycle(...)` 후 즉시 `{status:'async_launched', agentId}` 반환. 주석이 "부모의 abort controller에 연결하지 않는다 — 사용자가 ESC를 눌러도 백그라운드 에이전트는 살아야 한다"고 명시한다 [S].
+동기: `runAgent` 이터레이터를 끝까지 소비. 부모 턴의 툴콜이 열린 채로 대기한다 [S].
+
+**전경에서 배경으로 전환** [S] — 동기 에이전트도 도중에 백그라운드로 넘길 수 있다. 루프가 `Promise.race([nextMessage, backgroundSignal])`을 돌다가 시그널이 오면 부모는 `async_launched`를 반환하고 자식은 계속 돈다.
+
+**현재 기본값** [D] — v2.1.198부터 서브에이전트는 기본 백그라운드이고, 결과가 당장 필요할 때만 모델이 전경을 요청한다. 인터랙티브 fork 모드가 켜져 있으면 전부 백그라운드로 강제되고 모델은 전경을 요청할 수 없다. 동시 실행 한도는 기본 20(`CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`), 중첩 깊이 기본 3.
+
+**완료 알림 경로** [S][D] — 자식이 끝나면 `<task-notification>` XML을 전역 큐에 넣는다. 기본 우선순위는 `later`라 사용자 입력을 굶기지 않는다(messageQueueManager.ts:137-143). 다만 셸 완료 알림은 Monitor가 켜져 있으면 `next`로 올라간다(LocalShellTask.tsx:169). REPL은 턴과 턴 사이에 이 큐를 비운다. 진행 중인 쿼리 루프도 조건이 맞으면 mid-turn attachment로 끌어올 수 있지만, 그것도 원래 assistant 생성을 이어 붙이는 것이 아니라 다음 API 호출의 새 입력 쪽에 붙는 것이다 [S].
+코디네이터 프롬프트가 이 계약을 모델에게 직접 설명한다. 에이전트를 띄운 뒤 무엇을 띄웠는지 짧게 말하고 응답을 끝내라, 결과를 지어내지 마라, 워커 결과는 user-role 메시지로 도착한다 [S].
+
+## 3. 세션
+
+**저장과 재개** [S][D] — 메인 세션은 UUID `sessionId`의 JSONL. CLI `-c/--continue`, `-r/--resume [id]`, `--session-id`, `--fork-session`. SDK는 `continue` / `resume: <sessionId>` / `forkSession`.
+재개는 저장된 대화를 다시 열고 새 프롬프트로 이어가는 것이지, 멈춰 있던 생성을 그 지점부터 잇는 것이 아니다 [D].
+
+**sidechain** [S] — 서브에이전트 전사는 메인 JSONL이 아니라 `.../{sessionId}/subagents/agent-{agentId}.jsonl`에 `isSidechain: true`로 따로 쌓이고 `/resume` 목록에서 걸러진다. `resumeAgentBackground`는 그 파일을 읽어 자식을 백그라운드로 재시작한다.
+
+**Detached background session** [D] — agent view (`claude agents`, `claude --bg`, `/background`). 터미널을 떼도 supervisor가 세션 전체를 계속 돌린다. 리서치 프리뷰.
+`/background`(별칭 `/bg`)가 현재 대화를 백그라운드 세션으로 옮긴다. 문서 문장: "Background sessions don't need any terminal open to keep working" [D].
+소스 스냅샷에는 이것의 대응물이 없다. 비슷해 보이는 `LocalMainSessionTask`는 같은 프로세스 안에서 현재 쿼리를 백그라운드 태스크로 넘기고 UI만 비우는 것이고(LocalMainSessionTask.ts:1-8), 이 스냅샷에서 Ctrl+B의 세션 경로는 컴파일 시점에 꺼져 있다(SessionBackgroundHint.tsx:47-70). 감사에서 정정: detached supervisor는 [D]만 있고 이 트리에 소스 대응이 없다 [S].
+
+**`/subtask` vs `/fork`** [D] — `/subtask`는 대화를 상속한 백그라운드 서브에이전트를 띄우고 결과가 이 대화로 돌아온다. `/fork`는 대화를 별도 백그라운드 세션으로 복사하고 원본은 계속 돈다.
+
+## 4. SDK와 훅
+
+**streaming input mode** [D] — 권장 모드. 긴 수명 프로세스처럼 입력을 받고 메시지 큐, 인터럽트, 권한, 세션 관리가 된다.
+
+**`interrupt()`** [D] — streaming input 모드에서만 동작한다. 현재 턴만 끊고 세션은 살아 있어 다음 프롬프트로 이어간다.
+
+**Stop 훅의 `decision: "block"`** [D] — 에이전트가 멈추려는 시점에 이유를 주고 한 턴 더 돌게 한다. 8회 연속이면 런타임이 덮어쓰고 끝낸다. 반대로 모든 이벤트의 top-level `continue: false`는 에이전트를 완전히 멈춘다.
+
+**`PreToolUse`의 `permissionDecision: "defer"`** [D] — `-p` 비대화형에서만 존중된다. 프로세스가 그 도구 호출을 보존한 채 종료하고, 호스트가 입력을 모은 뒤 같은 세션을 resume한다. 인터랙티브에서는 경고 후 무시된다.
+이것이 Claude 진영에서 "런을 중지하고 나중에 재개"에 가장 가까운 1급 메커니즘이다.
+
+**Dynamic workflows** [D] — 문서 원문: "a runtime executes it in the background while your session stays responsive", "Workflows run in the background, so the session stays responsive while agents work". `/workflows` progress view에서 `p`가 pause/resume, `x` stop, `r` restart. 다만 "You can resume a run within the same Claude Code session"이고 "No mid-run user input", "Only agent permission prompts can pause a run"이라는 제약이 붙는다. 즉 workflow의 pause는 대화 턴의 pause가 아니라 스크립트 런의 pause다.
+
+## 5. 부모 런 park는 Claude에도 없다
+
+L1이 `waiting_for_child`, `parkQuery`, `suspendParent`, `parentWaiting`, `yieldUntilChild`, `waitForSubagent`, `wait_for_child`로 소스를 훑었고 매칭이 없었다 [S].
+`waiting_for_agents`는 headless `print.ts`가 턴이 끝난 뒤 백그라운드 에이전트를 기다리며 프로세스를 붙잡는 종료 폴링이다. `suspend`는 유닉스 SIGTSTP다.
+
+즉 Claude의 모델도 부모 생성을 얼렸다가 같은 지점에서 잇는 것이 아니다. 부모의 선택지는 세 가지다. 동기 Agent 툴콜로 열린 채 기다리거나(이 경우 부모 턴은 점유된다), 백그라운드로 띄우고 계속 일하거나, 턴을 끝내는 것. 어느 쪽이든 자식 결과는 다음 턴의 입력으로 들어온다. 사용자가 좋다고 느끼는 부분은 park가 아니라 이것이다. 자식을 띄운 뒤 부모가 자유로워지고, 완료가 스스로 대화에 돌아오며, 그 사이에 목록을 보고 붙었다 뗄 수 있다는 것.
+
+## 6. 공식 문서 원문 (Aside 브라우저로 직접 확인, [D] 승격)
+
+sub-agents (https://code.claude.com/docs/en/sub-agents):
+
+> Foreground subagents block the main conversation until complete. Permission prompts are passed through to you as they come up.
+
+> Where fork mode is off, Claude runs the subagent in the background by default and in the foreground when it needs the result before continuing.
+
+> A background subagent's results reach Claude as a completion notification in a later turn. Claude waits for that notification before reporting the subagent's results, and if you ask about progress first, it reports that the subagent is still running.
+
+tools-reference (https://code.claude.com/docs/en/tools-reference), Monitor:
+
+> Runs a command in the background and feeds each output line back to Claude, so it can react to log entries, file changes, or polled status mid-conversation. Can also open a WebSocket and treat each incoming message as an event.
+
+> The Monitor tool lets Claude watch something in the background and react when it changes, without pausing the conversation.
+
+hooks (https://code.claude.com/docs/en/hooks), PreToolUse defer:
+
+> "defer" exits gracefully so the tool can be resumed later.
+
+> "defer" is for integrations that run claude -p as a subprocess and read its JSON output... It lets that calling process pause Claude at a tool call, collect input through its own interface, and resume where it left off. Claude Code honors this value only in non-interactive mode with the -p flag. In interactive sessions it logs a warning and ignores the hook result.
+
+> The hook returns permissionDecision: "defer". The tool doesn't execute. The process exits with stop_reason: "tool_deferred" and the pending tool call preserved in the transcript.
+
+제약도 원문에 있다. defer는 그 턴에 도구 호출이 하나일 때만 동작하고, 여러 개면 경고와 함께 무시된다. 재개 시 도구가 사라졌으면 stop_reason은 tool_deferred_unavailable이 된다.
+
+agent view (https://code.claude.com/docs/en/agent-view):
+
+> Background sessions don't need any terminal open to keep working.
+
+workflows (https://code.claude.com/docs/en/workflows):
+
+> a runtime executes it in the background while your session stays responsive
+
+> You can resume a run within the same Claude Code session.
+
+> Only agent permission prompts can pause a run.
+
+이 인용들이 5절의 결론을 다시 확인해 준다. Claude의 "백그라운드"는 부모 생성을 얼리는 것이 아니라, 부모를 자유롭게 두고 완료를 다음 턴 알림으로 돌려주는 것이다. 유일하게 프로세스를 도구 호출 지점에 멈추는 defer조차 인터랙티브에서는 무시되고 -p 호스트 통합 전용이다.
+
+## 기준선 요약 (wp3가 대조할 항목)
+
+1. 셸을 백그라운드로 띄우고 부모는 계속 간다
+2. 타임아웃 시 자동 백그라운드 전환
+3. 실행 중인 전경 작업을 사후에 백그라운드로 보내는 단축키
+4. 세션 내 백그라운드 작업 목록 UI와 attach/stop
+5. 스트림 기반 추적(Monitor), 폴링 없이 중간 반응
+6. 서브에이전트 기본 백그라운드, 부모 턴 비블로킹
+7. 자식 완료가 다음 턴 입력으로 자동 재진입
+8. 터미널을 떼도 사는 detached 세션
+9. 세션 저장/재개/fork
+10. 도구 호출을 보존한 채 프로세스 종료 후 재개(PreToolUse defer)
+11. Stop 훅으로 멈추지 말고 한 턴 더
+12. 입력이 오면 깨는 블로킹 sleep (프로액티브 `Sleep`, tools.ts:25-27)
+13. 실행 중인 에이전트에 메시지를 붙이는 attach (`SendMessage`, SendMessageTool.ts:520-536)
+14. 수명 내내 running으로 남는 in-process teammate (headless 종료 폴링이 의도적으로 제외, print.ts:2427-2434)
+15. detached supervisor 세션과 in-process 백그라운드 태스크의 구분
+

--- a/devlog/_plan/260909_background_run_suspension_research/020_codex_surfaces.md
+++ b/devlog/_plan/260909_background_run_suspension_research/020_codex_surfaces.md
@@ -1,0 +1,170 @@
+# 020 — Codex 쪽 대기 표면 (wp3)
+
+경로는 모두 `/Users/jun/Developer/codex/121_openai-codex/codex-rs` 기준. 별도 표시가 없으면 메인이 직접 열어 확인했다.
+표면마다 네 가지를 기록한다. 종류(모델 도구 / 호스트 Op / 클라이언트 RPC), 기본 활성 여부, 호출자, 대기 중 부모 턴 생존.
+
+## 요약 표
+
+| # | 표면 | 종류 | 기본 | 호출자 | 대기 중 부모 턴 |
+|---|---|---|---|---|---|
+| 1 | `exec_command` / `write_stdin` | 모델 도구 | on | 모델 | 살아 있음 (도구 호출만 yield) |
+| 2 | `spawn_agent` | 모델 도구 | on | 모델 | 살아 있음, 자식은 별도 스레드 |
+| 3 | `wait_agent` V1 | 모델 도구 | on | 모델 | 살아 있음, 툴콜이 블로킹 |
+| 3b | `wait_agent` V2 | 모델 도구 | **off** (`multi_agent_v2` default_enabled false, `features/src/lib.rs:1265-1272`) | 모델 | 살아 있음 |
+| 4 | `clock.sleep` | 모델 도구 | **off** | 모델 | 살아 있음, 최대 12시간 |
+| 5 | `wait_for_environment` | 모델 도구 | **off** (`Feature::DeferredExecutor` 필요, `spec_plan.rs:1146-1156`) | 모델 | 살아 있음, 다른 도구 차단 |
+| 6 | code-mode `exec` / `wait` | 모델 도구 | **off** (`Feature::CodeMode` default_enabled false, `features/src/lib.rs:1011-1014`) | 모델 | 살아 있음, JS 셀만 재부착 |
+| 7 | `awaiter` 역할 | 에이전트 역할 | **제거됨** | — | — |
+| 8 | `SuspendTurnAndShutdown` / `RecoverTurn` | 호스트 Op | 내부 | 워커/핸드오프 | 턴 태스크는 취소되고 워커가 내려감. 턴 ID는 남아 다른 워커가 회수 가능 |
+| 9 | `turn/steer`, `thread/resume`, `thread/fork`, `thread/backgroundTerminals/*` | 클라이언트 RPC | 일부 experimental | 앱/TUI | 경우별 |
+| 10 | `cloud-tasks`, 앱 MCP `wait_threads` | CLI / MCP 도구 | 별개 표면 | 사용자/모델 | 살아 있음 |
+
+핵심: **부모 턴이 죽지 않은 채로 대기하는 표면은 많고, 부모 턴을 살려 둔 채 워커만 내려놓는 표면은 없다.** 8번만 턴을 멈추는데, 그건 프로세스 전체를 내리는 핸드오프다.
+
+## 1. unified_exec — 백그라운드 셸 세션
+
+`core/src/unified_exec/mod.rs:149-174`가 세션 스코프 `ProcessStore`를 들고, `core/src/state/service.rs:52`가 그걸 `SessionServices`에 붙인다. 프로세스 상한은 세션당 64개(`mod.rs:82`).
+
+`exec_command`는 `yield_time_ms`(250ms~30s, `mod.rs:73-77`)만 기다린 뒤 살아 있으면 `session_id`를 돌려주고 프로세스를 남긴다. 이후 `write_stdin`에 빈 `chars`를 주면 폴링이고, 빈 폴링은 5초~5분이다(clamp는 `process_manager.rs:955`, 기본 상한 필드 `background_terminal_max_timeout`는 `config/mod.rs:1046`, 기본값 300000).
+
+프로세스가 턴을 넘어 사는 것은 의도된 설계다. `process_manager.rs:567`의 주석이 이유를 적는다. "Persist live sessions before the initial yield wait so interrupting the turn cannot drop the last Arc and terminate the background process." 인터럽트 후 모델에게 주는 안내도 같은 말을 한다(`core/src/context/turn_aborted.rs:10-11`): "Any running unified exec processes may still be running in the background."
+
+전부 종료되는 지점은 세션 shutdown과 명시적 clean 두 곳뿐이다.
+
+한계: **모델이 볼 수 있는 세션 목록 도구가 없다.** 목록은 `list_processes()` → 클라이언트 RPC `thread/backgroundTerminals/list`로만 나가고 슬래시 커맨드 `/ps`가 그걸 쓴다. 컨텍스트가 압축되면서 `session_id`가 히스토리에서 사라지면 모델은 그 프로세스를 다시 붙잡을 수단이 없다. compaction 경로에 unified_exec 참조는 없다(L2 확인, 메인 미재검증).
+
+## 2~3. 서브에이전트 — spawn과 wait
+
+`spawn_agent`는 새 `CodexThread`를 만들고 초기 입력을 보낸 뒤 즉시 `agent_id`를 반환한다. 자식은 별도 스레드에서 자기 턴을 돌린다. **부모가 자기 턴을 끝내도 자식은 계속 돈다.**
+
+완료 알림 경로가 둘로 갈린다.
+- V1: spawn 직후 detached watcher가 붙고, 자식이 최종 상태가 되면 `inject_fragment_without_turn`으로 부모 히스토리에 `<subagent_notification>`을 넣는다(`core/src/codex_thread.rs:629-635`). 이름 그대로 **새 턴을 열지 않는다.**
+- V2: 자식의 `TurnComplete`/`TurnAborted`가 부모에게 `InterAgentCommunication`을 `trigger_turn = false`로 보낸다(`core/src/session/mod.rs:2299`).
+
+즉 **자식이 끝나도 부모의 새 턴은 자동으로 열리지 않는다.** 알림은 히스토리와 메일박스에 쌓여 있다가, 부모가 다음에 무언가로 턴을 열 때 함께 들어간다. 이것이 사용자가 느낀 불편의 코드상 위치다.
+
+예외가 하나 있다. `core/src/tasks/mod.rs:412-418`의 `has_outstanding_durable_sleep`다. 스레드에 `SleepItem`이 붙어 있으면, `trigger_turn`이 없는 메일조차 유휴 세션의 새 턴을 열 수 있다(`:439-450`, 주석: "Queue-only mail wakes durable sleep without selecting a new task's settings"). 이것이 Codex 안에서 "자고 있다가 메일이 오면 깨어난다"에 가장 가까운 기계다.
+**그러나 이 체크아웃에서 `SleepItem`을 `thread_store`에 넣는 곳은 테스트뿐이다**(`core/tests/suite/pending_input.rs:494`). `core/src/tools/handlers/sleep.rs:101`의 `SleepItem`은 화면 표시용 `TurnItem`이지 durable 마킹이 아니다. 즉 확장이 꽂을 수 있는 훅은 있고, 꽂는 확장은 이 트리에 없다.
+
+`wait_agent`는 두 버전이 다르다.
+- V1: 대상이 최종 상태가 될 때까지 부모 툴콜을 붙잡는다. 첫 최종 상태에서 break한다. `Interrupted`는 최종이 아니다(`core/src/agent/status.rs:26-31`).
+- V2: 대상 인자가 없다. 살아 있는 에이전트의 메일박스 갱신이나 사용자 steering을 기다린다. 스펙 원문(`multi_agents_spec.rs:283`): "Wait for a mailbox update from any live agent... The wait also ends early when new user input is steered into the active turn."
+
+동시성 기본값은 V1 스레드 6개, V2 세션당 4슬롯(부모 포함이라 자식 상한은 3), 깊이 1이다(`core/src/config/mod.rs:233-243`). Claude의 기본 20과 깊이 3에 비해 좁다.
+
+## 4. clock.sleep — 블로킹 대기, 기본 꺼짐
+
+`core/src/tools/handlers/sleep.rs`. 설명 원문: "Pause execution for a specified duration. The sleep ends early when new input arrives for the active turn." 최대 12시간(`MAX_SLEEP_DURATION_MS = 12*60*60*1000`).
+
+노출은 `ToolExposure::DirectModelOnly`이고, `CurrentTimeReminderConfig`의 `sleep_tool` 기본값이 `false`다(`core/src/config/mod.rs:1258-1276`). 켜져 있어도 턴은 살아 있다. 컨텍스트와 워커를 12시간까지 점유할 수 있다는 뜻이다.
+
+## 5. wait_for_environment
+
+`core/src/tools/handlers/wait_for_environment.rs:19` 설명 원문에 "Waiting may take several minutes and blocks other tool calls"라고 적혀 있다. 다른 도구 호출을 막는다고 명시적으로 말하는 표면은 이것뿐이지만, 블로킹 자체를 설명에 드러내는 도구는 더 있다. `clock.sleep`의 "Pause execution for a specified duration"(`sleep.rs:50`), V2 `wait_agent`의 "Wait for a mailbox update..."(`multi_agents_spec.rs:283`).
+등록 조건은 호스트 제공만이 아니다. `Feature::DeferredExecutor`가 켜져야 등록된다(`core/src/tools/spec_plan.rs:1146-1156`).
+
+## 6. code-mode exec / wait
+
+`code-mode-protocol/src/lib.rs:51-52`가 도구 이름 `exec`와 `wait`를 정의하고, `code-mode-runtime/src/service.rs:121-160`의 `wait`/`begin_wait`가 셀을 끝내지 않은 채 다시 관찰한다.
+재부착 대상은 **JS 셀**이지 턴이 아니다. 셀이 살아 있는 동안에도 모델은 턴 안에서 계속 돈다. 이 리서치 자체가 그 위에서 돌아갔다.
+
+## 7. awaiter — 있었다가 제거된 대기 전용 역할
+
+`core/assets/agent/builtins/awaiter.toml`은 지금도 저장소에 있다. 내용은 "You are an awaiter. Your role is to await the completion of a specific command or task and report its status only when it is finished"이고, "If the task is still running, continue polling using tool calls", "Use long timeouts... increase the timeouts/yield times exponentially"까지 적혀 있다. `background_terminal_max_timeout = 3600000`(1시간)도 포함한다.
+
+그런데 `core/src/agent/role.rs:383`에 `// Awaiter is temp removed`라는 주석과 함께 등록 블록 전체가 주석 처리되어 있다. 내장 역할은 `default`, `explorer`, `worker`뿐이다.
+
+이것이 이 조사에서 가장 강한 음수 증거다. "긴 작업을 대신 기다려 주는 서브에이전트"는 Codex가 만들었다가 껐다. 주석에 남은 원래 지침은 이렇게 시작한다. "Use an awaiter agent EVERY TIME you must run a command that will take some very long time... When an awaiter is running, you can work on something else."
+
+## 8. 턴 서스펜션 — 있지만 목적이 다르다
+
+`core/src/session/turn_suspension.rs`의 `suspend_turn_and_shutdown`이 유일하게 진행 중인 턴을 멈춘다. `protocol/src/turn_input.rs:20-28`의 결과 타입은 `Suspended{turn_id}`, `NotActive`, `HasLiveDescendants`, `UnsupportedTask`다.
+
+무엇을 하는가. 종료 이벤트를 기록하지 **않고** 태스크를 취소한 뒤(`:70-72` 주석: "Normal shutdown records a terminal turn event, preventing another worker from recovering this turn under its original ID. Cancel the task without that event."), 히스토리를 flush하고 writer를 닫고 세션 런타임을 내린다. 그러면 다른 워커가 `RecoverTurn`으로 같은 turn ID를 회수한다(`core/src/codex_thread.rs:353-361`: "Recovery starts no new user input and preserves the turn ID").
+
+왜 사용자가 원하는 것이 아닌가. 세 가지 이유가 코드에 있다.
+1. **살아 있는 자손이 있으면 거절한다.** `:37`에서 `HasLiveDescendants`로 조기 반환한다. 백그라운드 작업을 추적하려고 서스펜드하는 것 자체가 금지된 조합이다.
+2. **대기 상태가 아니라 종료다.** in-process 태스크는 `cancellation_token.cancel()`로 취소되고, 워커 프로세스의 세션 런타임이 내려간다.
+3. **pending input과 waiter를 버린다.** `:97-98` 주석: "Pending accepted input and interactive waiters live only in this process. Handoff intentionally drops that state; persisting or replaying it needs a separate protocol."
+
+프로토콜 레벨에도 pause 개념이 없다. `app-server-protocol/src/protocol/v2/turn.rs:32-38`의 `TurnStatus`는 `Completed | Interrupted | Failed | InProgress` 넷뿐이다.
+
+## 9. 클라이언트 RPC
+
+`turn/steer`(`common.rs:1028`)는 활성 턴에 입력을 넣는다. 이게 `wait_agent`와 `clock.sleep`을 깨우는 경로다.
+`thread/resume`은 저장되거나 실행 중인 스레드에 클라이언트를 다시 붙이는 것이고, `thread/fork`(`common.rs:564`)는 분기다.
+`thread/backgroundTerminals/`는 `clean`, `list`, `terminate` 셋 다 `#[experimental]`이다(`common.rs:716-732`). TUI 슬래시 커맨드 `/ps`와 `/stop`이 여기에 붙는다.
+
+## 10. 인접 표면
+
+`cloud-tasks` CLI는 `exec`로 원격 작업을 제출하고 `status`/`list`/`diff`/`apply`로 조회한다. 로컬 턴을 멈추지 않고 별도 작업을 시작하는 것이다.
+앱 MCP `wait_threads`(`tui/src/dynamic_tools.rs:179, 832-852`)는 다른 태스크의 완료를 현재 턴에서 기다린다. 호출 태스크 자신은 대상이 될 수 없다. 이것도 블로킹 대기다.
+
+## 11. 인접하지만 다른 축
+
+`request_user_input`은 실험적 블로킹 도구이고 `request_user_input_async`는 즉시 반환한다(`core/src/tools/spec_plan.rs:1158-1166`). 사용자 응답을 기다리는 것이라 백그라운드 작업 추적과는 다른 축이지만, "턴을 붙잡는 대기" 목록에는 들어간다.
+`thread_unload_delay`(`core/src/config/mod.rs:1049`)는 유휴 스레드를 메모리에서 내리는 설정이다. 핸드오프와 인접하지만 대기 도구는 아니다.
+
+## 12. 부재 확인 (검색어와 매치 수)
+
+로드맵의 증거 규칙에 따라, 무엇을 어떤 이름으로 찾았는지와 매치 수를 남긴다. codex-rs 트리 기준.
+
+- turn/pause|turn/resume RPC → 매치 0건
+- Paused in TurnStatus → 매치 0건
+- model-visible list of exec sessions → 매치 0건
+- run_in_background arg → 매치 1건 (TUI 종료 액션 테스트. 13절 참조. Claude식 도구 인자는 아니다)
+- auto-background on timeout → 매치 0건
+- monitor tool → 매치 0건
+- park/suspend parent turn → 매치 0건
+
+읽는 법. 턴 자체를 일시정지하는 RPC와 `TurnStatus::Paused`는 없다. 모델이 부를 수 있는 exec 세션 목록 도구가 없다(매치는 전부 core/src/tools 밖의 클라이언트 경로). Claude의 `run_in_background` 인자, 타임아웃 자동 백그라운드 전환, Monitor에 해당하는 것도 없다. 부모 턴을 park하는 이름도 없다.
+`spawn_agent`가 사실상 Codex의 백그라운드 실행 단위이지만, 그건 셸 명령이 아니라 에이전트다. 셸을 백그라운드로 두는 것은 `exec_command`의 yield 반환이고, 그건 인자가 아니라 시간이 정한다.
+
+## 13. TUI의 Run in background — Codex에 실재하는 detach
+
+이건 처음 세운 10개 목록에 없었다. 부재 검색 중 `run_in_background`가 codex-rs에 딱 1건 걸려서 찾았다.
+
+실행 중인 태스크를 두고 종료하려 하면 TUI가 세 선택지를 띄운다(`tui/src/app/input.rs:362-390`).
+
+- "Cancel task" — Stop the current task and stay in Codex
+- "Run in background" — **Exit Codex and leave the task running**
+- "Exit" — Stop the current task and exit Codex
+
+"Run in background"은 `allow_background`가 참일 때만 보인다. 조건은 실행 중인 side thread가 없고 큐에 쌓인 후속 메시지가 없을 것.
+동작은 `ExitMode::Immediate`로 나가는 것뿐이다(`tui/src/app/event_dispatch.rs:695-697`). 인터럽트를 보내지 않으므로 데몬 쪽 스레드는 계속 돈다. 테스트 이름이 계약을 그대로 말한다. `run_in_background_detaches_without_interrupting_main_or_side_threads`(`tui/src/app/tests/background_exit_tests.rs:274`).
+
+goal 관점에서 결정적인 차이가 여기 있다. **세 선택지 중 "Run in background"만 goal을 pause하지 않는다.**
+- Cancel task → `pause_active_goal_for_interrupt()`
+- Exit → `thread_goal_set(..., Paused, ...)`
+- Run in background → 아무것도 하지 않음
+
+즉 Codex에서 "런을 두고 나간다"는 것은 이미 가능하다. 다만 그것은 **TUI를 나가는 것**이지, 대화 안에서 턴을 대기 상태로 두는 것이 아니다. 그리고 이 경로로 나가면 goal은 Active로 남아 데몬이 계속 새 턴을 연다.
+
+## goal 쪽 사실 (wp4 충돌 분석의 입력)
+
+- 상태 집합은 `active | paused | blocked | usage_limited | budget_limited | complete`다(`state/goals_migrations/0001_thread_goals.sql:1-17`).
+- `update_goal`로 에이전트가 쓸 수 있는 것은 `complete`와 `blocked`뿐이다. 원문(`ext/goal/src/tool.rs:244`): "pause, resume, budget-limited, and usage-limited status changes are controlled by the user or system".
+- 자동 연속은 `on_thread_idle` → `continue_if_idle` → `start_turn_if_idle`이고, `turn_trigger = "goal"`인 **새 턴**을 연다(`ext/goal/src/runtime.rs:398-458`). 같은 턴을 잇는 것이 아니다.
+- `thread_goal_continuation_deferrals` 테이블이 연속을 한 번 건너뛰게 한다. goal 생성 시 삽입되고(`state/src/runtime/goals.rs:111`) 턴 시작 시 지워진다(`ext/goal/src/extension.rs:235`).
+- 서스펜션이 `emit_thread_stop_lifecycle`을 내면 goal의 `on_thread_stop`이 런타임을 unregister한다(`ext/goal/src/extension.rs:190-196`).
+- 공식 cookbook 문장(Aside 확인): "Interruptions pause the objective." 그리고 continuation은 스레드가 유휴일 때만 일어난다.
+
+## 상류에 이미 올라온 이슈
+
+사용자가 느낀 불편은 openai/codex에 이미 보고되어 있다. Aside가 `gh`로 직접 조회한 결과다.
+
+| 번호 | 제목 | 상태 |
+|---|---|---|
+| #15723 | Background subprocesses/subagents do not wake the calling agent on completion | OPEN, 댓글 21, bug/subagent |
+| #22003 | Support injecting command output from background completion into the active Codex session | OPEN, enhancement/session |
+| #42908 | Desktop agent is not resumed when a background exec session completes | OPEN, app/app-server/enhancement/tool-calls |
+| #14318 | Race condition between subagent async notification and main agent turn lifecycle | CLOSED |
+| #22099 | Parallel-first subagents and nonblocking background task management | OPEN, 엄브렐러 |
+| #36141 | Parent turn completes while newly spawned child agent is still pendingInit | OPEN |
+| #17737 | Feature request: Claude Code-like /monitoring for background terminals | OPEN |
+| #3968 | Background Terminal Sessions | CLOSED |
+| #34279 | Allow switching away from active CLI sessions while their turns keep running | CLOSED |
+| #38177 | macOS: pausing a Goal leaves the thread active/inProgress and sidebar spinner running | OPEN |
+
+#15723의 기대 동작이 사용자 질문과 같은 문장이다. 긴 백그라운드 작업이 끝나면 에이전트가 통보받아 자율적으로 이어서 행동해야 한다는 것.
+

--- a/devlog/_plan/260909_background_run_suspension_research/030_synthesis.md
+++ b/devlog/_plan/260909_background_run_suspension_research/030_synthesis.md
@@ -1,0 +1,137 @@
+# 030 — 매핑, goal 충돌, 설계 옵션 (wp4)
+
+## 1. 결론 먼저
+
+**Codex에는 "현재 런을 중지하고 대기한 채로 추적"하는 1급 기능이 없다.** 그리고 Claude에도 그 형태로는 없다.
+차이는 park의 유무가 아니라 **깨어나는 방식**에 있다.
+
+- Claude: 자식/셸을 백그라운드로 띄우면 부모는 턴을 끝내고 자유로워진다. 완료는 completion notification으로 **다음 턴에 스스로 돌아온다**. 문서 원문: "A background subagent's results reach Claude as a completion notification in a later turn."
+- Codex: 자식/셸을 백그라운드로 띄우면 부모는 마찬가지로 자유로워진다. 그런데 완료 알림이 **새 턴을 열지 않는다**. V1은 `inject_fragment_without_turn`, V2는 `trigger_turn = false`다. 알림은 히스토리와 메일박스에 조용히 쌓여 있다가, 부모가 다른 이유로 턴을 열 때 비로소 읽힌다.
+
+그래서 Codex에서 백그라운드 작업을 추적하려면 부모가 턴을 붙잡은 채 기다리는 수밖에 없다. `wait_agent`, `clock.sleep`, `write_stdin` 폴링이 전부 그 형태다. 사용자가 불편하다고 한 heartbeat는 그 회피책이다. 턴을 끝내고 외부 스케줄러로 다시 들어오는 것.
+
+이 진단은 상류에서도 같은 문장으로 보고되어 있다. openai/codex #15723 "Background subprocesses/subagents do not wake the calling agent on completion" (OPEN, 댓글 21), #22003, #42908.
+
+## 2. Claude 기준선 ↔ Codex 대응
+
+| # | Claude 기준선 | Codex 대응 | 판정 |
+|---|---|---|---|
+| 1 | 셸 백그라운드 실행, 부모 계속 진행 | `exec_command`가 yield 후 `session_id` 반환, 프로세스 생존 | 있음 (형태 다름: 인자가 아니라 시간이 결정) |
+| 2 | 타임아웃 시 자동 백그라운드 전환 | `exec_command`의 `yield_time_ms`가 끝나면 프로세스를 남기고 `session_id`를 반환(`mod.rs:73-77`, `process_manager.rs:566-567`). 1행과 같은 기계다 | 있음 (감사에서 정정) |
+| 3 | 실행 중 전경 작업을 사후 백그라운드로 (Ctrl+B) | 없음. TUI `Run in background`는 프로세스를 나가는 것 | 부분 (레벨이 다름) |
+| 4 | 세션 내 작업 목록 UI, attach/stop (`/tasks`) | `/ps`, `/stop` + `thread/backgroundTerminals/*` (experimental). **모델용 목록 도구는 없음** | 부분 (사람만 볼 수 있음) |
+| 5 | Monitor — 스트림 기반 추적, 대화 중단 없이 반응 | 없음 (매치 0). 요청은 이슈 #17737 | 없음 |
+| 6 | 서브에이전트 기본 백그라운드, 부모 턴 비블로킹 | `spawn_agent`가 즉시 반환, 자식은 별도 스레드 | 있음 |
+| 7 | 자식 완료가 다음 턴 입력으로 자동 재진입 | **없음.** `trigger_turn = false` / `inject_fragment_without_turn` | **없음 — 핵심 격차** |
+| 8 | 터미널을 떼도 사는 detached 세션 | TUI `Run in background`로 종료 시 데몬 스레드 유지 | 있음 (대화 레벨 아님) |
+| 9 | 세션 저장/재개/fork | `codex resume`, `thread/resume`, `thread/fork` | 있음 |
+| 10 | 도구 호출 보존 후 프로세스 종료·재개 (PreToolUse defer) | 없음. 가장 가까운 `SuspendTurnAndShutdown`은 워커 핸드오프이고 살아 있는 자손이 있으면 거절 | 없음 |
+| 11 | Stop 훅으로 "멈추지 말고 한 턴 더" | goal 자동 연속이 기능적으로 대응 (다만 사용자/시스템만 제어) | 있음 (다른 축) |
+| 12 | 입력으로 깨는 블로킹 sleep | `clock.sleep` (기본 off, 최대 12시간) | 있음 (기본 꺼짐) |
+| 13 | 실행 중 에이전트에 메시지 붙이기 | `send_input`(V1), `send_message`/`followup_task`(V2) | 있음 |
+| 14 | 수명 내내 running인 teammate | V2 residency로 로드된 자식 유지 | 부분 |
+| 15 | detached supervisor와 in-process 백그라운드의 구분 | 데몬 스레드 vs 세션 스코프 프로세스로 구분됨 | 있음 |
+
+## 3. Codex 표면의 4범주 분류
+
+| 표면 | 범주 |
+|---|---|
+| `exec_command` 반환 후 프로세스 생존 | 백그라운드 병행 |
+| `spawn_agent` | 백그라운드 병행 |
+| TUI `Run in background` 종료 | 백그라운드 병행 (프로세스 레벨) |
+| `write_stdin` 빈 폴링 | 블로킹 대기 |
+| `wait_agent` V1/V2 | 블로킹 대기 |
+| `clock.sleep` | 블로킹 대기 |
+| `wait_for_environment` | 블로킹 대기 |
+| code-mode `wait` | 블로킹 대기 (셀 단위) |
+| 앱 MCP `wait_threads` | 블로킹 대기 |
+| `request_user_input` | 블로킹 대기 |
+| goal 자동 연속 | 턴 종료 후 재진입 |
+| heartbeat / automation | 턴 종료 후 재진입 (사용자가 배제) |
+| durable sleep 훅 (`SleepItem`) | 턴 종료 후 재진입 — **프로덕션 생산자 없음** |
+| `SuspendTurnAndShutdown` / `RecoverTurn` | 서스펜션 (워커 핸드오프 전용) |
+| `awaiter` 역할 | 백그라운드 병행이었으나 **제거됨** |
+
+빈 칸이 어디인지가 답이다. "대기하지만 턴을 붙잡지 않고, 완료가 스스로 깨우는" 칸이 비어 있다.
+
+## 4. goal 충돌 — 로드맵이 고정한 네 질문
+
+**Q1. 블로킹 대기가 턴을 붙잡는 동안 idle 훅이 도는가.**
+돌지 않는다. `core/src/tasks/mod.rs:843-856`이 active turn이 비워졌을 때만 `emit_thread_idle_lifecycle_if_idle`을 부른다. `wait_agent`나 `clock.sleep`이 턴을 잡고 있으면 턴은 활성이므로 goal은 개입하지 않는다.
+→ 블로킹 대기는 goal과 충돌하지 않는다. 대신 컨텍스트와 워커를 그 시간만큼 태운다.
+
+**Q2. 턴이 끝나면 continuation이 곧바로 새 턴을 켜는가.**
+켠다. `ext/goal/src/extension.rs:175-186`의 `on_thread_idle`이 idle 원인을 보지 않고 `continue_if_idle()`을 부른다. `ThreadIdleCause`는 `Completed | Interrupted | Failed`인데 셋 다 같은 처리다. `runtime.rs:399-458`이 deferral이 없고 상태가 Active면 `start_turn_if_idle`로 `turn_trigger = "goal"`인 새 턴을 연다.
+→ **이것이 정확히 사용자가 예상한 충돌이다.** goal이 활성인 동안 "조용히 기다리려고 턴을 끝내는" 것은 불가능하다. 턴을 끝내는 순간 goal이 새 턴을 연다. goal은 유휴를 없애려고 만든 기계이고, 대기는 유휴다.
+
+빠져나갈 구멍은 `thread_goal_continuation_deferrals` 하나뿐인데, 그마저 에이전트가 닿을 수 없다.
+감사에서 정정: 이 INSERT는 `replace_thread_goal_snapshot` 안에만 있고(`state/src/runtime/goals.rs:68-118`), 호출자는 fork 상속 한 곳뿐이다(`app-server/src/request_processors/thread_fork_goal.rs:5-26`). 에이전트의 `create_goal`은 `insert_thread_goal`을 쓰고 deferral을 넣지 않으며(`ext/goal/src/tool.rs:203-211`), API `replace_thread_goal`도 넣지 않는다(`goals.rs:156-211`). 지우는 곳은 턴 시작 하나뿐이다(`ext/goal/src/extension.rs:232-235`).
+즉 deferral은 fork된 스레드가 즉시 폭주하지 않게 하는 일회성 장치이고, **에이전트에게 이걸 세우는 도구는 없다.** `update_goal`은 원문 그대로 거절한다: "pause, resume, budget-limited, and usage-limited status changes are controlled by the user or system"(`ext/goal/src/tool.rs:244`).
+
+**Q3. 서스펜션이 세션을 내릴 때 goal runtime은 어떻게 되는가.**
+서스펜션은 `emit_thread_stop_lifecycle`을 낸다(`turn_suspension.rs:107-114`). goal의 `on_thread_stop`이 런타임을 unregister한다(`ext/goal/src/extension.rs:190-196`). 재개 시 `restore_after_resume`이 DB 상태가 Active면 다시 활성으로 표시한다(`runtime.rs:375-396`).
+→ goal은 서스펜션을 견디도록 설계돼 있다. 다만 서스펜션 자체가 살아 있는 자손이 있으면 거절되므로(`HasLiveDescendants`), 백그라운드 추적 용도로는 쓸 수 없다.
+
+**Q4. goal의 steering 주입이 블로킹 대기를 깨우는가.**
+깬다. goal은 예산 한도 상황에서 `inject_active_turn_steering`으로 활성 턴에 아이템을 넣는다(`ext/goal/src/extension.rs:488`). V2 `wait_agent`는 steered input에 조기 종료하고(`multi_agents_spec.rs:283`), `clock.sleep`도 "The sleep ends early when new input arrives for the active turn"이다(`sleep.rs:50`).
+→ 긴 블로킹 대기는 goal의 예산 steering에 의해 예고 없이 끊길 수 있다. 다만 이 주입은 예산 한도 상황에서만 일어난다(`ext/goal/src/extension.rs:478-488`). 일상적인 continuation이 대기를 끊지는 않는다.
+
+**종합.** goal이 활성인 동안 가능한 대기는 블로킹 대기뿐이고, 그것도 steering에 깨질 수 있다. 턴을 끝내고 조용히 기다리는 선택지는 goal이 구조적으로 막는다. TUI `Run in background`로 나가도 goal은 Paused가 되지 않으므로 데몬이 계속 새 턴을 연다.
+
+## 5. 설계 옵션
+
+### Weak — 지금 있는 것만으로 (코드 변경 0)
+
+goal의 자동 연속을 **대기 메커니즘으로 전용**한다. 부모는 자식을 띄우고 턴을 끝낸다. goal이 새 턴을 열어 주면 그 턴 첫머리에서 `wait_agent`를 짧게 호출하거나 메일박스 알림을 읽는다.
+- 장점: 지금 당장 된다. 이 세션이 실제로 그렇게 돌았다.
+- 단점: 폴링 한 번이 턴 하나다. 토큰이 든다. goal이 없으면 성립하지 않는다.
+
+대안으로 `wait_agent`에 긴 타임아웃(V2 최대 1시간)을 주고 한 턴 안에서 버티는 방법이 있다. 턴 하나로 끝나 토큰은 아끼지만, 그동안 컨텍스트와 워커가 묶이고 goal steering에 끊길 수 있다.
+
+### Medium — codexclaw 레이어에서 (Codex 본체 무변경)
+
+로컬 백그라운드 작업 레지스트리를 두고, goal continuation 프롬프트에 "완료된 백그라운드 작업" 목록을 실어 보낸다. cli-jaw의 `bgtask`와 openclaw의 task registry가 이미 그 형태다. 깨우는 것은 goal이고, 무엇 때문에 깼는지를 알려 주는 것은 codexclaw다.
+- 장점: 상류 변경 없이 "완료가 스스로 돌아온다"는 감각을 만든다. 알림 내용이 구조화된다.
+- 단점: 여전히 goal에 의존한다. goal 없는 대화에서는 안 된다. 그리고 codexclaw가 Codex의 알림 경로를 이중화하게 된다.
+
+### Strong — 상류 변경 (이미 이슈로 존재)
+
+이미 있는 훅을 켜는 것이 가장 짧은 길이다. `has_outstanding_durable_sleep`(`core/src/tasks/mod.rs:412-450`)은 스레드에 `SleepItem`이 붙어 있으면 `trigger_turn` 없는 메일조차 새 턴을 열게 한다. 생산자만 없다.
+
+필요한 것 세 가지.
+1. 모델이 부를 수 있는 durable sleep 마킹. "지금 도는 자식/프로세스가 끝날 때까지 잔다"를 선언하고 턴을 끝낸다.
+2. 자식 완료 알림을 `trigger_turn = true`로 승격하거나, durable sleep이 걸린 스레드에 한해 승격.
+3. goal 쪽에서 durable sleep이 걸린 스레드의 continuation을 억제.
+감사에서 정정: 이걸 "deferral 테이블에 한 줄 넣기"로 구현하면 안 된다. 턴이 끝나면 idle이 **먼저** goal continuation을 돌리고(`core/src/tasks/mod.rs:855-864`), deferral은 다음 턴 시작에 지워지므로(`extension.rs:232-235`) 기상 턴이 그걸 지운 뒤 continuation이 다시 돈다. 자는 동안 `continue_if_idle`이 `SleepItem`의 존재를 직접 보고 건너뛰어야 한다.
+
+상류 이슈 대응: #15723(깨우지 않는다는 버그 보고), #22003(완료 출력을 활성 세션에 주입), #42908(Desktop 재개), #17737(Monitor식 추적). 3번은 아직 이슈로 정리되어 있지 않다. goal과 durable sleep의 상호작용은 이 조사에서 새로 드러난 부분이다.
+
+## 7. 이 세션 자체가 만든 1차 증거
+
+이 조사는 조사 대상 위에서 돌았다. 그래서 관찰된 것이 있다.
+
+grok-4.6 서브에이전트 8개와 Aside 셸 세션 10여 개를 병렬로 띄웠다. 관찰:
+
+- `spawn_agent` 8회가 즉시 반환했고 부모 턴은 계속 진행했다. 백그라운드 병행은 실제로 된다.
+- `wait_agent`로 기다리는 동안 부모 턴은 살아 있었다. 45초 타임아웃을 여러 번 반복해야 했고, 그 시간만큼 아무 일도 못 했다.
+- 자식이 끝나면 `<subagent_notification>`이 **다음 모델 스텝의 입력으로** 들어왔다. 부모가 `wait_agent`를 부르지 않아도 도착했다. 다만 부모가 이미 턴 안에 있었기 때문이다.
+- 부모가 턴을 끝냈다면 그 알림은 조용히 쌓여 있었을 것이고, goal이 새 턴을 열어 줄 때까지 읽히지 않았을 것이다. 이 세션에 goal이 걸려 있었으므로 결과적으로는 읽혔다. 5절 Weak 옵션이 실제로 작동한 사례다.
+- Aside 셸 세션은 `exec_command`가 `session_id`를 돌려준 뒤 턴을 넘어 살아남았고, 나중에 `write_stdin` 빈 폴링으로 회수했다. 1차 파견분(A1~A4)은 폴링 시 출력 상한에 잘려 유실됐다. 세션이 이미 끝나 있었기 때문이다. 2차 파견분은 출력을 파일로 받아 유실이 없었다.
+
+마지막 항목이 4번 격차(모델용 목록 도구 없음)의 실제 비용을 보여 준다. 백그라운드 프로세스의 출력을 놓치면 모델에게는 그걸 되찾을 경로가 없다.
+
+## 8. 무엇을 고를 것인가
+
+지금 당장 쓸 것은 Weak이다. 이미 그렇게 돌고 있고 추가 작업이 없다. 대신 폴링 한 번이 턴 하나라는 비용을 받아들여야 한다.
+
+Medium은 goal 없이 돌아가는 대화에서도 백그라운드 완료를 잃지 않으려 할 때 의미가 있다. codexclaw가 로컬 레지스트리를 들고 continuation 프롬프트를 채우는 방식이다. 다만 goal 의존은 남는다.
+
+Strong은 상류에 올릴 값어치가 있다. 특히 3번(자는 스레드의 continuation 억제)은 아직 아무도 이슈로 정리하지 않았고, 1번과 2번만 고치면 goal이 자는 스레드를 계속 깨워서 효과가 없다. 이 상호작용이 이번 조사에서 새로 드러난 부분이다.
+
+## 9. 남은 불확실성
+
+- Desktop(이 앱)이 TUI처럼 Stop 시 goal을 Paused로 바꾸는지는 확인하지 못했다. 서버만 보면 interrupt는 goal 상태를 바꾸지 않는다.
+- V2에서 부모 재시작 후 자손이 자동 회수되는지는 테스트가 V1에만 있다.
+- `150_claude_code` 스냅샷은 2026-03경이라 현재 배포본과 다르다. 현재 동작 판정은 공식 문서를 우선했다.
+- 이 조사는 로컬 체크아웃 기준이다. 실제 실행 중인 Codex 바이너리 버전과의 차이는 검증하지 않았다.
+

--- a/devlog/_plan/260909_bg_wake_component/000_plan.md
+++ b/devlog/_plan/260909_bg_wake_component/000_plan.md
@@ -1,0 +1,125 @@
+# 260909 — bg-wake 컴포넌트 설계 (wp1)
+
+상태: wp1 설계. 구현 없음. 감사 2회 반영본(1R fail → 2R near-pass, 잔여 10건 전부 fold).
+근거 리서치: `devlog/_plan/260909_background_run_suspension_research`.
+
+## 무엇을 만드는가
+
+리서치의 Medium 옵션. Codex는 백그라운드 작업이 끝나도 부모의 새 턴을 열지 않는다(V1 `inject_fragment_without_turn`, V2 `trigger_turn = false`). codexclaw가 로컬 레지스트리를 들고 그 구멍을 메운다.
+
+**Codex의 Stop 훅은 `{decision:"block", reason}`으로 턴을 잇는다.** camelCase이고 `reason`이 비면 block이 아니라 Failed다(`hooks/src/schema.rs:453-463`, `engine/output_parser.rs:290-347`). 런타임이 그 reason을 continuation prompt로 넣는다(`core/src/session/turn.rs:571-587`). pabcd-state가 이미 그 형태를 쓴다(`components/pabcd-state/src/hook.ts:1510-1515`).
+
+부수 효과: 리서치 격차 4번 — Codex에는 모델이 볼 수 있는 백그라운드 목록 도구가 없다. `/ps`는 사람만 본다. `cxc bg list`가 그 자리를 메운다.
+
+## 제1원칙: 끄기 쉬울 것
+
+**환경변수는 실행 중 세션에 닿지 않는다.** 훅 런타임은 세션 시작 시 `std::env::vars_os()` 스냅샷을 뜨고(`hooks/src/registry.rs:71`) 실행할 때 `env_clear()` 후 재생한다(`engine/command_runner.rs:425-427`).
+
+반면 훅의 cwd는 payload cwd로 설정된다(`engine/command_runner.rs:216-218`). 그래서 **파일 플래그가 즉시 먹는 유일한 수단**이다.
+
+| 단계 | 방법 | 적용 | 범위 |
+|---|---|---|---|
+| 1 | `cxc bg off` → `.codexclaw/bg/disabled` | 다음 훅 실행부터 즉시 | 그 cwd만 |
+| 1b | `CXC_BGWAKE=0` export | 새로 시작하는 세션부터 | 전역 |
+| 2 | 매니페스트에서 bg-wake 훅 3줄 + 훅 파일 3개 제거 | 재설치 후 | 전역 |
+| 3 | 컴포넌트 제거 (체크리스트) | 재설치 후 | 전역 |
+
+플래그는 워크트리마다 따로 꺼야 한다. 홈 전역 즉시 스위치는 없다. 이 한계를 문서에 적는다.
+
+**꺼 둔 동안 쌓인 완료 처리.** off 중에도 `cxc bg run`은 계속 받고 `deliveredAt`은 비어 쌓인다. 다시 켜는 순간 전부 깨우면 폭주하므로, 웨이크는 **한 번에 최대 5건, 그리고 플래그 해제 시각 이후 완료된 것만** 전달한다. 나머지는 `cxc bg list`에 남는다.
+
+### 제거 체크리스트
+
+감사가 실제로 센 접점이다. "디렉터리만 지우면 끝"은 거짓이므로 그렇게 적지 않는다.
+
+1. `plugins/codexclaw/components/bg-wake/` 디렉터리
+2. `plugins/codexclaw/hooks/`의 bg-wake 훅 파일 3개
+3. `plugins/codexclaw/.codex-plugin/plugin.json` `hooks[]` 3줄
+4. `plugins/codexclaw/scripts/build.mjs` `COMPONENTS` 1줄
+5. `package.json` test glob 1줄
+6. `plugins/codexclaw/bin/cxc.mjs` `COMMAND_TABLE`의 `bg` 1줄 + HELP 문자열(`:67`), `bin/codexclaw.mjs` case + HELP(`:249`), `plugins/codexclaw/test/payload-bin.test.mjs` 기대값
+7. `package-lock.json`의 `@codexclaw/bg-wake` 워크스페이스 항목 — `npm install`로 재생성
+8. `node plugins/codexclaw/scripts/inventory.mjs --write` 재실행. 훅 뱃지는 `README.md`, `README.ko.md`, `README.zh.md` **세 파일**에 있고 inventory가 셋을 함께 비교한다(`scripts/inventory.mjs:203-205,248-255,360-370`). 손으로 고치지 말고 반드시 `--write`로 돌린다.
+
+`packaging.test.mjs`의 ENTRYPOINTS와 `build.test.mjs`의 COMPONENTS는 **부분 목록이다.** skill-search가 둘 다에 없는 선례가 있으므로 bg-wake도 넣지 않는다. 접점이 그만큼 줄어든다.
+
+`cxc bg removal`이 이 체크리스트를 그대로 출력한다. wp3에서 8항목을 실제로 적용해 `build`/`test`/`gate`가 통과함을 실행으로 증명한다.
+
+### 제거를 쉽게 만드는 제약
+
+- `node:*`와 자기 파일만 import. cross-component dist import 금지.
+- 다른 컴포넌트 **소스**는 한 줄도 수정하지 않는다. 컴포넌트 밖 배선은 불가피하며 체크리스트로 관리한다.
+- `build.mjs`의 `COMPONENTS`를 `existsSync`로 필터해, 디렉터리만 먼저 지웠을 때 빌드가 깨지는 대신 조용히 빠지게 한다.
+
+## 데이터 모델
+
+`<cwd>/.codexclaw/bg/` 아래. `<taskId>.json`, `<taskId>.out`, `ledger.jsonl`, off 플래그 `disabled`.
+
+| 필드 | 뜻 |
+|---|---|
+| `id` | 짧은 slug |
+| `sessionId` | 등록 세션. 웨이크 대상 판정 |
+| `adoptedBy` | 재시작 후 이 레코드를 인수한 세션 |
+| `cwd`, `command`, `note` | |
+| `pid`, `startToken` | 감시 프로세스. `startToken`은 PID 재사용 오판 방지용 시작 시각 지문 |
+| `status` | `running` / `complete` / `failed` / `cancelled` |
+| `exitCode`, `startedAt`, `endedAt` | |
+| `deliveredAt` | 전달 시각. null이면 미전달 |
+
+`deliveredAt`이 중심이다. "완료됐지만 안 알렸다"가 웨이크 조건이고, 한 번 찍으면 다시 깨우지 않는 멱등 키다.
+
+## CLI 표면
+
+`cxc bg run [--note "..."] -- <command...>` / `list [--json]` / `get <id> [--tail N]` / `cancel <id>` / `off` / `on` / `status` / `removal` / `drain --session <id> [--json]`.
+
+`drain`은 `--session`을 필수로 받는다. 세션 필터 없는 drain은 다른 세션의 웨이크를 훔친다.
+
+## 훅 배치 — 세 개
+
+**Stop** — 미전달 완료가 있으면 `{decision:"block", reason}`으로 한 번 잇고 `deliveredAt`을 찍는다. 없으면 빈 stdout + exit 0.
+
+**UserPromptSubmit** — 봉투는 `{ hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext } }`로 고정한다(`pabcd-state/src/hook.ts:560-562`의 `buildContextOutput`과 동형). 여기서 `decision:"block"`을 내면 프롬프트 자체가 막힌다(`hooks/src/events/user_prompt_submit.rs:172-218`).
+
+**SessionStart** — 감사 4·5가 지적한 재시작·압축 구멍을 메운다. PostCompact는 additionalContext를 못 실어서 recall도 빈 stdout으로 돌리고, 실제 복구 경로는 source `"compact"`인 SessionStart다(`components/recall/src/hook.ts:495-499,533-549`, `core/src/session/mod.rs:3865`).
+여기서 두 가지를 한다.
+- **인수(adoption).** 같은 cwd에 미전달 완료가 있는데 등록 세션이 지금 세션이 아니면 `adoptedBy`를 현 세션으로 찍는다. 그러면 이후 Stop/프롬프트가 전달할 수 있다. 이게 없으면 스레드가 끝난 뒤 미전달분은 영영 못 깨운다.
+- **어포던스 한 줄.** `cxc bg list`가 있다는 것을 모델에게 알린다. 이게 없으면 "완료 통지"만 메우고 "목록 도구" 격차는 그대로다.
+
+## 안전 장치
+
+**무한 block 금지.** block 직전에 `deliveredAt`을 찍는다. 다음 Stop에서 같은 레코드는 미전달이 아니므로 놓아준다.
+
+`stop_hook_active`를 릴리스 가드로 쓰지 않는다. pabcd-state는 그 가드를 지웠고(`hook.ts:14`), 따라가면 HOTL 연속 Stop 동안 완료가 묻힌다. 멱등 키만으로 유한성을 보장한다.
+
+**pabcd-state와의 공존은 문제없다.** 같은 Stop에 훅이 여럿이면 Codex는 전부 돌리고, 둘 다 block이면 reason을 이어 붙이고 continuation fragment도 모두 넣는다(`hooks/src/events/stop.rs:413-437`). 어느 한쪽이 이기지 않는다.
+비용은 있다. bg-wake의 block도 Stop 이벤트를 하나 더 만들고 pabcd-state는 Stop마다 `MAX_STOP_BLOCKS` 정체 예산을 올린다(`hook.ts:1363-1369`). 완료가 있을 때만, 완료당 한 번만 block하므로 소모는 제한적이다. wp3에서 실측한다.
+
+**fail-open은 빈 stdout + exit 0.** 잘못된 JSON은 Failed이고 `exit 2` + stderr는 **block으로 취급된다**(`hooks/src/events/stop.rs:343-352`). 오류 경로는 반드시 아무것도 출력하지 않고 0으로 끝낸다.
+
+**세션 격리.** 레지스트리는 cwd 단위라 같은 디렉터리의 다른 세션이 파일을 공유한다. 웨이크는 `sessionId` 또는 `adoptedBy`가 현 세션일 때만, 목록은 전부 보여 준다.
+
+**서브에이전트 한계.** 루트 Stop만 이 훅을 돌리고 스폰된 자식은 SubagentStop이다(`core/src/hook_runtime.rs:383-387`). 자식이 `CODEX_THREAD_ID`로 등록하면 부모 Stop과 id가 어긋난다. SessionStart 인수가 일부 구제하지만, **`cxc bg run`은 메인 세션에서 쓰는 것을 전제로 문서화한다.**
+
+**reset 접점.** `.codexclaw/bg/`는 `cxc reset --state`로 지워지지 않고 `reset all`에서만 사라진다(`components/cxc-ops/src/reset.ts:5-11`). reset.ts를 수정하지 않는다. 대신 `cxc bg`에 자체 정리 명령을 두고 이 동작을 문서에 적는다.
+
+**허용 손실.** `deliveredAt`을 찍은 뒤 JSON 실패, 빈 reason, 또는 continuation 없는 block으로 Codex가 무시하면(`core/src/session/turn.rs:588-593`) 그 완료는 유실된다. 무한 block을 막는 대가다. 검증 계획에 명시적으로 넣는다.
+압축 직후에도 `deliveredAt`이 이미 찍힌 완료 본문은 재주입되지 않는다. 미전달분만 SessionStart가 살린다.
+
+## 하지 않는 것
+
+- 상류 자동 감지. 사용자가 명시적으로 배제했다.
+- Codex의 `unified_exec` 세션이나 서브에이전트 스레드를 직접 들여다보기. 내부 상태에 붙으면 상류가 바뀔 때 같이 깨진다. bg-wake는 자기가 띄운 프로세스만 안다.
+- 데몬. 감시자는 태스크당 detached 프로세스 하나이고 판정은 읽는 쪽에서 한다.
+
+## 검증 계획
+
+- 파일 플래그 off일 때 세 훅 모두 빈 stdout + exit 0
+- 미전달 완료가 있을 때만 Stop이 block하고 두 번째 Stop은 놓아줌
+- UserPromptSubmit이 정확한 `hookSpecificOutput` 봉투를 내고 block을 내지 않음
+- SessionStart 인수가 다른 세션의 미전달분을 현 세션으로 넘김
+- 오류 주입 시 빈 stdout + exit 0 (block으로 오인되지 않음)
+- 재활성화 시 5건 상한과 해제 시각 필터가 동작
+- `deliveredAt` 이후 유실이 허용 손실임을 테스트로 문서화
+- `npm run build`, `npm test`, `npm run gate` 통과
+- 제거 체크리스트 8항목을 실제로 적용한 뒤 같은 명령이 통과함을 실행으로 증명
+

--- a/devlog/_plan/260909_bg_wake_component/010_contract.md
+++ b/devlog/_plan/260909_bg_wake_component/010_contract.md
@@ -1,0 +1,134 @@
+# 010 — bg-wake 계약 (wp1 빌드 산출물)
+
+wp2가 이 문서를 그대로 구현한다. 설계 근거는 `000_plan.md`.
+
+## 훅 입출력 계약
+
+### Stop
+
+입력(payload, snake_case): `session_id`, `cwd`, `stop_hook_active`.
+
+출력은 둘 중 하나뿐이다.
+
+빈 stdout + exit 0 — 놓아준다. 다음 경우 전부 여기로 간다.
+- `<cwd>/.codexclaw/bg/disabled` 존재
+- `CXC_BGWAKE`가 `0` / `off` / `false`
+- 미전달 완료 없음
+- 어떤 오류든 (레지스트리 파손, 파싱 실패, 권한 오류)
+
+block — 미전달 완료가 있을 때만.
+
+```json
+{"decision":"block","reason":"<non-empty>"}
+```
+
+`reason`이 비면 Codex는 block이 아니라 Failed로 본다. 그래서 reason은 항상 최소 한 줄을 갖는다. `exit 2`는 절대 쓰지 않는다. stderr에 뭔가 있으면 그것이 block reason이 되어 버린다.
+
+reason 형태.
+
+```
+[codexclaw bg] 백그라운드 작업 2건이 끝났습니다.
+- build1 (complete, exit 0, 4m12s) — npm run build
+- probe2 (failed, exit 1, 31s) — node scripts/probe.mjs
+출력은 `cxc bg get <id> --tail 40`으로 봅니다. 전체 목록은 `cxc bg list`.
+결과를 확인하고 필요한 후속 작업을 이어가세요.
+```
+
+### UserPromptSubmit
+
+봉투를 고정한다. 다른 형태는 파싱되지 않거나 평문으로 취급된다.
+
+```json
+{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"<text>"}}
+```
+
+`decision` 필드를 넣지 않는다. 여기서 block은 프롬프트를 막는다.
+
+### SessionStart
+
+같은 봉투에 `hookEventName: "SessionStart"`. 두 가지를 싣는다.
+
+1. 인수한 미전달 완료 요약 (있을 때만)
+2. 어포던스 한 줄 — 이 세션에 백그라운드 태스크가 하나라도 있을 때만 낸다. 없으면 조용히 빈 stdout.
+
+인수 규칙: 같은 cwd에 `deliveredAt`이 null이고 `status`가 `running`이 아닌 레코드 중, `sessionId`와 `adoptedBy`가 모두 현 세션이 아닌 것에 `adoptedBy`를 현 세션으로 찍는다. 인수는 전달이 아니다. 전달은 이후 Stop이나 UserPromptSubmit이 한다.
+
+## 웨이크 대상 판정
+
+한 레코드가 지금 깨울 대상인지는 다섯 조건을 전부 만족할 때다.
+
+1. `status`가 `complete` / `failed` / `cancelled` 중 하나
+2. `deliveredAt`이 null
+3. `sessionId` 또는 `adoptedBy`가 현재 세션
+4. `endedAt`이 마지막 off 해제 시각보다 나중 (off 기간에 쌓인 것을 한꺼번에 쏟지 않기 위해)
+5. 한 번에 최대 5건. 초과분은 다음 기회로 미룬다
+
+## 상태 판정 (데몬 없음)
+
+읽는 쪽이 판정한다.
+
+- `status`가 `running`인데 `pid`(POSIX는 셸, Windows는 헬퍼)가 죽었으면 → `failed`, `exitCode`는 null, `endedAt`은 지금
+- `pid`가 살아 있어도 그 프로세스의 시작 시각이 `startToken`과 다르면 PID 재사용이므로 죽은 것으로 본다
+- 판정 결과는 레코드에 되쓴다. 매번 다시 계산하지 않는다
+
+## CLI 계약
+
+| 명령 | 출력 | 종료 코드 |
+|---|---|---|
+| `cxc bg run --note "..." -- <cmd...>` | id 한 줄 (`--json`이면 레코드) | 스폰 성공 0 |
+| `cxc bg list [--json]` | 표 또는 JSON 배열 | 0 |
+| `cxc bg get <id> [--tail N]` | 레코드 + 출력 꼬리 | 없는 id면 1 |
+| `cxc bg cancel <id>` | 결과 한 줄. 이미 끝난 작업은 상태를 덮어쓰지 않는다 | 없는 id도 0 |
+| `cxc bg off` / `on` / `status` | 현재 상태 한 줄 | 0 |
+| `cxc bg removal` | 체크리스트 8항목 | 0 |
+| `cxc bg drain --session <id> [--json]` | 전달 대상 + `deliveredAt` 기록. **off 스위치를 타지 않는다** — 스위치는 자동 웨이크를 끄는 것이고, 명시적으로 달라고 하면 준다 | 0 |
+
+`--session` 없는 `drain`은 사용법을 출력하고 아무것도 찍지 않는다.
+
+## 파일 레이아웃
+
+```
+<cwd>/.codexclaw/bg/
+  disabled          # 존재하면 웨이크 off. 내용은 해제 판정용 타임스탬프
+  <id>.json         # 레코드
+  <id>.out          # 합쳐진 stdout/stderr
+  <id>.exit         # 종료 코드. 감시 데몬 대신 셸이 스스로 쓴다
+  <id>.out.helper.cjs # Windows 전용 2-hop 헬퍼. 자기가 출력 파일을 열고 종료 코드를 쓴다
+  enabled-at        # 마지막 'bg on' 시각. 웨이크 조건 4의 기준
+  ledger.jsonl      # registered / completed / delivered / adopted / disabled / enabled
+```
+
+레코드 쓰기는 원자적이다. 임시 파일에 쓰고 rename한다. `ledger.jsonl`은 append-only 저널이라 append로 쓴다. 기존 컴포넌트의 `atomic-write.ts`와 같은 방식이되, cross-component import 금지 제약 때문에 자체 구현을 둔다.
+
+## 구현 제약 재확인
+
+- import는 `node:*`와 `./*.ts`만
+- 다른 컴포넌트 소스 수정 없음
+- 오류는 전부 삼키고 빈 stdout + exit 0
+- 테스트는 `node --test`, 파일시스템은 `mkdtemp` 임시 디렉터리
+
+
+
+## 감사 1회차(fail) 반영
+
+- `cxc bg on`은 이미 ON이면 `enabled-at`을 다시 쓰지 않는다. 다시 쓰면 대기 중이던 완료가 게이트에 걸려 삼켜진다.
+- `drain`은 `wakeSuppressed`를 타지 않는다. 자동 웨이크와 수동 회수는 다른 것이다.
+- `cancel`은 먼저 `reconcile`하고, `running`이 아니면 아무것도 하지 않는다. 죽일 때는 `startToken`으로 우리 프로세스인지 확인한다.
+- Windows는 한 줄 `cmd /c`가 아니라 배치 파일을 썼다. 260910 실측 후 이 경로 자체가 Node 헬퍼로 교체되었으므로 이 항목은 이력이다. 아래 "Windows 경로" 절이 현행이다.
+- 훅의 `stdout.write`도 try 안에 넣는다. EPIPE로 죽으면 stderr 스택 + 비0 종료가 되고, Codex는 그걸 Stop block으로 읽는다.
+- `markDelivered`는 레코드마다 독립적으로 찍는다. 하나가 실패해도 나머지는 전달되고, 실패한 것은 미전달로 남아 다음에 다시 깨운다.
+- SessionStart 어포던스는 이 세션이 소유한 작업이 있을 때만 낸다.
+
+
+## Windows 경로 (260910 실측 반영)
+
+POSIX는 셸이 자기 종료 코드를 쓴다. Windows는 그럴 수 없다. libuv가 detached로 띄운 첫 홉은 외부 자식에게 쓸 수 있는 stdout을 주지 못해, cmd 배치의 리다이렉트가 아무것도 잡지 못했다(030 v3).
+
+그래서 Windows는 Node 헬퍼를 두 번째 홉으로 쓴다. 헬퍼가 `<id>.out`을 직접 열고, 그 핸들로 사용자 명령을 argv로 spawn하고, 종료 코드를 tmp+rename으로 쓴다. cmd를 거치지 않으므로 인용 규칙도 사라진다.
+
+측정된 계약 차이:
+
+- 없는 실행 파일은 `exitCode 127`이다.
+- **cmd 내장 명령은 실행되지 않는다.** `echo`, `dir`, `exit` 같은 것은 `cmd /c ...`로 감싸야 한다. 감싸면 출력과 종료 코드 모두 정상이다.
+- 기록되는 `pid`는 셸이 아니라 헬퍼의 것이다. `cancel`과 `startToken`이 그 pid를 가리킨다.
+- 헬퍼가 종료 코드를 쓰기 전에 죽으면 exit 파일이 없고, 레코드는 나이 기반 백스톱으로 `failed` + `exitCode: null`이 된다.

--- a/devlog/_plan/260909_bg_wake_component/020_wiring_and_removal.md
+++ b/devlog/_plan/260909_bg_wake_component/020_wiring_and_removal.md
@@ -1,0 +1,54 @@
+# 020 — 배선과 제거 증명 (wp3)
+
+## 배선한 것
+
+| 접점 | 변경 |
+|---|---|
+| `plugins/codexclaw/hooks/` | 훅 파일 3개 신설 (stop / user-prompt-submit / session-start) |
+| `.codex-plugin/plugin.json` | `hooks[]` 24 → 27, append만. 기존 항목 순서 불변 |
+| `scripts/build.mjs` | `REQUIRED_COMPONENTS` + `OPTIONAL_COMPONENTS` 분리. 선택 컴포넌트만 `existsSync`로 거른다 |
+| `package.json` | test glob 1줄 |
+| `plugins/codexclaw/bin/cxc.mjs` | `COMMAND_TABLE`의 `bg`, HELP 줄, slice(3) 분기 |
+| `bin/codexclaw.mjs` | `case "bg"`, `runBgWake()`, HELP 줄 |
+| `inventory.json` + README 3종 | `inventory.mjs --write`로 뱃지 24 → 27 |
+
+기존 컴포넌트 `src/`는 한 줄도 건드리지 않았다. 리뷰어가 `git diff --cached --name-only`로 독립 확인했다.
+
+개수를 하드코딩하던 테스트 두 개는 **개수 무관으로 바꿨다.** `test/hook-e2e.test.mjs`의 `length === 24`를 `length > 0`으로, `test/inventory.test.mjs`의 뱃지 숫자를 README에서 파생하도록. 그래서 이 둘은 제거 접점이 아니다. 선택 컴포넌트가 붙었다 떨어질 때마다 테스트를 고치게 두면 "쉽게 끈다"가 거짓말이 된다.
+
+## 제거 증명
+
+체크리스트 8단계를 실제로 적용했다. 디렉터리 삭제, 훅 파일 3개 삭제, 매니페스트 3줄 제거, `OPTIONAL_COMPONENTS` 비우기, test glob 제거, 디스패처 양쪽 정리, `inventory.mjs --write` 재실행.
+
+결과:
+
+```
+[codexclaw inventory] wrote inventory.json (28 skills, 24 hooks, 8 components)
+[codexclaw] build OK — 167 files compiled, layout validated.
+[codexclaw gate] OK — no status drift, false-enforcement prose, count mismatch, or inventory drift.
+npm test EXIT=0
+```
+
+그 뒤 `git checkout -- .`로 복원하고 다시 확인했다.
+
+```
+[codexclaw inventory] wrote inventory.json (28 skills, 27 hooks, 9 components)
+[codexclaw gate] OK
+npm test EXIT=0
+```
+
+즉 체크리스트는 완전하다. 빠뜨린 접점이 있었다면 제거 후 build나 gate나 test 중 하나가 깨졌을 것이다.
+
+## 감사에서 잡힌 것
+
+1라운드 fail이 실제로 중요한 걸 잡았다. `bin/codexclaw.mjs`의 `runBgWake` 경로에 `..`가 하나 부족해서 `components/provider-bridge/bg-wake/dist/cli.js`를 가리키고 있었다. 루트 `cxc bg`가 전부 spawn 실패했고, **그건 곧 끄는 스위치가 안 된다는 뜻이었다.** 사용자 요구의 핵심이 조용히 깨져 있었던 셈이다.
+같이 잡힌 것: payload 디스패처가 `["bg","off"]`를 넘겨 verb 파싱이 한 칸 밀렸고, `existsSync` 필터가 필수 컴포넌트 누락까지 조용히 삼켰다.
+
+지금은 루트와 payload 양쪽에서 `cxc bg status / off / on`이 실제로 동작하는 것을 실행으로 확인했다.
+
+## 남은 것
+
+`package-lock.json`에 `@codexclaw/bg-wake` 항목이 없다. 형제 컴포넌트들과 다르지만 워크스페이스 glob이 `components/*`라 런타임에는 영향이 없고, 훅과 CLI는 `dist/cli.js` 경로로 직접 간다. 체크리스트 7단계가 이미 조건부로 적어 두었다.
+
+Windows 실행 경로는 이 머신에서 검증하지 못했다. 컴포넌트 README의 "알려진 한계"에 적어 두었다.
+

--- a/devlog/_plan/260909_bg_wake_component/030_windows_validation.md
+++ b/devlog/_plan/260909_bg_wake_component/030_windows_validation.md
@@ -1,0 +1,203 @@
+# 030 — Windows 실측 (wp1)
+
+이전 D의 결론을 인용한다. "Windows 실행 경로는 이 머신에서 검증하지 못했다. 사용자 명령에 bare exit가 있으면 배치가 조기 종료되어 종료 코드가 기록되지 않고, 프로세스 그룹이 없어 cancel이 손자 프로세스를 남긴다." 이 추정을 측정으로 대체한다.
+
+호스트: `ssh desktop-c795oh4` — Microsoft Windows 10.0.26200.9445, MINGW64 기본 셸, node v24.19.0.
+전송: `src/`, `test/`, `package.json`을 `~/bgwake-verify`로 tar 파이프. 임시 디렉터리 밖은 건드리지 않았다.
+
+## 1. 기존 테스트는 Windows 경로를 한 번도 돌리지 않는다
+
+```
+ℹ tests 37 / pass 29 / fail 0 / skipped 8
+﹣ a real command runs detached and records its own exit code  # posix shell path
+﹣ an argument with spaces and quotes survives the shell        # posix shell path
+﹣ cancel does not overwrite an already finished job            # posix shell path
+﹣ on is idempotent and does not move the gate forward          # posix shell path
+﹣ off then on gates only what finished while off               # posix shell path
+﹣ drain works even while the wake is switched off              # posix shell path
+﹣ a half-written exit file keeps the job running               # posix shell path
+﹣ run -- exit N still records the code                         # posix shell path
+```
+
+실행을 건드리는 테스트가 전부 `t.skip("posix shell path")`였다. 순수 로직 29개는 Windows에서도 통과하지만, **배치 경로는 검증된 적이 없었다.** 그래서 별도 프로브를 썼다.
+
+## 2. 네 항목 실측
+
+### 종료 코드 기록 — 통과
+
+```
+[A1 zero]    {"status":"complete","exitCode":0,"want":0}
+[A2 nonzero] {"status":"failed","exitCode":3,"want":3}
+```
+
+`(call echo %%ERRORLEVEL%%) > tmp` + `move /y`가 실제로 동작한다. 감사에서 "한 줄 파싱 시점에 펼쳐져 이전 값을 쓴다"고 지적받아 `call`로 고쳤던 부분이 맞았다.
+
+### bare exit — 한계 확정
+
+```
+[C bare exit] {"status":"failed","exitCode":null}
+```
+
+예상대로다. 배치 안의 `exit`는 배치를 끝내므로 ERRORLEVEL 줄에 도달하지 못한다. 코드 미상의 `failed`로 조정된다. POSIX는 서브셸로 막았지만 cmd에는 같은 수단이 없다.
+
+### cancel — 이 회차 기록 (이 경로의 손자 생존은 끝내 미측정)
+
+```
+[D cancel] {"pid":9872,"aliveBefore":true,"statusAfter":"cancelled","shellAliveAfter":false}
+```
+
+셸 프로세스는 확실히 죽는다. 손자(실제 명령) 생존은 이 회차에서 `tasklist` 필터가 한국어 로케일에서 깨져 못 쟀고, 3절에서 마커 파일로 다시 쟀다. 단 3절 측정은 **헬퍼 경로**의 것이라 이 배치 경로의 손자 생존은 여전히 미측정이다.
+
+### 인자 인용과 출력 캡처 — 이 회차 기록 (3절이 대체)
+
+```
+[B quoting] {"sent":["a b","x&y","50%","q\"uote","excl!am"],"got":"","exitCode":0}
+```
+
+출력이 비었다. 인용 문제인 줄 알았는데 아니었다. 가장 단순한 `node -e "console.log('hello')"`도 `out: ""`였다.
+
+## 3. 원인 좁히기 (감사 1회차 fail 반영)
+
+1회차 초안은 "detached가 아니라 cmd.exe가 문제"라고 단정했다. 감사가 정확히 반박했다. 같은 회차의 d2(detached + 중첩 `cmd /c`가 리다이렉트 소유)가 **캡처에 성공**했으므로 그 기제와 모순된다. 변수가 분리되지 않은 채였다.
+
+그래서 **부모가 즉시 종료하는 조건으로 통일**해 다섯 변형을 다시 쟀다. 이전 회차의 d1은 부모가 살아 있어 제품 조건이 아니었다.
+
+```
+v1  detached + fd,     대상을 직접 spawn             rc=0  out=[immediate/late/]
+v2  detached + ignore, 대상을 직접 spawn             rc=0  out=[]
+v3  detached + ignore, 1-hop cmd 배치의 리다이렉트     rc=0  out=[]        <- 현재 제품 경로
+v4  detached + ignore, 2-hop 중첩 cmd /c 가 리다이렉트  rc=1  out=[캡처됨]
+v5  detached + ignore, 2-hop Node 헬퍼 + fd           rc=0  out=[immediate/late/]
+```
+
+이제 말할 수 있는 것만 말한다.
+
+두 개의 **별개** 사실이다. 하나로 합치지 않는다.
+
+- **v1 vs v2 (cmd 없는 직접 spawn):** fd를 주면 남고 `ignore`면 사라진다. 자식이 파일을 직접 열지 않는 한 당연한 결과이고, POSIX에서도 같다. 이 비교가 말하는 것은 "직접 spawn 경로에서 캡처하려면 핸들을 줘야 한다"뿐이다. 3b의 `nodetach+ignore → captured`와 모순되지 않는다. 그쪽은 **cmd 배치의 리다이렉트가 캡처를 담당**하는 다른 경로다.
+- **v3 vs v4 (둘 다 ignore, cmd 경유):** 1-hop 배치의 리다이렉트만 비고, 2-hop 중첩 `cmd /c`는 캡처된다. 여기서 갈린 축은 핸들 유무가 아니라 **홉 수**다.
+
+그래서 제품 실패(v3)의 필요조건이 "1-hop 배치 리다이렉트"인지 "Node가 첫 홉에 핸들을 안 줌"인지는 **아직 갈리지 않았다.** 그걸 가르려면 1-hop cmd × fd를 부모 즉시 종료 조건에서 재현해야 하는데, 이번 회차에 하지 않았다. 강등된 d3가 부모 생존 조건에서 `detached+fd, cmd 경유 → out=[]`였을 뿐이다.
+
+수정 방향 자체는 이 미해결에 걸리지 않는다. v5가 제품 조건에서 동작을 보였기 때문이다. 다만 정직하게 적자면, 이 칸이 비어 있어서 **cmd 래퍼를 유지하는 대안이 가능한지 아닌지를 모른다.** 헬퍼로 가는 것은 측정에 의해 강제된 결론이 아니라, 동작이 확인된 경로를 고르는 선택이다.
+
+v4의 `rc=1`은 프로브 자신의 결함이다. 중첩 `cmd /c` 안에서 인용이 겹쳐 안쪽 `node -e` 스크립트가 깨졌고, node가 SyntaxError로 1을 반환했다. 그 에러 텍스트가 `.out`에 남았다는 사실이 곧 캡처 성공의 증거다.
+
+v1과 v5의 `out`은 부모가 죽은 뒤 **별도 ssh 호출**이 10초 뒤에 읽은 값이다. 부모 프로브가 읽은 것이 아니다.
+
+### 인용은 아직 측정되지 않았다
+
+1회차 표는 "인자 인용 / 출력 캡처 실패"를 한 칸에 묶었다. 틀렸다. 관측된 것은 **stdout 파일 유실뿐**이고, 출력이 애초에 비어 있었으므로 인용이 옳았는지는 알 수 없다. 인용 판정은 캡처가 고쳐진 뒤로 미룬다.
+
+### cancel 손자 생존 — 측정함
+
+1회차에서 `tasklist` 필터가 한국어 로케일에서 깨져 못 쟀다. 손자가 1초마다 마커 파일을 쓰게 하고 다시 쟀다.
+
+```
+{"helperPid":14996,"markerAtKill":"3","markerAfter1s":"3","markerAfter4s":"3","verdict":"grandchild stopped"}
+{"afterTaskkillT":"3","then3s":"3","verdict2":"stopped"}
+```
+
+헬퍼를 죽이자 손자도 멈췄다. 다만 이 호스트는 OpenSSH 세션이라 잡 오브젝트가 개입했을 수 있고, 같은 회차에서 비-detached 자식이 부모 종료와 함께 죽은 것도 같은 설명에 들어맞는다. **대화형 로컬 세션에서도 같은지는 측정하지 않았다.** 프로세스 그룹이 없다는 것은 이번 실측이 아니라 플랫폼 사실이다.
+
+## 3b. 1회차 원시 기록 (참고)
+
+
+배치 자체는 멀쩡하다. 같은 배치를 `spawnSync`(비-detached)로 돌리면 전부 잡힌다.
+
+```
+t1_paren_parens | spawnStatus=0 | rcFile=0 | out="hello1\n"
+t4_paren_version | spawnStatus=0 | rcFile=0 | out="v24.19.0\r\n"
+t7_echo_paren   | spawnStatus=0 | rcFile=0 | out="hi7\r\n"
+```
+
+조합을 갈랐다.
+
+```
+detached+ignore      | rc=0 | out=""
+detached+ignore+hide | rc=0 | out=""
+nodetach+ignore      | rc=0 | out="captured\n"
+detached+pipe        | rc=0 | out=""
+```
+
+그런데 `detached`를 빼면 이번엔 **부모가 죽을 때 자식도 죽는다.**
+
+```
+A (detached:false) → run.cmd 만 남음. rc 없음, out 없음
+B (detached:true)  → rc=0, out 없음
+```
+
+여기까지가 막다른 길처럼 보였다. 마지막으로 cmd를 빼고 대상을 직접 띄웠다.
+
+```
+d1 (detached + fd, node를 직접 spawn)        rc=[0] out=[immediate/late/]
+d2 (detached + 중첩 cmd /c 가 리다이렉트 소유)  출력 캡처됨
+d3 (detached + fd, cmd 경유)                 rc=[0] out=[]
+```
+
+(이 회차의 d1은 부모가 살아 있어 제품 조건이 아니었다. d2는 3절 v4와 같은 방향의 결과이고, 당시 초안의 인과 서술과 어긋났던 것이다. 부모 즉시 종료로 통일한 3절 v 시리즈가 이 기록을 대체한다.)
+
+## 4. 판정
+
+| 항목 | 판정 |
+|---|---|
+| 종료 코드 기록 | **현재 cmd 배치 경로 기준** 통과. wp2가 그 경로를 폐기하므로 헬퍼 경로에서 다시 확인해야 한다 |
+| bare exit | **현재 cmd 배치 경로의** 확정 한계. cmd에는 POSIX 서브셸 대응물이 없다. 헬퍼 경로에서는 이 한계가 사라지고 대신 cmd 내장 명령 미실행이라는 다른 한계가 들어선다 |
+| cancel (현재 배치 경로) | 셸 사망 확인. 이 경로의 손자 생존은 미측정 |
+| cancel (헬퍼 경로) | 헬퍼를 죽이면 손자도 멈춤을 3절에서 마커 파일로 측정. 단 SSH 잡 오브젝트 개입 가능성이 있어 대화형 세션은 미확인 |
+| 출력 캡처 | **실패. 수정 필요** (v3) |
+| 인자 인용 | 미측정. 캡처가 비어 있어 판정 불가 |
+| 1-hop cmd × fd | 미측정 (부모 즉시 종료 조건). 원인 축을 완전히 가르지 못한 지점 |
+
+## 5. wp2가 할 일
+
+Windows에서 첫 홉을 Node 헬퍼로 바꾼다. 헬퍼는 `stdio:"ignore"`로 detached 실행되고, **헬퍼 자신이** 출력 파일을 열어 그 핸들로 사용자 명령을 argv 직접 spawn한 뒤, 종료 코드를 원자적으로 쓴다. CLI 부모는 핸들을 열지 않는다. **v5가 부모 종료 후 조건에서 이 방식의 동작을 보였다.**
+
+헬퍼가 필요한 이유를 적는다. 캡처만이라면 v1처럼 1-hop + fd로도 된다. 그런데 v1에는 **종료 코드를 파일에 쓰는 주체가 없다.** v1의 `rc=0`은 프로브가 손으로 써 넣은 값이지 제품형 exit 파일이 아니다. 그러니 v1은 "캡처는 1-hop으로도 된다"만 말하고, 종료 코드 기록에 대해서는 아무 말도 하지 않는다.
+
+따라서 헬퍼는 **종료 코드를 대신 기록할 누군가**로서 필요하다. POSIX에서는 셸이 그 일을 했고, Windows에서는 cmd가 그 일을 하려다 출력을 잃었다. 2-hop cmd(v4)가 종료 코드까지 제대로 쓰는지는 이번 표에 없다. 이것도 측정이 아니라 선택임을 명시해 둔다.
+
+새로 생기는 위험을 미리 적는다. 확정된 설계가 아니라 wp2에서 검증할 대상이다.
+
+- 헬퍼가 종료 코드를 쓰기 전에 죽으면 exit 파일이 없다. 현재의 `failed` + `exitCode: null` 경로로 접히는데, 그건 한계가 아니라 헬퍼 수명 버그다.
+- 기록되는 pid가 헬퍼 pid가 된다. `cancel`과 `startToken`의 의미가 셸 pid에서 헬퍼 pid로 바뀐다.
+- POSIX는 `/bin/sh -c` + 프로세스 그룹, Windows는 헬퍼로 **이원화**된다. 계약 문서의 "셸이 스스로 쓴다"와 `<id>.out.cmd` 레이아웃을 함께 개정해야 한다.
+- argv 직접 spawn이므로 **cmd 내장 명령이 실행되지 않는다.** `echo`, `dir`, `exit` 같은 것은 사용자가 `cmd /c ...`로 감싸야 한다. bare `exit` 한계는 사라지지만 그 자리에 다른 한계가 들어선다.
+
+POSIX 경로는 측정으로 동작이 확인되어 있으므로 건드리지 않는다.
+
+
+## 6. 수정 후 재측정 (wp2)
+
+Windows 첫 홉을 cmd 배치에서 Node 헬퍼로 바꾼 뒤, 같은 호스트에서 다시 쟀다. 전부 제품 코드 경로(`runBackground` / `cancel`)를 그대로 호출한다.
+
+```
+platform=win32
+[exit0]                          {"status":"complete","exitCode":0,"want":0}
+[exit3]                          {"status":"failed","exitCode":3,"want":3}
+[capture]                        {"out":["captured stdout","captured stderr"]}
+[quoting]                        {"sent":["a b","x&y","50%","q\"uote","excl!am","semi;colon"],
+                                  "got": ["a b","x&y","50%","q\"uote","excl!am","semi;colon"],"match":true}
+[missing binary]                 {"status":"failed","exitCode":127}
+[cmd builtin (known limitation)] {"status":"failed","exitCode":1}
+[cmd /c wrapper]                 {"exitCode":0,"out":"wrapped builtin"}
+[cancel]                         {"aliveBefore":true,"status":"cancelled","helperAliveAfter":false}
+```
+
+### 판정 갱신
+
+| 항목 | wp1 판정 | wp2 판정 |
+|---|---|---|
+| 출력 캡처 | 실패 | **통과.** stdout과 stderr 모두 파일에 남는다 |
+| 인자 인용 | 미측정 | **통과.** 공백, `&`, `%`, 큰따옴표, `!`, `;` 가 전부 바이트 그대로 도착한다 |
+| 종료 코드 기록 | 현재 cmd 경로 기준 통과 | **헬퍼 경로에서 다시 통과.** 0과 3을 정확히 기록 |
+| bare exit | cmd 배치의 확정 한계 | **사라졌다.** cmd가 없으므로 배치 조기 종료라는 개념이 없다 |
+| cmd 내장 명령 | (해당 없음) | **새 한계.** `echo`를 직접 넘기면 `failed`로 끝난다(측정값 exit 1). `cmd /c echo ...`로 감싸면 정상 동작하고 출력도 잡힌다 |
+| 없는 실행 파일 | (미측정) | `failed` + `exitCode 127`. POSIX의 not-found 관례와 같다 |
+| cancel | 배치 경로 손자 미측정 | 헬퍼가 죽고 작업이 `cancelled`로 남는다. SSH 잡 오브젝트 caveat는 그대로 |
+
+### 남은 미측정
+
+- 대화형 로컬 Windows 세션(SSH 아님)에서의 생존과 cancel. 이 회차도 OpenSSH를 통했다.
+- 1-hop cmd × fd (부모 즉시 종료 조건). cmd 래퍼 유지 대안이 가능했는지는 끝내 모른다. 헬퍼 경로가 동작하므로 더 파지 않았다.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,6 +307,10 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@codexclaw/bg-wake": {
+      "resolved": "plugins/codexclaw/components/bg-wake",
+      "link": true
+    },
     "node_modules/@codexclaw/cli": {
       "resolved": "cli",
       "link": true
@@ -1946,6 +1950,10 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "plugins/codexclaw/components/bg-wake": {
+      "name": "@codexclaw/bg-wake",
+      "version": "0.2.24"
     },
     "plugins/codexclaw/components/config-guard": {
       "name": "@codexclaw/config-guard",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "node plugins/codexclaw/scripts/build.mjs",
     "gate": "node plugins/codexclaw/scripts/gate.mjs",
-    "test": "node plugins/codexclaw/scripts/test.mjs \"plugins/codexclaw/components/pabcd-state/test/*.test.ts\" \"plugins/codexclaw/components/config-guard/test/*.test.ts\" \"plugins/codexclaw/components/cxc-ops/test/*.test.ts\" \"plugins/codexclaw/components/recall/test/*.test.ts\" \"plugins/codexclaw/components/provider-bridge/test/*.test.ts\" \"plugins/codexclaw/components/subagent-config/test/*.test.ts\" \"plugins/codexclaw/components/messenger-bridge/test/*.test.ts\" \"plugins/codexclaw/components/skill-search/test/*.test.ts\" \"plugins/codexclaw/gui/test/*.test.ts\" \"plugins/codexclaw/test/*.test.mjs\" \".github/scripts/pr-labeler.test.cjs\" \".github/scripts/closed-pr-branch-cleanup.test.cjs\"",
+    "test": "node plugins/codexclaw/scripts/test.mjs \"plugins/codexclaw/components/pabcd-state/test/*.test.ts\" \"plugins/codexclaw/components/config-guard/test/*.test.ts\" \"plugins/codexclaw/components/cxc-ops/test/*.test.ts\" \"plugins/codexclaw/components/recall/test/*.test.ts\" \"plugins/codexclaw/components/provider-bridge/test/*.test.ts\" \"plugins/codexclaw/components/subagent-config/test/*.test.ts\" \"plugins/codexclaw/components/messenger-bridge/test/*.test.ts\" \"plugins/codexclaw/components/skill-search/test/*.test.ts\" \"plugins/codexclaw/components/bg-wake/test/*.test.ts\" \"plugins/codexclaw/gui/test/*.test.ts\" \"plugins/codexclaw/test/*.test.mjs\" \".github/scripts/pr-labeler.test.cjs\" \".github/scripts/closed-pr-branch-cleanup.test.cjs\"",
     "smoke": "node plugins/codexclaw/scripts/platform-smoke.mjs"
   },
   "overrides": {

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -44,7 +44,10 @@
     "./hooks/session-start-detecting-managed-worktree.json",
     "./hooks/user-prompt-submit-guiding-worktree-rename.json",
     "./hooks/pre-tool-use-guarding-managed-worktree-deletion.json",
-    "./hooks/pre-tool-use-guarding-memory-write.json"
+    "./hooks/pre-tool-use-guarding-memory-write.json",
+    "./hooks/stop-waking-on-background-completion.json",
+    "./hooks/user-prompt-submit-delivering-background-completions.json",
+    "./hooks/session-start-adopting-background-completions.json"
   ],
   "mcpServers": "./.mcp.json",
   "interface": {

--- a/plugins/codexclaw/bin/cxc.mjs
+++ b/plugins/codexclaw/bin/cxc.mjs
@@ -62,6 +62,7 @@ export const COMMAND_TABLE = Object.freeze({
   serve: "messenger-bridge",
   service: "messenger-bridge",
   provider: "provider-bridge",
+  bg: "bg-wake",
 });
 
 const HELP = [
@@ -91,6 +92,7 @@ const HELP = [
   "",
   "Operations:",
   "  subagents | provider | serve | service",
+  "  bg run|list|get|off            background tasks + completion wake (cxc bg removal to uninstall)",
   "",
   "Repo-checkout only (not in the payload dispatcher):",
   "  gui, map — use a git checkout of codexclaw (README: Development)",
@@ -169,7 +171,10 @@ if (isMain) {
     const entry = componentCli(component).replace(/cli\.js$/, "fallback-dispatch-cli.js");
     const result = spawnSync(process.execPath, [entry, ...process.argv.slice(4)], { stdio: "inherit" });
     process.exit(typeof result.status === "number" ? result.status : 1);
-  } else if (component === "skill-search") {
+  } else if (component === "skill-search" || component === "bg-wake") {
+    // These two take the verb as argv[0] of their own CLI, so the leading command word
+    // is dropped here rather than re-parsed downstream. Everything else still receives
+    // [cmd, ...rest] verbatim.
     process.exit(delegate(component, process.argv.slice(3)));
   } else if (component === "provider-bridge") {
     process.exit(delegate(component, ["detect"]));

--- a/plugins/codexclaw/components/bg-wake/README.md
+++ b/plugins/codexclaw/components/bg-wake/README.md
@@ -1,0 +1,56 @@
+# bg-wake
+
+백그라운드 작업 레지스트리와 **완료 웨이크**. Codex는 자식 프로세스나 서브에이전트가 끝나도 부모의 새 턴을 열지 않는다(V1 `inject_fragment_without_turn`, V2 `trigger_turn = false`). 이 컴포넌트가 그 구멍을 메운다.
+
+설계 근거: `devlog/_plan/260909_bg_wake_component/000_plan.md`, 계약: `010_contract.md`.
+왜 필요한지: `devlog/_plan/260909_background_run_suspension_research/030_synthesis.md`. 상류 이슈 openai/codex #15723, #22003, #42908.
+
+## 쓰는 법
+
+```
+cxc bg run --note "야간 빌드" -- npm run build     # 즉시 id 반환, 턴을 붙잡지 않음
+cxc bg list                                        # 모델이 볼 수 있는 백그라운드 목록
+cxc bg get <id> --tail 40                          # 출력 꼬리
+cxc bg cancel <id>
+```
+
+작업이 끝나면 다음 Stop 훅이 턴을 한 번 이어서 결과를 알린다. 턴이 이미 끝났으면 다음 프롬프트에 주입되고, 세션이 바뀌었으면 SessionStart가 인수해서 그다음에 전달한다. 같은 완료로 두 번 깨우지 않는다.
+
+## 끄는 법
+
+```
+cxc bg off      # 이 워크트리, 즉시. 재시작·재설치 불필요
+cxc bg on
+cxc bg status
+```
+
+전역으로 끄려면 `export CXC_BGWAKE=0`. 다만 **새로 시작하는 세션부터** 적용된다. 훅 런타임은 세션 시작 시점의 환경을 스냅샷해서 재생하기 때문에(`codex-rs/hooks/src/registry.rs:71`, `engine/command_runner.rs:425-427`), 이미 열린 세션에는 닿지 않는다. 그래서 즉시 끄는 수단은 파일 플래그다.
+
+끈 동안에도 `cxc bg run`은 계속 받고 기록도 남는다. 다시 켜면 그 사이에 끝난 작업은 웨이크하지 않고 목록에만 남는다. 한꺼번에 쏟아지지 않게 하기 위해서다. 필요하면 `cxc bg drain --session <id>`로 직접 받아간다. drain은 스위치를 타지 않는다.
+
+## 지우는 법
+
+```
+cxc bg removal
+```
+
+8단계 체크리스트를 출력한다. 디렉터리만 지우면 되지 않는다. 빌드 컴포넌트 목록, 매니페스트 훅 항목, test glob, 디스패처 동사, lockfile, inventory 재생성까지 포함이다.
+
+## 설계 메모
+
+**데몬이 없다.** 상주 감시 프로세스를 두지 않는다. POSIX에서는 `cxc bg run`이 띄우는 셸이 자기 종료 코드를 `<id>.exit`에 직접 쓴다. Windows에서는 셸이 그 일을 하지 못한다는 것을 실측해서(030 v3) 작업당 Node 헬퍼 하나가 그 자리를 대신한다. 어느 쪽이든 작업 하나에 프로세스 하나이고, 읽는 쪽이 그 파일과 PID 생존으로 상태를 판정한다.
+
+**Codex 내부에 붙지 않는다.** `unified_exec` 세션이나 서브에이전트 스레드를 들여다보지 않는다. 자기가 띄운 프로세스만 안다. 상류가 바뀌어도 같이 깨지지 않게 하려는 것이다.
+
+**다른 컴포넌트를 참조하지 않는다.** import는 `node:*`와 `./*.ts`뿐이다. 그래서 디렉터리를 통째로 지워도 나머지 빌드가 돈다.
+
+## 알려진 한계
+
+Windows 경로는 2026-09-10에 실제 Windows 머신(10.0.26200)에서 측정했다. 근거는 `devlog/_plan/260909_bg_wake_component/030_windows_validation.md`.
+
+- **Windows에서 cmd 내장 명령은 직접 실행되지 않는다.** `cxc bg run -- echo hi`는 실패로 끝난다. `cxc bg run -- cmd /c echo hi`로 감싸면 출력과 종료 코드 모두 정상이다. 헬퍼가 argv를 CreateProcess로 바로 넘기기 때문이고, 그 대가로 cmd 인용 문제가 통째로 사라졌다.
+- 없는 실행 파일은 종료 코드 127로 기록된다.
+- Windows에서 기록되는 pid는 셸이 아니라 헬퍼의 것이다. `cancel`은 헬퍼를 죽인다. 측정한 실행에서는 자식도 함께 멈췄지만, 그 측정이 OpenSSH 세션에서 이뤄져 잡 오브젝트가 개입했을 수 있다. **대화형 로컬 세션은 확인하지 않았다.**
+- 서브에이전트는 SubagentStop을 타므로 루트 Stop 훅과 세션 id가 어긋난다. `cxc bg run`은 메인 세션에서 쓰는 것을 전제로 한다.
+- `deliveredAt`을 찍은 뒤 런타임이 block을 버리면 그 완료는 유실된다. 무한 block을 막는 대가로 받아들인 손실이다.
+- `.codexclaw/bg/`는 `cxc reset --state`로 지워지지 않는다. `reset all`에서만 사라진다.

--- a/plugins/codexclaw/components/bg-wake/dist/cli.js
+++ b/plugins/codexclaw/components/bg-wake/dist/cli.js
@@ -1,0 +1,208 @@
+/**
+ * cli.ts — `cxc bg` entry. Both dispatchers strip the leading command word, so the
+ * argv this CLI receives is [<verb>, ...rest] — same shape skill-search gets.
+ *
+ * Two callers with opposite failure rules:
+ *   hook <event>  — reads the payload on stdin. NEVER writes to stderr and NEVER exits
+ *                   non-zero: exit 2 with stderr is read by Codex as a Stop block.
+ *   everything else — an ordinary CLI for the human and the model.
+ */
+import { readFileSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  describeRecord,
+  disabledState,
+  envDisabled,
+  listRecords,
+  readRecord,
+  reconcile,
+
+} from "./registry.js";
+import { cancel, runBackground } from "./spawn.js";
+import { drainNow, handleSessionStart, handleStop, handleUserPromptSubmit,                  } from "./hook.js";
+import { atomicWrite, appendLedger, disabledPath, enabledAtPath, ensureDir, outPath, readTextOrNull, removePath } from "./store.js";
+import { removalText } from "./removal.js";
+
+const USAGE = [
+  "cxc bg run [--note \"...\"] -- <command...>   백그라운드로 실행하고 id를 반환",
+  "cxc bg list [--json]                        이 디렉터리의 백그라운드 작업",
+  "cxc bg get <id> [--tail N]                  상태와 출력 꼬리",
+  "cxc bg cancel <id>                          중지",
+  "cxc bg off | on | status                    완료 웨이크 스위치 (이 워크트리)",
+  "cxc bg drain --session <id> [--json]        미전달 완료를 받아가고 전달 표시",
+  "cxc bg removal                              제거 체크리스트",
+].join("\n");
+
+const MAX_STDIN_BYTES = 1024 * 1024;
+
+function readStdin()         {
+  try {
+    const raw = readFileSync(0, "utf8");
+    return raw.length > MAX_STDIN_BYTES ? "" : raw;
+  } catch {
+    return "";
+  }
+}
+
+function parsePayload(raw        )              {
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed               ) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Hook path. Any failure degrades to silence, which is the only safe release. */
+function runHook(event        )         {
+  let out = "";
+  try {
+    const payload = parsePayload(readStdin());
+    const cwd = process.cwd();
+    if (event === "stop") out = handleStop(payload, cwd);
+    else if (event === "user-prompt-submit") out = handleUserPromptSubmit(payload, cwd);
+    else if (event === "session-start") out = handleSessionStart(payload, cwd);
+  } catch {
+    out = "";
+  }
+  try {
+    if (out.length > 0) process.stdout.write(out + "\n");
+  } catch {
+    // A broken stdout must not surface as a stack trace on stderr: Codex reads
+    // exit 2 + stderr as a Stop BLOCK, which is the opposite of failing open.
+  }
+  return 0;
+}
+
+function flagValue(args          , name        )                {
+  const i = args.indexOf(name);
+  if (i < 0 || i + 1 >= args.length) return null;
+  return args[i + 1] ?? null;
+}
+
+function formatList(records            )         {
+  if (records.length === 0) return "백그라운드 작업 없음";
+  return records
+    .map((r) => {
+      const delivered = r.deliveredAt === null ? "미전달" : "전달됨";
+      return describeRecord(r) + (r.status === "running" ? "" : "  [" + delivered + "]");
+    })
+    .join("\n");
+}
+
+export function run(argv          , cwd        )                                {
+  const verb = argv[0] ?? "";
+  const args = argv.slice(1);
+
+  if (verb === "run") {
+    const sep = args.indexOf("--");
+    if (sep < 0 || sep === args.length - 1) return { out: USAGE, code: 1 };
+    const note = flagValue(args.slice(0, sep), "--note");
+    const command = args.slice(sep + 1);
+    const rec = runBackground({ cwd, sessionId: process.env.CODEX_THREAD_ID ?? null, command, note });
+    if (args.includes("--json")) return { out: JSON.stringify(rec), code: 0 };
+    return { out: rec.id, code: 0 };
+  }
+
+  if (verb === "list") {
+    const records = listRecords(cwd);
+    if (args.includes("--json")) return { out: JSON.stringify(records), code: 0 };
+    return { out: formatList(records), code: 0 };
+  }
+
+  if (verb === "get") {
+    const id = args[0] ?? "";
+    const rec = readRecord(cwd, id);
+    if (rec === null) return { out: "없는 id: " + id, code: 1 };
+    const fresh = reconcile(rec);
+    const tailArg = flagValue(args, "--tail");
+    const tail = tailArg === null ? 20 : Math.max(0, Number.parseInt(tailArg, 10) || 0);
+    const body = readTextOrNull(outPath(cwd, id)) ?? "";
+    const lines = body.split("\n");
+    const shown = tail > 0 ? lines.slice(-tail).join("\n") : "";
+    return { out: [describeRecord(fresh), "", shown].join("\n").trimEnd(), code: 0 };
+  }
+
+  if (verb === "cancel") {
+    const rec = readRecord(cwd, args[0] ?? "");
+    // Cancelling something already gone is not an error; contract 010 pins this to 0.
+    if (rec === null) return { out: "없는 id: " + (args[0] ?? ""), code: 0 };
+    const next = cancel(rec);
+    return { out: next.id + " " + next.status, code: 0 };
+  }
+
+  if (verb === "off") {
+    ensureDir(cwd);
+    atomicWrite(disabledPath(cwd), new Date().toISOString() + "\n");
+    appendLedger(cwd, { event: "disabled" });
+    return { out: "bg wake OFF (이 워크트리). 다시 켜려면: cxc bg on", code: 0 };
+  }
+
+  if (verb === "on") {
+    ensureDir(cwd);
+    // Re-running `on` while already on must not move the gate forward, or it would
+    // swallow completions that were waiting to be delivered.
+    if (!disabledState(cwd).disabled) return { out: "bg wake 이미 ON", code: 0 };
+    removePath(disabledPath(cwd));
+    // Everything that finished while the switch was off stays in the list but does not
+    // stampede the next Stop (contract 010, wake condition 4).
+    atomicWrite(enabledAtPath(cwd), new Date().toISOString() + "\n");
+    appendLedger(cwd, { event: "enabled" });
+    return { out: "bg wake ON. 꺼져 있는 동안 끝난 작업은 웨이크하지 않고 cxc bg list 에만 남습니다.", code: 0 };
+  }
+
+  if (verb === "status") {
+    const state = disabledState(cwd);
+    const envOff = envDisabled();
+    const lines = [
+      "wake: " + (state.disabled || envOff ? "OFF" : "ON"),
+      state.disabled ? "  파일 플래그: off (" + (state.since ?? "?") + ")" : "  파일 플래그: on",
+      "  CXC_BGWAKE: " + (envOff ? "off" : "unset/on"),
+      "  작업 " + listRecords(cwd).length + "건",
+    ];
+    return { out: lines.join("\n"), code: 0 };
+  }
+
+  if (verb === "drain") {
+    const session = flagValue(args, "--session");
+    if (session === null) return { out: USAGE, code: 1 };
+    const text = drainNow(cwd, session);
+    if (args.includes("--json")) return { out: JSON.stringify({ delivered: text.length > 0, text }), code: 0 };
+    return { out: text.length > 0 ? text : "미전달 완료 없음", code: 0 };
+  }
+
+  if (verb === "removal") return { out: removalText(), code: 0 };
+
+  return { out: USAGE, code: 0 };
+}
+
+function main()       {
+  const argv = process.argv.slice(2);
+  if (argv[0] === "hook") {
+    process.exit(runHook(argv[1] ?? ""));
+  }
+  const { out, code } = run(argv, process.cwd());
+  if (out.length > 0) process.stdout.write(out + "\n");
+  process.exit(code);
+}
+
+// Entry guard mirrors skill-search/src/cli.ts: importing this module from a test must
+// not execute main(), and a symlinked bin path must still match.
+function realOrSelf(p        )         {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+const invokedPath = process.argv[1] ? realOrSelf(resolve(process.argv[1])) : "";
+if (invokedPath === realOrSelf(fileURLToPath(import.meta.url))) {
+  try {
+    main();
+  } catch {
+    // An unhandled throw would reach stderr with a non-zero code, and Codex reads
+    // exit 2 + stderr as a Stop BLOCK. Silence is the only safe failure here.
+    process.exit(process.argv[2] === "hook" ? 0 : 1);
+  }
+}

--- a/plugins/codexclaw/components/bg-wake/dist/hook.js
+++ b/plugins/codexclaw/components/bg-wake/dist/hook.js
@@ -1,0 +1,132 @@
+/**
+ * hook.ts — pure hook logic. No process IO; cli.ts owns stdin/stdout.
+ *
+ * Stop:              {"decision":"block","reason":...} ONLY when an undelivered
+ *                    completion exists. Everything else returns "" (release).
+ * UserPromptSubmit:  hookSpecificOutput.additionalContext only. A block here would
+ *                    reject the user's prompt (codex-rs events/user_prompt_submit.rs).
+ * SessionStart:      adopt orphaned completions into this session, then inject.
+ *
+ * FAIL-OPEN everywhere: any throw becomes "". An empty stdout with exit 0 is the only
+ * safe "do nothing" — malformed JSON is a Failed hook and exit 2 is read as a BLOCK.
+ */
+import {
+  adoptOrphans,
+  describeRecord,
+  hasAnyTask,
+  markDelivered,
+  selectWake,
+  wakeSuppressed,
+
+} from "./registry.js";
+
+
+
+
+
+
+
+
+/**
+ * Falls back to CODEX_THREAD_ID: a payload without session_id would otherwise leave
+ * every completion permanently undelivered, since the wake requires an owner match.
+ */
+export function payloadSessionId(payload             , env                    = process.env)                {
+  if (typeof payload.session_id === "string" && payload.session_id.length > 0) return payload.session_id;
+  const fromEnv = (env.CODEX_THREAD_ID ?? "").trim();
+  return fromEnv.length > 0 ? fromEnv : null;
+}
+
+export function payloadCwd(payload             , fallback        )         {
+  return typeof payload.cwd === "string" && payload.cwd.length > 0 ? payload.cwd : fallback;
+}
+
+const AFFORDANCE = "[codexclaw bg] 백그라운드 작업은 `cxc bg list`로 보고 `cxc bg get <id> --tail 40`으로 출력을 읽습니다.";
+
+export function completionText(records            )         {
+  const head = "[codexclaw bg] 백그라운드 작업 " + records.length + "건이 끝났습니다.";
+  const body = records.map(describeRecord).join("\n");
+  const tail = "출력은 `cxc bg get <id> --tail 40`으로 봅니다. 전체 목록은 `cxc bg list`.\n결과를 확인하고 필요한 후속 작업을 이어가세요.";
+  return [head, body, tail].join("\n");
+}
+
+function contextEnvelope(eventName        , text        )         {
+  return JSON.stringify({ hookSpecificOutput: { hookEventName: eventName, additionalContext: text } });
+}
+
+/** Stop. Returns "" (release) or the block envelope. Never throws. */
+export function handleStop(payload             , fallbackCwd        , env                    = process.env)         {
+  try {
+    const cwd = payloadCwd(payload, fallbackCwd);
+    if (wakeSuppressed(cwd, env)) return "";
+    const sessionId = payloadSessionId(payload, env);
+    const due = selectWake(cwd, sessionId);
+    if (due.length === 0) return "";
+    const reason = completionText(due);
+    if (reason.trim().length === 0) return "";
+    // Stamp BEFORE emitting: a second Stop must not block on the same records.
+    // The cost is an accepted loss if the runtime discards this block (000_plan "허용 손실").
+    markDelivered(due);
+    return JSON.stringify({ decision: "block", reason });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Manual collection for `cxc bg drain`. Deliberately does NOT consult the off switch:
+ * the switch silences automatic wakes, and a human or agent asking for the results
+ * explicitly should still get them.
+ */
+export function drainNow(cwd        , sessionId               )         {
+  try {
+    const due = selectWake(cwd, sessionId);
+    if (due.length === 0) return "";
+    const text = completionText(due);
+    markDelivered(due);
+    return text;
+  } catch {
+    return "";
+  }
+}
+
+/** UserPromptSubmit. Injection only — never a decision. */
+export function handleUserPromptSubmit(payload             , fallbackCwd        , env                    = process.env)         {
+  try {
+    const cwd = payloadCwd(payload, fallbackCwd);
+    if (wakeSuppressed(cwd, env)) return "";
+    const sessionId = payloadSessionId(payload, env);
+    const due = selectWake(cwd, sessionId);
+    if (due.length === 0) return "";
+    const text = completionText(due);
+    markDelivered(due);
+    return contextEnvelope("UserPromptSubmit", text);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * SessionStart. Adoption happens even when the wake is switched off, because it only
+ * re-points ownership; without it a restart strands every undelivered completion.
+ * The injection itself still respects the switch.
+ */
+export function handleSessionStart(payload             , fallbackCwd        , env                    = process.env)         {
+  try {
+    const cwd = payloadCwd(payload, fallbackCwd);
+    const sessionId = payloadSessionId(payload, env);
+    const adopted = adoptOrphans(cwd, sessionId);
+    if (wakeSuppressed(cwd, env)) return "";
+    if (!hasAnyTask(cwd, sessionId)) return "";
+    const lines           = [];
+    if (adopted.length > 0) {
+      lines.push("[codexclaw bg] 이전 세션에서 끝난 백그라운드 작업 " + adopted.length + "건이 아직 전달되지 않았습니다.");
+      lines.push(adopted.slice(0, 5).map(describeRecord).join("\n"));
+    }
+    lines.push(AFFORDANCE);
+    return contextEnvelope("SessionStart", lines.join("\n"));
+  } catch {
+    return "";
+  }
+}
+

--- a/plugins/codexclaw/components/bg-wake/dist/registry.js
+++ b/plugins/codexclaw/components/bg-wake/dist/registry.js
@@ -1,0 +1,280 @@
+/**
+ * registry.ts — record shape, daemon-free status reconciliation, and wake selection.
+ *
+ * There is no watcher process. `bg run` spawns a shell that writes <id>.exit when the
+ * command finishes; readers reconcile from that file plus PID liveness. See contract
+ * 010 "상태 판정 (데몬 없음)".
+ */
+import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  appendLedger,
+  mtimeMs,
+  atomicWrite,
+  disabledPath,
+  enabledAtPath,
+  exitPath,
+  listRecordIds,
+  readJsonOrNull,
+  readTextOrNull,
+  recordPath,
+} from "./store.js";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/** Max completions handed over in one wake (000_plan "꺼 둔 동안 쌓인 완료 처리"). */
+export const WAKE_BATCH_LIMIT = 5;
+
+/** How long a half-written exit file is tolerated before the job is called failed. */
+export const PENDING_EXIT_GRACE_MS = 15_000;
+
+export function isRecord(value         )                    {
+  if (!value || typeof value !== "object") return false;
+  const r = value                           ;
+  return typeof r.id === "string" && typeof r.cwd === "string" && Array.isArray(r.command) && typeof r.status === "string";
+}
+
+export function writeRecord(rec          )       {
+  atomicWrite(recordPath(rec.cwd, rec.id), JSON.stringify(rec, null, 2) + "\n");
+}
+
+export function readRecord(cwd        , id        )                  {
+  const raw = readJsonOrNull          (recordPath(cwd, id));
+  return isRecord(raw) ? raw : null;
+}
+
+/**
+ * Process start fingerprint. POSIX `ps -o lstart=` is stable across the life of a PID;
+ * on Windows there is no cheap equivalent, so the token is null and reconciliation falls
+ * back to liveness alone (documented limitation, 000_plan).
+ */
+export function processStartToken(pid        )                {
+  if (process.platform === "win32") return null;
+  try {
+    const out = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    const trimmed = out.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function pidAlive(pid        )          {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means it exists but belongs to someone else — still "alive" for our purposes.
+    return (err                         )?.code === "EPERM";
+  }
+}
+
+/**
+ * "no exit file yet" and "exit file half-written" must not look the same as "the shell
+ * died without one". The shell writes atomically (tmp + mv), but a filesystem can still
+ * hand us an empty read, so an unparseable body means WAIT, not FAIL.
+ */
+
+
+function readExitCode(cwd        , id        )           {
+  const raw = readTextOrNull(exitPath(cwd, id));
+  if (raw === null) return { state: "absent", code: null };
+  const body = raw.trim();
+  if (body.length === 0) return { state: "pending", code: null };
+  const n = Number.parseInt(body, 10);
+  if (!Number.isFinite(n)) return { state: "pending", code: null };
+  return { state: "known", code: n };
+}
+
+/**
+ * Bring a record up to date and persist the correction. Returns the reconciled record.
+ * Ordering matters: the exit file is authoritative, because a recycled PID can look alive.
+ */
+export function reconcile(rec          , now         = new Date().toISOString())           {
+  if (rec.status !== "running") return rec;
+  const exit = readExitCode(rec.cwd, rec.id);
+  if (exit.state === "known") {
+    const code = exit.code ?? 0;
+    const next           = { ...rec, status: code === 0 ? "complete" : "failed", exitCode: code, endedAt: rec.endedAt ?? now };
+    writeRecord(next);
+    appendLedger(rec.cwd, { event: "completed", id: rec.id, exitCode: code });
+    return next;
+  }
+  // The shell got as far as creating the exit file, so its code is on the way. Staying
+  // "running" for one more poll is far better than freezing a wrong verdict: once a
+  // record leaves running we never look at the exit file again.
+  //
+  // Bounded, though: a truncated file that nobody will ever finish would otherwise pin
+  // the job to "running" forever, so give it a grace window and then call it failed.
+  if (exit.state === "pending") {
+    const stamped = mtimeMs(exitPath(rec.cwd, rec.id));
+    const stale = stamped !== null && Date.now() - stamped > PENDING_EXIT_GRACE_MS;
+    const dead = rec.pid === null || !pidAlive(rec.pid);
+    if (!(stale && dead)) return rec;
+    // Fall through to the failure write below. Returning here — or letting the
+    // pid === null branch catch it — would pin a truncated exit file to "running"
+    // forever, which is exactly what the grace window exists to prevent.
+  } else if (rec.pid === null) {
+    // No pid and no exit file: nothing will ever finish this record. That happens when
+    // the shell failed to spawn at all — and the async 'error' handler cannot be relied
+    // on, because the CLI process may exit before its tick runs. Bound it by age rather
+    // than leaving it "running" forever.
+    const age = Date.now() - Date.parse(rec.startedAt);
+    if (!Number.isFinite(age) || age <= PENDING_EXIT_GRACE_MS) return rec;
+  } else {
+    const alive = pidAlive(rec.pid);
+    const tokenMatches = rec.startToken === null || processStartToken(rec.pid) === rec.startToken;
+    if (alive && tokenMatches) return rec;
+  }
+  // Dead, or a different process now owns that PID: the shell went away without writing
+  // an exit file, so the outcome is unknown and the honest status is failed.
+  const next           = { ...rec, status: "failed", exitCode: null, endedAt: now };
+  writeRecord(next);
+  appendLedger(rec.cwd, { event: "completed", id: rec.id, exitCode: null, detail: "watcher vanished" });
+  return next;
+}
+
+export function listRecords(cwd        )             {
+  const out             = [];
+  for (const id of listRecordIds(cwd)) {
+    const rec = readRecord(cwd, id);
+    if (rec) out.push(reconcile(rec));
+  }
+  return out;
+}
+
+
+
+export function disabledState(cwd        )                {
+  const raw = readTextOrNull(disabledPath(cwd));
+  if (raw === null) return { disabled: false, since: null };
+  const t = raw.trim();
+  return { disabled: true, since: t.length > 0 ? t : null };
+}
+
+/** Env kill switch. Only reaches sessions started after it was exported (000_plan 제1원칙). */
+export function envDisabled(env                    = process.env)          {
+  const v = (env.CXC_BGWAKE ?? "").trim().toLowerCase();
+  return v === "0" || v === "off" || v === "false" || v === "no";
+}
+
+export function wakeSuppressed(cwd        , env                    = process.env)          {
+  return envDisabled(env) || disabledState(cwd).disabled;
+}
+
+function enabledAt(cwd        )                {
+  const raw = readTextOrNull(enabledAtPath(cwd));
+  const t = (raw ?? "").trim();
+  return t.length > 0 ? t : null;
+}
+
+export function isTerminal(status          )          {
+  return status === "complete" || status === "failed" || status === "cancelled";
+}
+
+/**
+ * The five wake conditions from contract 010 "웨이크 대상 판정", in order.
+ * Records are NOT mutated here; the caller stamps deliveredAt once it has emitted them.
+ */
+export function selectWake(cwd        , sessionId               , limit         = WAKE_BATCH_LIMIT)             {
+  const gate = enabledAt(cwd);
+  const eligible = listRecords(cwd).filter((rec) => {
+    if (!isTerminal(rec.status)) return false;
+    if (rec.deliveredAt !== null) return false;
+    if (sessionId === null) return false;
+    if (rec.sessionId !== sessionId && rec.adoptedBy !== sessionId) return false;
+    // '<=' not '<': a job that finishes in the same millisecond as 'bg on' finished
+    // during the off window, and a one-millisecond race should not turn into a wake.
+    if (gate !== null && rec.endedAt !== null && rec.endedAt <= gate) return false;
+    return true;
+  });
+  eligible.sort((a, b) => String(a.endedAt ?? "").localeCompare(String(b.endedAt ?? "")));
+  return eligible.slice(0, Math.max(0, limit));
+}
+
+/**
+ * Stamps each record independently. If one write fails the others still land, and the
+ * failed one simply stays undelivered so a later wake picks it up — a re-wake is much
+ * cheaper than a silently dropped completion.
+ */
+export function markDelivered(records            , now         = new Date().toISOString())             {
+  const stamped             = [];
+  for (const rec of records) {
+    try {
+      writeRecord({ ...rec, deliveredAt: now });
+      appendLedger(rec.cwd, { event: "delivered", id: rec.id, sessionId: rec.adoptedBy ?? rec.sessionId });
+      stamped.push(rec);
+    } catch {
+      // leave it undelivered
+    }
+  }
+  return stamped;
+}
+
+/**
+ * Adoption (contract 010 "인수 규칙"): after a restart the registering session is gone,
+ * so undelivered completions would never wake anyone. Hand them to the live session.
+ * Adoption is not delivery — a later Stop/UserPromptSubmit still does that.
+ */
+export function adoptOrphans(cwd        , sessionId               , now         = new Date().toISOString())             {
+  if (sessionId === null) return [];
+  const adopted             = [];
+  for (const rec of listRecords(cwd)) {
+    if (!isTerminal(rec.status)) continue;
+    if (rec.deliveredAt !== null) continue;
+    if (rec.sessionId === sessionId || rec.adoptedBy === sessionId) continue;
+    const next           = { ...rec, adoptedBy: sessionId };
+    writeRecord(next);
+    appendLedger(cwd, { event: "adopted", id: rec.id, sessionId, at: now });
+    adopted.push(next);
+  }
+  return adopted;
+}
+
+/**
+ * Counts PARSEABLE records owned by this session, not .json files. A directory holding
+ * unreadable junk, or only another session's jobs, should stay quiet rather than
+ * advertise a registry this session cannot act on.
+ */
+export function hasAnyTask(cwd        , sessionId                = null)          {
+  const records = listRecords(cwd);
+  if (sessionId === null) return records.length > 0;
+  return records.some((r) => r.sessionId === sessionId || r.adoptedBy === sessionId);
+}
+
+export function durationLabel(rec          )         {
+  if (rec.endedAt === null) return "running";
+  const ms = Date.parse(rec.endedAt) - Date.parse(rec.startedAt);
+  if (!Number.isFinite(ms) || ms < 0) return "?";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return s + "s";
+  const m = Math.floor(s / 60);
+  return m + "m" + String(s % 60).padStart(2, "0") + "s";
+}
+
+export function describeRecord(rec          )         {
+  const code = rec.exitCode === null ? "exit ?" : "exit " + rec.exitCode;
+  return "- " + rec.id + " (" + rec.status + ", " + code + ", " + durationLabel(rec) + ") — " + rec.command.join(" ");
+}
+
+export function recordExists(cwd        , id        )          {
+  return existsSync(recordPath(cwd, id));
+}
+

--- a/plugins/codexclaw/components/bg-wake/dist/removal.js
+++ b/plugins/codexclaw/components/bg-wake/dist/removal.js
@@ -1,0 +1,35 @@
+/**
+ * removal.ts — the uninstall checklist, kept next to the thing it uninstalls.
+ *
+ * 000_plan "제거 체크리스트": the honest count is 8 touch points, not "delete the
+ * directory". Printing it from the component means the list cannot drift out of the
+ * repo silently, and wp3 proves it is complete by actually applying it.
+ */
+export const REMOVAL_STEPS           = [
+  "1. plugins/codexclaw/components/bg-wake/ 디렉터리 삭제",
+  "2. plugins/codexclaw/hooks/ 의 bg-wake 훅 파일 3개 삭제 (stop / user-prompt-submit / session-start)",
+  "3. plugins/codexclaw/.codex-plugin/plugin.json 의 hooks[] 에서 그 3줄 제거",
+  "4. plugins/codexclaw/scripts/build.mjs 의 OPTIONAL_COMPONENTS 에서 \"bg-wake\" 제거 (빈 배열이면 그 상수와 filter 도 함께 정리)",
+  "5. package.json 의 test glob 에서 bg-wake 줄 제거",
+  "6. 디스패처 정리: plugins/codexclaw/bin/cxc.mjs 의 COMMAND_TABLE bg 항목 + HELP 줄 + \"bg-wake\" slice(3) 분기, bin/codexclaw.mjs 의 case \"bg\" + runBgWake() + HELP 줄",
+  "7. package-lock.json 에 @codexclaw/bg-wake 항목이 있으면 npm install 로 재생성 (workspaces glob 만 쓰는 현재 lock 에는 없어 대개 no-op)",
+  "8. node plugins/codexclaw/scripts/inventory.mjs --write 재실행 (README.md / README.ko.md / README.zh.md 훅 뱃지를 손으로 고치지 말 것)",
+  "9. plugins/codexclaw/test/hook-e2e.test.mjs 의 훅 개수 핀을 3 줄여서 되돌리기",
+];
+
+export function removalText()         {
+  return [
+    "bg-wake 제거 체크리스트 (9단계)",
+    "",
+    ...REMOVAL_STEPS,
+    "",
+    "확인: npm run build && npm test && npm run gate",
+    "",
+    "이 목록은 260909에 실제로 전부 적용해서 build/test/gate 통과를 확인했다.",
+    "",
+    "끄기만 하려면 제거할 필요 없습니다.",
+    "  즉시(이 워크트리):   cxc bg off",
+    "  새 세션부터(전역):   export CXC_BGWAKE=0",
+  ].join("\n");
+}
+

--- a/plugins/codexclaw/components/bg-wake/dist/spawn.js
+++ b/plugins/codexclaw/components/bg-wake/dist/spawn.js
@@ -1,0 +1,178 @@
+/**
+ * spawn.ts — detached background start, with no watcher process of our own.
+ *
+ * POSIX: the spawned shell records its own exit code.
+ *   `( cmd ) > out 2>&1; printf %s $? > exit.tmp && mv exit.tmp exit`
+ * A reader can then tell "finished with code N" from "shell vanished" without ever
+ * having watched the process (registry.reconcile).
+ *
+ * Windows: a shell cannot do that job here. Measured on Windows 10.0.26200
+ * (devlog/_plan/260909_bg_wake_component/030_windows_validation.md): a first hop launched
+ * by libuv with detached + stdio "ignore" leaves its external children with no usable
+ * stdout, so the batch redirect captured nothing (probe v3). A second hop that owns a
+ * real handle does work (v4, v5). Making that hop Node also removes cmd quoting entirely.
+ *
+ * The helper is not there for capture — one detached hop with an inherited fd already
+ * captures (v1). It is there because SOMETHING has to record the exit code after the
+ * parent CLI is gone, which on POSIX is the shell itself.
+ */
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { appendLedger, ensureDir, exitPath, outPath, removePath } from "./store.js";
+import { pidAlive, processStartToken, readRecord, reconcile, recordExists, writeRecord,               } from "./registry.js";
+
+/** Short, human-quotable id. Collisions are re-rolled against the registry. */
+export function newId(cwd        , seed         )         {
+  for (let i = 0; i < 20; i += 1) {
+    const candidate = seed && i === 0 ? seed : "bg" + randomBytes(3).toString("hex");
+    if (!recordExists(cwd, candidate)) return candidate;
+  }
+  return "bg" + Date.now().toString(36);
+}
+
+function shellQuotePosix(arg        )         {
+  return "'" + arg.split("'").join("'\\''") + "'";
+}
+
+/**
+ * The Windows second hop. Written to disk next to the task's output so a failure is
+ * inspectable rather than hidden inside an argv blob.
+ */
+export function buildWindowsHelper()         {
+  const L = [
+    "'use strict';",
+    "const { spawn } = require('node:child_process');",
+    "const fs = require('node:fs');",
+    "const [outPath, exitPath, ...cmd] = process.argv.slice(2);",
+    "function record(code) {",
+    "  try {",
+    "    fs.writeFileSync(exitPath + '.tmp', String(code));",
+    "    fs.renameSync(exitPath + '.tmp', exitPath);",
+    "  } catch (err) {}",
+    "}",
+    "let fd = null;",
+    "try { fd = fs.openSync(outPath, 'a'); } catch (err) {}",
+    "const sink = fd === null ? 'ignore' : fd;",
+    "let child = null;",
+    "try {",
+    "  child = spawn(cmd[0], cmd.slice(1), { stdio: ['ignore', sink, sink], windowsHide: true });",
+    "} catch (err) {",
+    "  // A synchronous throw would otherwise kill the helper before any listener runs,",
+    "  // leaving no exit file at all.",
+    "  record(127);",
+    "  process.exit(0);",
+    "}",
+    "if (fd !== null) { try { fs.closeSync(fd); } catch (err) {} }",
+    "let done = false;",
+    "function finish(code) { if (done) return; done = true; record(code); process.exit(0); }",
+    "// ENOENT arrives here. A cmd builtin is not an executable, but Windows does not",
+    "// always report it as ENOENT: the measured `echo` came back as a normal exit 1.",
+    "child.on('error', function () { finish(127); });",
+    "child.on('exit', function (code, signal) { finish(code === null ? (signal ? 129 : 1) : code); });",
+    "",
+  ];
+  return L.join("\n");
+}
+
+export function buildShell(command          , out        , exit        , helperPath         )                                   {
+  if (process.platform === "win32") {
+    const helper = helperPath ?? out + ".helper.cjs";
+    writeFileSync(helper, buildWindowsHelper(), "utf8");
+    // argv goes straight to CreateProcess, so there are no cmd quoting rules to get wrong.
+    return { file: process.execPath, args: [helper, out, exit, ...command] };
+  }
+  const joined = command.map(shellQuotePosix).join(" ");
+  // tmp + mv so a reader never sees a half-written exit code.
+  const tmp = shellQuotePosix(exit + ".tmp");
+  // A SUBSHELL, not a brace group: 'cxc bg run -- exit 3' inside { } would exit the
+  // wrapper itself and the exit code would never be written.
+  const script =
+    "( " + joined + " ) > " + shellQuotePosix(out) + " 2>&1; printf %s $? > " + tmp + " && mv " + tmp + " " + shellQuotePosix(exit);
+  return { file: "/bin/sh", args: ["-c", script] };
+}
+
+
+
+
+
+
+
+
+
+export function runBackground(opts            )           {
+  ensureDir(opts.cwd);
+  const id = newId(opts.cwd, opts.id);
+  const out = outPath(opts.cwd, id);
+  const exit = exitPath(opts.cwd, id);
+  // A stale exit file from a reused id would be read as an instant completion, and a
+  // stale output file would be appended to on Windows (the helper opens with 'a')
+  // while POSIX truncates. Clearing both keeps the two platforms saying the same thing.
+  removePath(exit);
+  removePath(out);
+  const { file, args } = buildShell(opts.command, out, exit);
+  const child = spawn(file, args, { cwd: opts.cwd, detached: true, stdio: "ignore", windowsHide: true });
+  // Two jobs here. Swallowing the event keeps an ENOENT on the shell itself from
+  // becoming an unhandled 'error' (stderr + non-zero exit, which a hook must never
+  // produce). Marking the record failed keeps it from sitting at "running" forever,
+  // since a shell that never started will never write an exit file either.
+  child.on("error", () => {
+    const current = readRecord(opts.cwd, id);
+    if (current !== null && current.status === "running") {
+      writeRecord({ ...current, status: "failed", exitCode: null, endedAt: new Date().toISOString() });
+      appendLedger(opts.cwd, { event: "completed", id, exitCode: null, detail: "spawn failed" });
+    }
+  });
+  child.unref();
+  const pid = typeof child.pid === "number" ? child.pid : null;
+  const rec           = {
+    id,
+    sessionId: opts.sessionId,
+    adoptedBy: null,
+    cwd: opts.cwd,
+    command: opts.command,
+    note: opts.note ?? null,
+    pid,
+    startToken: pid === null ? null : processStartToken(pid),
+    status: "running",
+    exitCode: null,
+    startedAt: new Date().toISOString(),
+    endedAt: null,
+    deliveredAt: null,
+  };
+  writeRecord(rec);
+  appendLedger(opts.cwd, { event: "registered", id, pid, command: opts.command });
+  return rec;
+}
+
+/**
+ * Cancel is only meaningful for something still running, and only for the process we
+ * actually started. Reconciling first stops us from overwriting a finished job's real
+ * outcome; the start-token check stops us from signalling a recycled PID's group.
+ */
+export function cancel(input          , now         = new Date().toISOString())           {
+  const rec = reconcile(input);
+  if (rec.status !== "running") return rec;
+  // On Windows startToken is always null (no cheap start-time probe). Killing the helper
+  // also stopped its child in the measured run, but that ran under an OpenSSH session
+  // where a job object may have done the work, so an interactive session is not proven
+  // (030_windows_validation.md section 3).
+  const ours = rec.pid !== null && pidAlive(rec.pid) && (rec.startToken === null || processStartToken(rec.pid) === rec.startToken);
+  if (ours && rec.pid !== null) {
+    try {
+      // Negative pid targets the detached process group, so children die with the shell.
+      process.kill(-rec.pid, "SIGTERM");
+    } catch {
+      try {
+        process.kill(rec.pid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+    }
+  }
+  const next           = { ...rec, status: "cancelled", endedAt: rec.endedAt ?? now };
+  writeRecord(next);
+  appendLedger(rec.cwd, { event: "cancelled", id: rec.id });
+  return next;
+}
+

--- a/plugins/codexclaw/components/bg-wake/dist/store.js
+++ b/plugins/codexclaw/components/bg-wake/dist/store.js
@@ -1,0 +1,116 @@
+/**
+ * store.ts — filesystem substrate for the bg registry.
+ *
+ * Layout (contract 010, "파일 레이아웃"):
+ *   <cwd>/.codexclaw/bg/
+ *     disabled        wake off flag; body is the ISO time it was set
+ *     enabled-at      ISO time of the last 'bg on'; wake ignores tasks that ended before it
+ *     <id>.json       record
+ *     <id>.out        merged stdout/stderr
+ *     <id>.exit       exit code, written by the detached shell itself
+ *     ledger.jsonl    append-only events
+ *
+ * Record writes are atomic (tmp + rename). The ledger is an append-only journal, so it
+ * uses appendFileSync instead. pabcd-state has an atomic-write module but
+ * cross-component imports are banned here (000_plan "제거를 쉽게 만드는 제약"), so this
+ * is a deliberate local copy of that one idea.
+ */
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, appendFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export const BG_DIRNAME = "bg";
+export const DISABLED_FILE = "disabled";
+export const ENABLED_AT_FILE = "enabled-at";
+export const LEDGER_FILE = "ledger.jsonl";
+
+export function bgDir(cwd        )         {
+  return join(cwd, ".codexclaw", BG_DIRNAME);
+}
+export function recordPath(cwd        , id        )         {
+  return join(bgDir(cwd), id + ".json");
+}
+export function outPath(cwd        , id        )         {
+  return join(bgDir(cwd), id + ".out");
+}
+export function exitPath(cwd        , id        )         {
+  return join(bgDir(cwd), id + ".exit");
+}
+export function disabledPath(cwd        )         {
+  return join(bgDir(cwd), DISABLED_FILE);
+}
+export function enabledAtPath(cwd        )         {
+  return join(bgDir(cwd), ENABLED_AT_FILE);
+}
+
+export function ensureDir(cwd        )         {
+  const dir = bgDir(cwd);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Atomic write: same-directory tmp then rename, so a reader never sees a torn file. */
+export function atomicWrite(path        , text        )       {
+  const tmp = path + ".tmp-" + process.pid + "-" + Date.now();
+  writeFileSync(tmp, text, "utf8");
+  renameSync(tmp, path);
+}
+
+export function readTextOrNull(path        )                {
+  try {
+    if (!existsSync(path)) return null;
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function readJsonOrNull   (path        )           {
+  const raw = readTextOrNull(path);
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed     ) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function appendLedger(cwd        , event                         )       {
+  try {
+    ensureDir(cwd);
+    appendFileSync(join(bgDir(cwd), LEDGER_FILE), JSON.stringify({ at: new Date().toISOString(), ...event }) + "\n", "utf8");
+  } catch {
+    // Ledger loss must never break a hook. FAIL-OPEN (010 "구현 제약 재확인").
+  }
+}
+
+export function listRecordIds(cwd        )           {
+  try {
+    const dir = bgDir(cwd);
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => f.slice(0, -".json".length))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/** File mtime in ms, or null. Used to bound how long a half-written exit file is tolerated. */
+export function mtimeMs(path        )                {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+export function removePath(path        )       {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    // best effort
+  }
+}
+

--- a/plugins/codexclaw/components/bg-wake/package.json
+++ b/plugins/codexclaw/components/bg-wake/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@codexclaw/bg-wake",
+  "version": "0.2.24",
+  "private": true,
+  "type": "module",
+  "description": "Background task registry + completion wake for Codex. Registers detached commands, then wakes the agent through the Stop hook when they finish.",
+  "main": "dist/cli.js",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/plugins/codexclaw/components/bg-wake/src/cli.ts
+++ b/plugins/codexclaw/components/bg-wake/src/cli.ts
@@ -1,0 +1,208 @@
+/**
+ * cli.ts — `cxc bg` entry. Both dispatchers strip the leading command word, so the
+ * argv this CLI receives is [<verb>, ...rest] — same shape skill-search gets.
+ *
+ * Two callers with opposite failure rules:
+ *   hook <event>  — reads the payload on stdin. NEVER writes to stderr and NEVER exits
+ *                   non-zero: exit 2 with stderr is read by Codex as a Stop block.
+ *   everything else — an ordinary CLI for the human and the model.
+ */
+import { readFileSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  describeRecord,
+  disabledState,
+  envDisabled,
+  listRecords,
+  readRecord,
+  reconcile,
+  type BgRecord,
+} from "./registry.ts";
+import { cancel, runBackground } from "./spawn.ts";
+import { drainNow, handleSessionStart, handleStop, handleUserPromptSubmit, type HookPayload } from "./hook.ts";
+import { atomicWrite, appendLedger, disabledPath, enabledAtPath, ensureDir, outPath, readTextOrNull, removePath } from "./store.ts";
+import { removalText } from "./removal.ts";
+
+const USAGE = [
+  "cxc bg run [--note \"...\"] -- <command...>   백그라운드로 실행하고 id를 반환",
+  "cxc bg list [--json]                        이 디렉터리의 백그라운드 작업",
+  "cxc bg get <id> [--tail N]                  상태와 출력 꼬리",
+  "cxc bg cancel <id>                          중지",
+  "cxc bg off | on | status                    완료 웨이크 스위치 (이 워크트리)",
+  "cxc bg drain --session <id> [--json]        미전달 완료를 받아가고 전달 표시",
+  "cxc bg removal                              제거 체크리스트",
+].join("\n");
+
+const MAX_STDIN_BYTES = 1024 * 1024;
+
+function readStdin(): string {
+  try {
+    const raw = readFileSync(0, "utf8");
+    return raw.length > MAX_STDIN_BYTES ? "" : raw;
+  } catch {
+    return "";
+  }
+}
+
+function parsePayload(raw: string): HookPayload {
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as HookPayload) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Hook path. Any failure degrades to silence, which is the only safe release. */
+function runHook(event: string): number {
+  let out = "";
+  try {
+    const payload = parsePayload(readStdin());
+    const cwd = process.cwd();
+    if (event === "stop") out = handleStop(payload, cwd);
+    else if (event === "user-prompt-submit") out = handleUserPromptSubmit(payload, cwd);
+    else if (event === "session-start") out = handleSessionStart(payload, cwd);
+  } catch {
+    out = "";
+  }
+  try {
+    if (out.length > 0) process.stdout.write(out + "\n");
+  } catch {
+    // A broken stdout must not surface as a stack trace on stderr: Codex reads
+    // exit 2 + stderr as a Stop BLOCK, which is the opposite of failing open.
+  }
+  return 0;
+}
+
+function flagValue(args: string[], name: string): string | null {
+  const i = args.indexOf(name);
+  if (i < 0 || i + 1 >= args.length) return null;
+  return args[i + 1] ?? null;
+}
+
+function formatList(records: BgRecord[]): string {
+  if (records.length === 0) return "백그라운드 작업 없음";
+  return records
+    .map((r) => {
+      const delivered = r.deliveredAt === null ? "미전달" : "전달됨";
+      return describeRecord(r) + (r.status === "running" ? "" : "  [" + delivered + "]");
+    })
+    .join("\n");
+}
+
+export function run(argv: string[], cwd: string): { out: string; code: number } {
+  const verb = argv[0] ?? "";
+  const args = argv.slice(1);
+
+  if (verb === "run") {
+    const sep = args.indexOf("--");
+    if (sep < 0 || sep === args.length - 1) return { out: USAGE, code: 1 };
+    const note = flagValue(args.slice(0, sep), "--note");
+    const command = args.slice(sep + 1);
+    const rec = runBackground({ cwd, sessionId: process.env.CODEX_THREAD_ID ?? null, command, note });
+    if (args.includes("--json")) return { out: JSON.stringify(rec), code: 0 };
+    return { out: rec.id, code: 0 };
+  }
+
+  if (verb === "list") {
+    const records = listRecords(cwd);
+    if (args.includes("--json")) return { out: JSON.stringify(records), code: 0 };
+    return { out: formatList(records), code: 0 };
+  }
+
+  if (verb === "get") {
+    const id = args[0] ?? "";
+    const rec = readRecord(cwd, id);
+    if (rec === null) return { out: "없는 id: " + id, code: 1 };
+    const fresh = reconcile(rec);
+    const tailArg = flagValue(args, "--tail");
+    const tail = tailArg === null ? 20 : Math.max(0, Number.parseInt(tailArg, 10) || 0);
+    const body = readTextOrNull(outPath(cwd, id)) ?? "";
+    const lines = body.split("\n");
+    const shown = tail > 0 ? lines.slice(-tail).join("\n") : "";
+    return { out: [describeRecord(fresh), "", shown].join("\n").trimEnd(), code: 0 };
+  }
+
+  if (verb === "cancel") {
+    const rec = readRecord(cwd, args[0] ?? "");
+    // Cancelling something already gone is not an error; contract 010 pins this to 0.
+    if (rec === null) return { out: "없는 id: " + (args[0] ?? ""), code: 0 };
+    const next = cancel(rec);
+    return { out: next.id + " " + next.status, code: 0 };
+  }
+
+  if (verb === "off") {
+    ensureDir(cwd);
+    atomicWrite(disabledPath(cwd), new Date().toISOString() + "\n");
+    appendLedger(cwd, { event: "disabled" });
+    return { out: "bg wake OFF (이 워크트리). 다시 켜려면: cxc bg on", code: 0 };
+  }
+
+  if (verb === "on") {
+    ensureDir(cwd);
+    // Re-running `on` while already on must not move the gate forward, or it would
+    // swallow completions that were waiting to be delivered.
+    if (!disabledState(cwd).disabled) return { out: "bg wake 이미 ON", code: 0 };
+    removePath(disabledPath(cwd));
+    // Everything that finished while the switch was off stays in the list but does not
+    // stampede the next Stop (contract 010, wake condition 4).
+    atomicWrite(enabledAtPath(cwd), new Date().toISOString() + "\n");
+    appendLedger(cwd, { event: "enabled" });
+    return { out: "bg wake ON. 꺼져 있는 동안 끝난 작업은 웨이크하지 않고 cxc bg list 에만 남습니다.", code: 0 };
+  }
+
+  if (verb === "status") {
+    const state = disabledState(cwd);
+    const envOff = envDisabled();
+    const lines = [
+      "wake: " + (state.disabled || envOff ? "OFF" : "ON"),
+      state.disabled ? "  파일 플래그: off (" + (state.since ?? "?") + ")" : "  파일 플래그: on",
+      "  CXC_BGWAKE: " + (envOff ? "off" : "unset/on"),
+      "  작업 " + listRecords(cwd).length + "건",
+    ];
+    return { out: lines.join("\n"), code: 0 };
+  }
+
+  if (verb === "drain") {
+    const session = flagValue(args, "--session");
+    if (session === null) return { out: USAGE, code: 1 };
+    const text = drainNow(cwd, session);
+    if (args.includes("--json")) return { out: JSON.stringify({ delivered: text.length > 0, text }), code: 0 };
+    return { out: text.length > 0 ? text : "미전달 완료 없음", code: 0 };
+  }
+
+  if (verb === "removal") return { out: removalText(), code: 0 };
+
+  return { out: USAGE, code: 0 };
+}
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  if (argv[0] === "hook") {
+    process.exit(runHook(argv[1] ?? ""));
+  }
+  const { out, code } = run(argv, process.cwd());
+  if (out.length > 0) process.stdout.write(out + "\n");
+  process.exit(code);
+}
+
+// Entry guard mirrors skill-search/src/cli.ts: importing this module from a test must
+// not execute main(), and a symlinked bin path must still match.
+function realOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+const invokedPath = process.argv[1] ? realOrSelf(resolve(process.argv[1])) : "";
+if (invokedPath === realOrSelf(fileURLToPath(import.meta.url))) {
+  try {
+    main();
+  } catch {
+    // An unhandled throw would reach stderr with a non-zero code, and Codex reads
+    // exit 2 + stderr as a Stop BLOCK. Silence is the only safe failure here.
+    process.exit(process.argv[2] === "hook" ? 0 : 1);
+  }
+}

--- a/plugins/codexclaw/components/bg-wake/src/hook.ts
+++ b/plugins/codexclaw/components/bg-wake/src/hook.ts
@@ -1,0 +1,132 @@
+/**
+ * hook.ts — pure hook logic. No process IO; cli.ts owns stdin/stdout.
+ *
+ * Stop:              {"decision":"block","reason":...} ONLY when an undelivered
+ *                    completion exists. Everything else returns "" (release).
+ * UserPromptSubmit:  hookSpecificOutput.additionalContext only. A block here would
+ *                    reject the user's prompt (codex-rs events/user_prompt_submit.rs).
+ * SessionStart:      adopt orphaned completions into this session, then inject.
+ *
+ * FAIL-OPEN everywhere: any throw becomes "". An empty stdout with exit 0 is the only
+ * safe "do nothing" — malformed JSON is a Failed hook and exit 2 is read as a BLOCK.
+ */
+import {
+  adoptOrphans,
+  describeRecord,
+  hasAnyTask,
+  markDelivered,
+  selectWake,
+  wakeSuppressed,
+  type BgRecord,
+} from "./registry.ts";
+
+export type HookPayload = {
+  session_id?: unknown;
+  cwd?: unknown;
+  source?: unknown;
+  stop_hook_active?: unknown;
+};
+
+/**
+ * Falls back to CODEX_THREAD_ID: a payload without session_id would otherwise leave
+ * every completion permanently undelivered, since the wake requires an owner match.
+ */
+export function payloadSessionId(payload: HookPayload, env: NodeJS.ProcessEnv = process.env): string | null {
+  if (typeof payload.session_id === "string" && payload.session_id.length > 0) return payload.session_id;
+  const fromEnv = (env.CODEX_THREAD_ID ?? "").trim();
+  return fromEnv.length > 0 ? fromEnv : null;
+}
+
+export function payloadCwd(payload: HookPayload, fallback: string): string {
+  return typeof payload.cwd === "string" && payload.cwd.length > 0 ? payload.cwd : fallback;
+}
+
+const AFFORDANCE = "[codexclaw bg] 백그라운드 작업은 `cxc bg list`로 보고 `cxc bg get <id> --tail 40`으로 출력을 읽습니다.";
+
+export function completionText(records: BgRecord[]): string {
+  const head = "[codexclaw bg] 백그라운드 작업 " + records.length + "건이 끝났습니다.";
+  const body = records.map(describeRecord).join("\n");
+  const tail = "출력은 `cxc bg get <id> --tail 40`으로 봅니다. 전체 목록은 `cxc bg list`.\n결과를 확인하고 필요한 후속 작업을 이어가세요.";
+  return [head, body, tail].join("\n");
+}
+
+function contextEnvelope(eventName: string, text: string): string {
+  return JSON.stringify({ hookSpecificOutput: { hookEventName: eventName, additionalContext: text } });
+}
+
+/** Stop. Returns "" (release) or the block envelope. Never throws. */
+export function handleStop(payload: HookPayload, fallbackCwd: string, env: NodeJS.ProcessEnv = process.env): string {
+  try {
+    const cwd = payloadCwd(payload, fallbackCwd);
+    if (wakeSuppressed(cwd, env)) return "";
+    const sessionId = payloadSessionId(payload, env);
+    const due = selectWake(cwd, sessionId);
+    if (due.length === 0) return "";
+    const reason = completionText(due);
+    if (reason.trim().length === 0) return "";
+    // Stamp BEFORE emitting: a second Stop must not block on the same records.
+    // The cost is an accepted loss if the runtime discards this block (000_plan "허용 손실").
+    markDelivered(due);
+    return JSON.stringify({ decision: "block", reason });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Manual collection for `cxc bg drain`. Deliberately does NOT consult the off switch:
+ * the switch silences automatic wakes, and a human or agent asking for the results
+ * explicitly should still get them.
+ */
+export function drainNow(cwd: string, sessionId: string | null): string {
+  try {
+    const due = selectWake(cwd, sessionId);
+    if (due.length === 0) return "";
+    const text = completionText(due);
+    markDelivered(due);
+    return text;
+  } catch {
+    return "";
+  }
+}
+
+/** UserPromptSubmit. Injection only — never a decision. */
+export function handleUserPromptSubmit(payload: HookPayload, fallbackCwd: string, env: NodeJS.ProcessEnv = process.env): string {
+  try {
+    const cwd = payloadCwd(payload, fallbackCwd);
+    if (wakeSuppressed(cwd, env)) return "";
+    const sessionId = payloadSessionId(payload, env);
+    const due = selectWake(cwd, sessionId);
+    if (due.length === 0) return "";
+    const text = completionText(due);
+    markDelivered(due);
+    return contextEnvelope("UserPromptSubmit", text);
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * SessionStart. Adoption happens even when the wake is switched off, because it only
+ * re-points ownership; without it a restart strands every undelivered completion.
+ * The injection itself still respects the switch.
+ */
+export function handleSessionStart(payload: HookPayload, fallbackCwd: string, env: NodeJS.ProcessEnv = process.env): string {
+  try {
+    const cwd = payloadCwd(payload, fallbackCwd);
+    const sessionId = payloadSessionId(payload, env);
+    const adopted = adoptOrphans(cwd, sessionId);
+    if (wakeSuppressed(cwd, env)) return "";
+    if (!hasAnyTask(cwd, sessionId)) return "";
+    const lines: string[] = [];
+    if (adopted.length > 0) {
+      lines.push("[codexclaw bg] 이전 세션에서 끝난 백그라운드 작업 " + adopted.length + "건이 아직 전달되지 않았습니다.");
+      lines.push(adopted.slice(0, 5).map(describeRecord).join("\n"));
+    }
+    lines.push(AFFORDANCE);
+    return contextEnvelope("SessionStart", lines.join("\n"));
+  } catch {
+    return "";
+  }
+}
+

--- a/plugins/codexclaw/components/bg-wake/src/registry.ts
+++ b/plugins/codexclaw/components/bg-wake/src/registry.ts
@@ -1,0 +1,280 @@
+/**
+ * registry.ts — record shape, daemon-free status reconciliation, and wake selection.
+ *
+ * There is no watcher process. `bg run` spawns a shell that writes <id>.exit when the
+ * command finishes; readers reconcile from that file plus PID liveness. See contract
+ * 010 "상태 판정 (데몬 없음)".
+ */
+import { existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import {
+  appendLedger,
+  mtimeMs,
+  atomicWrite,
+  disabledPath,
+  enabledAtPath,
+  exitPath,
+  listRecordIds,
+  readJsonOrNull,
+  readTextOrNull,
+  recordPath,
+} from "./store.ts";
+
+export type BgStatus = "running" | "complete" | "failed" | "cancelled";
+
+export type BgRecord = {
+  id: string;
+  sessionId: string | null;
+  adoptedBy: string | null;
+  cwd: string;
+  command: string[];
+  note: string | null;
+  pid: number | null;
+  /** Process start fingerprint, so a recycled PID is not mistaken for our shell. */
+  startToken: string | null;
+  status: BgStatus;
+  exitCode: number | null;
+  startedAt: string;
+  endedAt: string | null;
+  deliveredAt: string | null;
+};
+
+/** Max completions handed over in one wake (000_plan "꺼 둔 동안 쌓인 완료 처리"). */
+export const WAKE_BATCH_LIMIT = 5;
+
+/** How long a half-written exit file is tolerated before the job is called failed. */
+export const PENDING_EXIT_GRACE_MS = 15_000;
+
+export function isRecord(value: unknown): value is BgRecord {
+  if (!value || typeof value !== "object") return false;
+  const r = value as Record<string, unknown>;
+  return typeof r.id === "string" && typeof r.cwd === "string" && Array.isArray(r.command) && typeof r.status === "string";
+}
+
+export function writeRecord(rec: BgRecord): void {
+  atomicWrite(recordPath(rec.cwd, rec.id), JSON.stringify(rec, null, 2) + "\n");
+}
+
+export function readRecord(cwd: string, id: string): BgRecord | null {
+  const raw = readJsonOrNull<BgRecord>(recordPath(cwd, id));
+  return isRecord(raw) ? raw : null;
+}
+
+/**
+ * Process start fingerprint. POSIX `ps -o lstart=` is stable across the life of a PID;
+ * on Windows there is no cheap equivalent, so the token is null and reconciliation falls
+ * back to liveness alone (documented limitation, 000_plan).
+ */
+export function processStartToken(pid: number): string | null {
+  if (process.platform === "win32") return null;
+  try {
+    const out = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    const trimmed = out.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means it exists but belongs to someone else — still "alive" for our purposes.
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
+  }
+}
+
+/**
+ * "no exit file yet" and "exit file half-written" must not look the same as "the shell
+ * died without one". The shell writes atomically (tmp + mv), but a filesystem can still
+ * hand us an empty read, so an unparseable body means WAIT, not FAIL.
+ */
+export type ExitRead = { state: "absent" | "pending" | "known"; code: number | null };
+
+function readExitCode(cwd: string, id: string): ExitRead {
+  const raw = readTextOrNull(exitPath(cwd, id));
+  if (raw === null) return { state: "absent", code: null };
+  const body = raw.trim();
+  if (body.length === 0) return { state: "pending", code: null };
+  const n = Number.parseInt(body, 10);
+  if (!Number.isFinite(n)) return { state: "pending", code: null };
+  return { state: "known", code: n };
+}
+
+/**
+ * Bring a record up to date and persist the correction. Returns the reconciled record.
+ * Ordering matters: the exit file is authoritative, because a recycled PID can look alive.
+ */
+export function reconcile(rec: BgRecord, now: string = new Date().toISOString()): BgRecord {
+  if (rec.status !== "running") return rec;
+  const exit = readExitCode(rec.cwd, rec.id);
+  if (exit.state === "known") {
+    const code = exit.code ?? 0;
+    const next: BgRecord = { ...rec, status: code === 0 ? "complete" : "failed", exitCode: code, endedAt: rec.endedAt ?? now };
+    writeRecord(next);
+    appendLedger(rec.cwd, { event: "completed", id: rec.id, exitCode: code });
+    return next;
+  }
+  // The shell got as far as creating the exit file, so its code is on the way. Staying
+  // "running" for one more poll is far better than freezing a wrong verdict: once a
+  // record leaves running we never look at the exit file again.
+  //
+  // Bounded, though: a truncated file that nobody will ever finish would otherwise pin
+  // the job to "running" forever, so give it a grace window and then call it failed.
+  if (exit.state === "pending") {
+    const stamped = mtimeMs(exitPath(rec.cwd, rec.id));
+    const stale = stamped !== null && Date.now() - stamped > PENDING_EXIT_GRACE_MS;
+    const dead = rec.pid === null || !pidAlive(rec.pid);
+    if (!(stale && dead)) return rec;
+    // Fall through to the failure write below. Returning here — or letting the
+    // pid === null branch catch it — would pin a truncated exit file to "running"
+    // forever, which is exactly what the grace window exists to prevent.
+  } else if (rec.pid === null) {
+    // No pid and no exit file: nothing will ever finish this record. That happens when
+    // the shell failed to spawn at all — and the async 'error' handler cannot be relied
+    // on, because the CLI process may exit before its tick runs. Bound it by age rather
+    // than leaving it "running" forever.
+    const age = Date.now() - Date.parse(rec.startedAt);
+    if (!Number.isFinite(age) || age <= PENDING_EXIT_GRACE_MS) return rec;
+  } else {
+    const alive = pidAlive(rec.pid);
+    const tokenMatches = rec.startToken === null || processStartToken(rec.pid) === rec.startToken;
+    if (alive && tokenMatches) return rec;
+  }
+  // Dead, or a different process now owns that PID: the shell went away without writing
+  // an exit file, so the outcome is unknown and the honest status is failed.
+  const next: BgRecord = { ...rec, status: "failed", exitCode: null, endedAt: now };
+  writeRecord(next);
+  appendLedger(rec.cwd, { event: "completed", id: rec.id, exitCode: null, detail: "watcher vanished" });
+  return next;
+}
+
+export function listRecords(cwd: string): BgRecord[] {
+  const out: BgRecord[] = [];
+  for (const id of listRecordIds(cwd)) {
+    const rec = readRecord(cwd, id);
+    if (rec) out.push(reconcile(rec));
+  }
+  return out;
+}
+
+export type DisabledState = { disabled: boolean; since: string | null };
+
+export function disabledState(cwd: string): DisabledState {
+  const raw = readTextOrNull(disabledPath(cwd));
+  if (raw === null) return { disabled: false, since: null };
+  const t = raw.trim();
+  return { disabled: true, since: t.length > 0 ? t : null };
+}
+
+/** Env kill switch. Only reaches sessions started after it was exported (000_plan 제1원칙). */
+export function envDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env.CXC_BGWAKE ?? "").trim().toLowerCase();
+  return v === "0" || v === "off" || v === "false" || v === "no";
+}
+
+export function wakeSuppressed(cwd: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  return envDisabled(env) || disabledState(cwd).disabled;
+}
+
+function enabledAt(cwd: string): string | null {
+  const raw = readTextOrNull(enabledAtPath(cwd));
+  const t = (raw ?? "").trim();
+  return t.length > 0 ? t : null;
+}
+
+export function isTerminal(status: BgStatus): boolean {
+  return status === "complete" || status === "failed" || status === "cancelled";
+}
+
+/**
+ * The five wake conditions from contract 010 "웨이크 대상 판정", in order.
+ * Records are NOT mutated here; the caller stamps deliveredAt once it has emitted them.
+ */
+export function selectWake(cwd: string, sessionId: string | null, limit: number = WAKE_BATCH_LIMIT): BgRecord[] {
+  const gate = enabledAt(cwd);
+  const eligible = listRecords(cwd).filter((rec) => {
+    if (!isTerminal(rec.status)) return false;
+    if (rec.deliveredAt !== null) return false;
+    if (sessionId === null) return false;
+    if (rec.sessionId !== sessionId && rec.adoptedBy !== sessionId) return false;
+    // '<=' not '<': a job that finishes in the same millisecond as 'bg on' finished
+    // during the off window, and a one-millisecond race should not turn into a wake.
+    if (gate !== null && rec.endedAt !== null && rec.endedAt <= gate) return false;
+    return true;
+  });
+  eligible.sort((a, b) => String(a.endedAt ?? "").localeCompare(String(b.endedAt ?? "")));
+  return eligible.slice(0, Math.max(0, limit));
+}
+
+/**
+ * Stamps each record independently. If one write fails the others still land, and the
+ * failed one simply stays undelivered so a later wake picks it up — a re-wake is much
+ * cheaper than a silently dropped completion.
+ */
+export function markDelivered(records: BgRecord[], now: string = new Date().toISOString()): BgRecord[] {
+  const stamped: BgRecord[] = [];
+  for (const rec of records) {
+    try {
+      writeRecord({ ...rec, deliveredAt: now });
+      appendLedger(rec.cwd, { event: "delivered", id: rec.id, sessionId: rec.adoptedBy ?? rec.sessionId });
+      stamped.push(rec);
+    } catch {
+      // leave it undelivered
+    }
+  }
+  return stamped;
+}
+
+/**
+ * Adoption (contract 010 "인수 규칙"): after a restart the registering session is gone,
+ * so undelivered completions would never wake anyone. Hand them to the live session.
+ * Adoption is not delivery — a later Stop/UserPromptSubmit still does that.
+ */
+export function adoptOrphans(cwd: string, sessionId: string | null, now: string = new Date().toISOString()): BgRecord[] {
+  if (sessionId === null) return [];
+  const adopted: BgRecord[] = [];
+  for (const rec of listRecords(cwd)) {
+    if (!isTerminal(rec.status)) continue;
+    if (rec.deliveredAt !== null) continue;
+    if (rec.sessionId === sessionId || rec.adoptedBy === sessionId) continue;
+    const next: BgRecord = { ...rec, adoptedBy: sessionId };
+    writeRecord(next);
+    appendLedger(cwd, { event: "adopted", id: rec.id, sessionId, at: now });
+    adopted.push(next);
+  }
+  return adopted;
+}
+
+/**
+ * Counts PARSEABLE records owned by this session, not .json files. A directory holding
+ * unreadable junk, or only another session's jobs, should stay quiet rather than
+ * advertise a registry this session cannot act on.
+ */
+export function hasAnyTask(cwd: string, sessionId: string | null = null): boolean {
+  const records = listRecords(cwd);
+  if (sessionId === null) return records.length > 0;
+  return records.some((r) => r.sessionId === sessionId || r.adoptedBy === sessionId);
+}
+
+export function durationLabel(rec: BgRecord): string {
+  if (rec.endedAt === null) return "running";
+  const ms = Date.parse(rec.endedAt) - Date.parse(rec.startedAt);
+  if (!Number.isFinite(ms) || ms < 0) return "?";
+  const s = Math.round(ms / 1000);
+  if (s < 60) return s + "s";
+  const m = Math.floor(s / 60);
+  return m + "m" + String(s % 60).padStart(2, "0") + "s";
+}
+
+export function describeRecord(rec: BgRecord): string {
+  const code = rec.exitCode === null ? "exit ?" : "exit " + rec.exitCode;
+  return "- " + rec.id + " (" + rec.status + ", " + code + ", " + durationLabel(rec) + ") — " + rec.command.join(" ");
+}
+
+export function recordExists(cwd: string, id: string): boolean {
+  return existsSync(recordPath(cwd, id));
+}
+

--- a/plugins/codexclaw/components/bg-wake/src/removal.ts
+++ b/plugins/codexclaw/components/bg-wake/src/removal.ts
@@ -1,0 +1,35 @@
+/**
+ * removal.ts — the uninstall checklist, kept next to the thing it uninstalls.
+ *
+ * 000_plan "제거 체크리스트": the honest count is 8 touch points, not "delete the
+ * directory". Printing it from the component means the list cannot drift out of the
+ * repo silently, and wp3 proves it is complete by actually applying it.
+ */
+export const REMOVAL_STEPS: string[] = [
+  "1. plugins/codexclaw/components/bg-wake/ 디렉터리 삭제",
+  "2. plugins/codexclaw/hooks/ 의 bg-wake 훅 파일 3개 삭제 (stop / user-prompt-submit / session-start)",
+  "3. plugins/codexclaw/.codex-plugin/plugin.json 의 hooks[] 에서 그 3줄 제거",
+  "4. plugins/codexclaw/scripts/build.mjs 의 OPTIONAL_COMPONENTS 에서 \"bg-wake\" 제거 (빈 배열이면 그 상수와 filter 도 함께 정리)",
+  "5. package.json 의 test glob 에서 bg-wake 줄 제거",
+  "6. 디스패처 정리: plugins/codexclaw/bin/cxc.mjs 의 COMMAND_TABLE bg 항목 + HELP 줄 + \"bg-wake\" slice(3) 분기, bin/codexclaw.mjs 의 case \"bg\" + runBgWake() + HELP 줄",
+  "7. package-lock.json 에 @codexclaw/bg-wake 항목이 있으면 npm install 로 재생성 (workspaces glob 만 쓰는 현재 lock 에는 없어 대개 no-op)",
+  "8. node plugins/codexclaw/scripts/inventory.mjs --write 재실행 (README.md / README.ko.md / README.zh.md 훅 뱃지를 손으로 고치지 말 것)",
+  "9. plugins/codexclaw/test/hook-e2e.test.mjs 의 훅 개수 핀을 3 줄여서 되돌리기",
+];
+
+export function removalText(): string {
+  return [
+    "bg-wake 제거 체크리스트 (9단계)",
+    "",
+    ...REMOVAL_STEPS,
+    "",
+    "확인: npm run build && npm test && npm run gate",
+    "",
+    "이 목록은 260909에 실제로 전부 적용해서 build/test/gate 통과를 확인했다.",
+    "",
+    "끄기만 하려면 제거할 필요 없습니다.",
+    "  즉시(이 워크트리):   cxc bg off",
+    "  새 세션부터(전역):   export CXC_BGWAKE=0",
+  ].join("\n");
+}
+

--- a/plugins/codexclaw/components/bg-wake/src/spawn.ts
+++ b/plugins/codexclaw/components/bg-wake/src/spawn.ts
@@ -1,0 +1,178 @@
+/**
+ * spawn.ts — detached background start, with no watcher process of our own.
+ *
+ * POSIX: the spawned shell records its own exit code.
+ *   `( cmd ) > out 2>&1; printf %s $? > exit.tmp && mv exit.tmp exit`
+ * A reader can then tell "finished with code N" from "shell vanished" without ever
+ * having watched the process (registry.reconcile).
+ *
+ * Windows: a shell cannot do that job here. Measured on Windows 10.0.26200
+ * (devlog/_plan/260909_bg_wake_component/030_windows_validation.md): a first hop launched
+ * by libuv with detached + stdio "ignore" leaves its external children with no usable
+ * stdout, so the batch redirect captured nothing (probe v3). A second hop that owns a
+ * real handle does work (v4, v5). Making that hop Node also removes cmd quoting entirely.
+ *
+ * The helper is not there for capture — one detached hop with an inherited fd already
+ * captures (v1). It is there because SOMETHING has to record the exit code after the
+ * parent CLI is gone, which on POSIX is the shell itself.
+ */
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { appendLedger, ensureDir, exitPath, outPath, removePath } from "./store.ts";
+import { pidAlive, processStartToken, readRecord, reconcile, recordExists, writeRecord, type BgRecord } from "./registry.ts";
+
+/** Short, human-quotable id. Collisions are re-rolled against the registry. */
+export function newId(cwd: string, seed?: string): string {
+  for (let i = 0; i < 20; i += 1) {
+    const candidate = seed && i === 0 ? seed : "bg" + randomBytes(3).toString("hex");
+    if (!recordExists(cwd, candidate)) return candidate;
+  }
+  return "bg" + Date.now().toString(36);
+}
+
+function shellQuotePosix(arg: string): string {
+  return "'" + arg.split("'").join("'\\''") + "'";
+}
+
+/**
+ * The Windows second hop. Written to disk next to the task's output so a failure is
+ * inspectable rather than hidden inside an argv blob.
+ */
+export function buildWindowsHelper(): string {
+  const L = [
+    "'use strict';",
+    "const { spawn } = require('node:child_process');",
+    "const fs = require('node:fs');",
+    "const [outPath, exitPath, ...cmd] = process.argv.slice(2);",
+    "function record(code) {",
+    "  try {",
+    "    fs.writeFileSync(exitPath + '.tmp', String(code));",
+    "    fs.renameSync(exitPath + '.tmp', exitPath);",
+    "  } catch (err) {}",
+    "}",
+    "let fd = null;",
+    "try { fd = fs.openSync(outPath, 'a'); } catch (err) {}",
+    "const sink = fd === null ? 'ignore' : fd;",
+    "let child = null;",
+    "try {",
+    "  child = spawn(cmd[0], cmd.slice(1), { stdio: ['ignore', sink, sink], windowsHide: true });",
+    "} catch (err) {",
+    "  // A synchronous throw would otherwise kill the helper before any listener runs,",
+    "  // leaving no exit file at all.",
+    "  record(127);",
+    "  process.exit(0);",
+    "}",
+    "if (fd !== null) { try { fs.closeSync(fd); } catch (err) {} }",
+    "let done = false;",
+    "function finish(code) { if (done) return; done = true; record(code); process.exit(0); }",
+    "// ENOENT arrives here. A cmd builtin is not an executable, but Windows does not",
+    "// always report it as ENOENT: the measured `echo` came back as a normal exit 1.",
+    "child.on('error', function () { finish(127); });",
+    "child.on('exit', function (code, signal) { finish(code === null ? (signal ? 129 : 1) : code); });",
+    "",
+  ];
+  return L.join("\n");
+}
+
+export function buildShell(command: string[], out: string, exit: string, helperPath?: string): { file: string; args: string[] } {
+  if (process.platform === "win32") {
+    const helper = helperPath ?? out + ".helper.cjs";
+    writeFileSync(helper, buildWindowsHelper(), "utf8");
+    // argv goes straight to CreateProcess, so there are no cmd quoting rules to get wrong.
+    return { file: process.execPath, args: [helper, out, exit, ...command] };
+  }
+  const joined = command.map(shellQuotePosix).join(" ");
+  // tmp + mv so a reader never sees a half-written exit code.
+  const tmp = shellQuotePosix(exit + ".tmp");
+  // A SUBSHELL, not a brace group: 'cxc bg run -- exit 3' inside { } would exit the
+  // wrapper itself and the exit code would never be written.
+  const script =
+    "( " + joined + " ) > " + shellQuotePosix(out) + " 2>&1; printf %s $? > " + tmp + " && mv " + tmp + " " + shellQuotePosix(exit);
+  return { file: "/bin/sh", args: ["-c", script] };
+}
+
+export type RunOptions = {
+  cwd: string;
+  sessionId: string | null;
+  command: string[];
+  note?: string | null;
+  id?: string;
+};
+
+export function runBackground(opts: RunOptions): BgRecord {
+  ensureDir(opts.cwd);
+  const id = newId(opts.cwd, opts.id);
+  const out = outPath(opts.cwd, id);
+  const exit = exitPath(opts.cwd, id);
+  // A stale exit file from a reused id would be read as an instant completion, and a
+  // stale output file would be appended to on Windows (the helper opens with 'a')
+  // while POSIX truncates. Clearing both keeps the two platforms saying the same thing.
+  removePath(exit);
+  removePath(out);
+  const { file, args } = buildShell(opts.command, out, exit);
+  const child = spawn(file, args, { cwd: opts.cwd, detached: true, stdio: "ignore", windowsHide: true });
+  // Two jobs here. Swallowing the event keeps an ENOENT on the shell itself from
+  // becoming an unhandled 'error' (stderr + non-zero exit, which a hook must never
+  // produce). Marking the record failed keeps it from sitting at "running" forever,
+  // since a shell that never started will never write an exit file either.
+  child.on("error", () => {
+    const current = readRecord(opts.cwd, id);
+    if (current !== null && current.status === "running") {
+      writeRecord({ ...current, status: "failed", exitCode: null, endedAt: new Date().toISOString() });
+      appendLedger(opts.cwd, { event: "completed", id, exitCode: null, detail: "spawn failed" });
+    }
+  });
+  child.unref();
+  const pid = typeof child.pid === "number" ? child.pid : null;
+  const rec: BgRecord = {
+    id,
+    sessionId: opts.sessionId,
+    adoptedBy: null,
+    cwd: opts.cwd,
+    command: opts.command,
+    note: opts.note ?? null,
+    pid,
+    startToken: pid === null ? null : processStartToken(pid),
+    status: "running",
+    exitCode: null,
+    startedAt: new Date().toISOString(),
+    endedAt: null,
+    deliveredAt: null,
+  };
+  writeRecord(rec);
+  appendLedger(opts.cwd, { event: "registered", id, pid, command: opts.command });
+  return rec;
+}
+
+/**
+ * Cancel is only meaningful for something still running, and only for the process we
+ * actually started. Reconciling first stops us from overwriting a finished job's real
+ * outcome; the start-token check stops us from signalling a recycled PID's group.
+ */
+export function cancel(input: BgRecord, now: string = new Date().toISOString()): BgRecord {
+  const rec = reconcile(input);
+  if (rec.status !== "running") return rec;
+  // On Windows startToken is always null (no cheap start-time probe). Killing the helper
+  // also stopped its child in the measured run, but that ran under an OpenSSH session
+  // where a job object may have done the work, so an interactive session is not proven
+  // (030_windows_validation.md section 3).
+  const ours = rec.pid !== null && pidAlive(rec.pid) && (rec.startToken === null || processStartToken(rec.pid) === rec.startToken);
+  if (ours && rec.pid !== null) {
+    try {
+      // Negative pid targets the detached process group, so children die with the shell.
+      process.kill(-rec.pid, "SIGTERM");
+    } catch {
+      try {
+        process.kill(rec.pid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+    }
+  }
+  const next: BgRecord = { ...rec, status: "cancelled", endedAt: rec.endedAt ?? now };
+  writeRecord(next);
+  appendLedger(rec.cwd, { event: "cancelled", id: rec.id });
+  return next;
+}
+

--- a/plugins/codexclaw/components/bg-wake/src/store.ts
+++ b/plugins/codexclaw/components/bg-wake/src/store.ts
@@ -1,0 +1,116 @@
+/**
+ * store.ts — filesystem substrate for the bg registry.
+ *
+ * Layout (contract 010, "파일 레이아웃"):
+ *   <cwd>/.codexclaw/bg/
+ *     disabled        wake off flag; body is the ISO time it was set
+ *     enabled-at      ISO time of the last 'bg on'; wake ignores tasks that ended before it
+ *     <id>.json       record
+ *     <id>.out        merged stdout/stderr
+ *     <id>.exit       exit code, written by the detached shell itself
+ *     ledger.jsonl    append-only events
+ *
+ * Record writes are atomic (tmp + rename). The ledger is an append-only journal, so it
+ * uses appendFileSync instead. pabcd-state has an atomic-write module but
+ * cross-component imports are banned here (000_plan "제거를 쉽게 만드는 제약"), so this
+ * is a deliberate local copy of that one idea.
+ */
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, appendFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export const BG_DIRNAME = "bg";
+export const DISABLED_FILE = "disabled";
+export const ENABLED_AT_FILE = "enabled-at";
+export const LEDGER_FILE = "ledger.jsonl";
+
+export function bgDir(cwd: string): string {
+  return join(cwd, ".codexclaw", BG_DIRNAME);
+}
+export function recordPath(cwd: string, id: string): string {
+  return join(bgDir(cwd), id + ".json");
+}
+export function outPath(cwd: string, id: string): string {
+  return join(bgDir(cwd), id + ".out");
+}
+export function exitPath(cwd: string, id: string): string {
+  return join(bgDir(cwd), id + ".exit");
+}
+export function disabledPath(cwd: string): string {
+  return join(bgDir(cwd), DISABLED_FILE);
+}
+export function enabledAtPath(cwd: string): string {
+  return join(bgDir(cwd), ENABLED_AT_FILE);
+}
+
+export function ensureDir(cwd: string): string {
+  const dir = bgDir(cwd);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Atomic write: same-directory tmp then rename, so a reader never sees a torn file. */
+export function atomicWrite(path: string, text: string): void {
+  const tmp = path + ".tmp-" + process.pid + "-" + Date.now();
+  writeFileSync(tmp, text, "utf8");
+  renameSync(tmp, path);
+}
+
+export function readTextOrNull(path: string): string | null {
+  try {
+    if (!existsSync(path)) return null;
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function readJsonOrNull<T>(path: string): T | null {
+  const raw = readTextOrNull(path);
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function appendLedger(cwd: string, event: Record<string, unknown>): void {
+  try {
+    ensureDir(cwd);
+    appendFileSync(join(bgDir(cwd), LEDGER_FILE), JSON.stringify({ at: new Date().toISOString(), ...event }) + "\n", "utf8");
+  } catch {
+    // Ledger loss must never break a hook. FAIL-OPEN (010 "구현 제약 재확인").
+  }
+}
+
+export function listRecordIds(cwd: string): string[] {
+  try {
+    const dir = bgDir(cwd);
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => f.slice(0, -".json".length))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/** File mtime in ms, or null. Used to bound how long a half-written exit file is tolerated. */
+export function mtimeMs(path: string): number | null {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+export function removePath(path: string): void {
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    // best effort
+  }
+}
+

--- a/plugins/codexclaw/components/bg-wake/test/cli.test.ts
+++ b/plugins/codexclaw/components/bg-wake/test/cli.test.ts
@@ -1,0 +1,260 @@
+/**
+ * cli.test.ts — the CLI surface and one real end-to-end run.
+ *
+ * The unit tests above fabricate records; this file actually spawns a shell, so the
+ * "no watcher process" claim is exercised rather than asserted.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { run } from "../src/cli.ts";
+import { listRecords, readRecord, selectWake } from "../src/registry.ts";
+import { buildShell, buildWindowsHelper } from "../src/spawn.ts";
+import { disabledPath } from "../src/store.ts";
+
+function workspace(): string {
+  return mkdtempSync(join(tmpdir(), "bgcli-"));
+}
+
+async function settle(cwd: string, id: string, tries = 60): Promise<void> {
+  for (let i = 0; i < tries; i += 1) {
+    const rec = listRecords(cwd).find((r) => r.id === id);
+    if (rec && rec.status !== "running") return;
+    await delay(100);
+  }
+}
+
+test("a real command runs detached and records its own exit code", async (t) => {
+  if (process.platform === "win32") return t.skip("posix shell path");
+  const cwd = workspace();
+  process.env.CODEX_THREAD_ID = "S1";
+  const started = run(["run", "--note", "smoke", "--", "sh", "-c", "echo hello; exit 3"], cwd);
+  assert.equal(started.code, 0);
+  const id = started.out.trim();
+  await settle(cwd, id);
+  const rec = readRecord(cwd, id);
+  assert.equal(rec?.status, "failed");
+  assert.equal(rec?.exitCode, 3);
+  const got = run(["get", id, "--tail", "5"], cwd);
+  assert.match(got.out, /hello/);
+});
+
+test("an argument with spaces and quotes survives the shell", async (t) => {
+  if (process.platform === "win32") return t.skip("posix shell path");
+  const cwd = workspace();
+  process.env.CODEX_THREAD_ID = "S1";
+  const id = run(["run", "--", "printf", "%s", "it's a test"], cwd).out.trim();
+  await settle(cwd, id);
+  assert.match(run(["get", id, "--tail", "5"], cwd).out, /it's a test/);
+});
+
+test("run without -- prints usage and fails", () => {
+  const cwd = workspace();
+  const res = run(["run", "echo", "hi"], cwd);
+  assert.equal(res.code, 1);
+  assert.match(res.out, /cxc bg run/);
+});
+
+test("cancel of a missing id is not an error", () => {
+  const cwd = workspace();
+  const res = run(["cancel", "nope"], cwd);
+  assert.equal(res.code, 0);
+});
+
+test("cancel does not overwrite an already finished job", async (t) => {
+  if (process.platform === "win32") return t.skip("posix shell path");
+  const cwd = workspace();
+  process.env.CODEX_THREAD_ID = "S1";
+  const id = run(["run", "--", "sh", "-c", "exit 0"], cwd).out.trim();
+  await settle(cwd, id);
+  run(["cancel", id], cwd);
+  assert.equal(readRecord(cwd, id)?.status, "complete", "a finished job keeps its real outcome");
+});
+
+test("on is idempotent and does not move the gate forward", async (t) => {
+  if (process.platform === "win32") return t.skip("posix shell path");
+  const cwd = workspace();
+  process.env.CODEX_THREAD_ID = "S1";
+  const id = run(["run", "--", "sh", "-c", "exit 0"], cwd).out.trim();
+  await settle(cwd, id);
+  assert.equal(selectWake(cwd, "S1").length, 1);
+  const again = run(["on"], cwd);
+  assert.match(again.out, /이미 ON/);
+  assert.equal(selectWake(cwd, "S1").length, 1, "a redundant 'on' must not swallow a pending completion");
+});
+
+test("off then on gates only what finished while off", async (t) => {
+  if (process.platform === "win32") return t.skip("posix shell path");
+  const cwd = workspace();
+  process.env.CODEX_THREAD_ID = "S1";
+  run(["off"], cwd);
+  assert.ok(existsSync(disabledPath(cwd)));
+  const id = run(["run", "--", "sh", "-c", "exit 0"], cwd).out.trim();
+  await settle(cwd, id);
+  run(["on"], cwd);
+  assert.equal(selectWake(cwd, "S1").length, 0, "finished during the off window");
+});
+
+test("drain works even while the wake is switched off", async (t) => {
+  if (process.platform === "win32") return t.skip("posix shell path");
+  const cwd = workspace();
+  process.env.CODEX_THREAD_ID = "S1";
+  const id = run(["run", "--", "sh", "-c", "exit 0"], cwd).out.trim();
+  await settle(cwd, id);
+  run(["off"], cwd);
+  const drained = run(["drain", "--session", "S1"], cwd);
+  assert.match(drained.out, new RegExp(id));
+  assert.notEqual(readRecord(cwd, id)?.deliveredAt, null);
+});
+
+test("drain without --session refuses", () => {
+  const cwd = workspace();
+  const res = run(["drain"], cwd);
+  assert.equal(res.code, 1);
+});
+
+test("status reports the switch and the count", () => {
+  const cwd = workspace();
+  assert.match(run(["status"], cwd).out, /wake: ON/);
+  run(["off"], cwd);
+  assert.match(run(["status"], cwd).out, /wake: OFF/);
+});
+
+test("removal prints all eight steps", () => {
+  const out = run(["removal"], workspace()).out;
+  for (let i = 1; i <= 8; i += 1) assert.match(out, new RegExp("^" + i + "\\.", "m"));
+});
+
+test("the windows path spawns node directly, with no cmd quoting in between", () => {
+  const { file, args } = buildShell(["npm", "run", "build"], "C:\\o.txt", "C:\\e.txt", "C:\\h.cjs");
+  if (process.platform !== "win32") {
+    // buildShell only takes the windows branch on win32; assert the posix shape here.
+    assert.equal(file, "/bin/sh");
+    return;
+  }
+  assert.equal(file, process.execPath);
+  assert.deepEqual(args, ["C:\\h.cjs", "C:\\o.txt", "C:\\e.txt", "npm", "run", "build"]);
+});
+
+test("the windows helper actually runs, captures output and records the exit code", async () => {
+  // The helper is plain Node, so its behaviour can be exercised anywhere — this is the
+  // part the previous string-matching tests did not lock.
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const run2 = promisify(execFile);
+  const cwd = workspace();
+  const helperPath = join(cwd, "h.cjs");
+  const outFile = join(cwd, "o.txt");
+  const exitFile = join(cwd, "e.txt");
+  writeFileSync(helperPath, buildWindowsHelper(), "utf8");
+  await run2(process.execPath, [helperPath, outFile, exitFile, process.execPath, "-e",
+    "console.log('on stdout'); console.error('on stderr'); process.exit(5)"]);
+  assert.equal(readFileSync(exitFile, "utf8").trim(), "5");
+  const captured = readFileSync(outFile, "utf8");
+  assert.match(captured, /on stdout/);
+  assert.match(captured, /on stderr/, "stderr must land in the same file");
+});
+
+test("the windows helper records 127 when the executable does not exist", async () => {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const run2 = promisify(execFile);
+  const cwd = workspace();
+  const helperPath = join(cwd, "h.cjs");
+  writeFileSync(helperPath, buildWindowsHelper(), "utf8");
+  await run2(process.execPath, [helperPath, join(cwd, "o.txt"), join(cwd, "e.txt"), "definitely-not-a-real-binary-xyz"]);
+  assert.equal(readFileSync(join(cwd, "e.txt"), "utf8").trim(), "127");
+});
+
+test("the windows helper preserves arguments byte-for-byte", async () => {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const run2 = promisify(execFile);
+  const cwd = workspace();
+  const helperPath = join(cwd, "h.cjs");
+  const outFile = join(cwd, "o.txt");
+  writeFileSync(helperPath, buildWindowsHelper(), "utf8");
+  const args = ["a b", "x&y", "50%", 'q"uote', "excl!am", "semi;colon"];
+  await run2(process.execPath, [helperPath, outFile, join(cwd, "e.txt"), process.execPath, "-e",
+    "console.log(JSON.stringify(process.argv.slice(1)))", ...args]);
+  assert.deepEqual(JSON.parse(readFileSync(outFile, "utf8").trim()), args);
+});
+
+test("an unknown verb prints usage without failing", () => {
+  const res = run(["nope"], workspace());
+  assert.equal(res.code, 0);
+  assert.match(res.out, /cxc bg run/);
+});
+
+
+test("a half-written exit file keeps the job running instead of failing it", async (t) => {
+  if (process.platform === "win32") return t.skip("posix shell path");
+  const { writeFileSync } = await import("node:fs");
+  const { reconcile, writeRecord } = await import("../src/registry.ts");
+  const { exitPath, ensureDir } = await import("../src/store.ts");
+  const cwd = workspace();
+  ensureDir(cwd);
+  const rec = {
+    id: "half", sessionId: "S1", adoptedBy: null, cwd, command: ["x"], note: null,
+    pid: 2147483646, startToken: null, status: "running" as const, exitCode: null,
+    startedAt: "2026-09-09T00:00:00.000Z", endedAt: null, deliveredAt: null,
+  };
+  writeRecord(rec);
+  writeFileSync(exitPath(cwd, "half"), "", "utf8");
+  // The shell created the file, so its code is on the way even though the PID is gone.
+  assert.equal(reconcile(rec).status, "running");
+});
+
+test("a hook payload without session_id falls back to CODEX_THREAD_ID", async () => {
+  const { handleStop } = await import("../src/hook.ts");
+  const { writeRecord } = await import("../src/registry.ts");
+  const { ensureDir } = await import("../src/store.ts");
+  const cwd = workspace();
+  ensureDir(cwd);
+  writeRecord({
+    id: "envwake", sessionId: "S7", adoptedBy: null, cwd, command: ["x"], note: null,
+    pid: null, startToken: null, status: "complete", exitCode: 0,
+    startedAt: "2026-09-09T00:00:00.000Z", endedAt: "2026-09-09T00:01:00.000Z", deliveredAt: null,
+  });
+  const out = handleStop({ cwd }, cwd, { CODEX_THREAD_ID: "S7" } as NodeJS.ProcessEnv);
+  assert.match(out, /envwake/);
+});
+
+test("run -- exit N still records the code (subshell, not a brace group)", async (t) => {
+  if (process.platform === "win32") return t.skip("posix shell path");
+  const { readRecord } = await import("../src/registry.ts");
+  const cwd = workspace();
+  process.env.CODEX_THREAD_ID = "S1";
+  const id = run(["run", "--", "exit", "7"], cwd).out.trim();
+  await settle(cwd, id);
+  assert.equal(readRecord(cwd, id)?.exitCode, 7, "a brace group would have taken the wrapper down with it");
+});
+
+test("spawning a missing binary does not throw into the parent", () => {
+  const cwd = workspace();
+  process.env.CODEX_THREAD_ID = "S1";
+  const res = run(["run", "--", "definitely-not-a-real-binary-xyz"], cwd);
+  assert.equal(res.code, 0);
+});
+
+test("a stale half-written exit file with no pid eventually fails instead of hanging", async () => {
+  const { writeFileSync, utimesSync } = await import("node:fs");
+  const { reconcile, writeRecord, PENDING_EXIT_GRACE_MS } = await import("../src/registry.ts");
+  const { exitPath, ensureDir } = await import("../src/store.ts");
+  const cwd = workspace();
+  ensureDir(cwd);
+  const rec = {
+    id: "stuck", sessionId: "S1", adoptedBy: null, cwd, command: ["x"], note: null,
+    pid: null, startToken: null, status: "running" as const, exitCode: null,
+    startedAt: "2026-09-09T00:00:00.000Z", endedAt: null, deliveredAt: null,
+  };
+  writeRecord(rec);
+  const p = exitPath(cwd, "stuck");
+  writeFileSync(p, "", "utf8");
+  const old = (Date.now() - PENDING_EXIT_GRACE_MS - 5000) / 1000;
+  utimesSync(p, old, old);
+  assert.equal(reconcile(rec).status, "failed", "no pid must not mean 'running forever'");
+});

--- a/plugins/codexclaw/components/bg-wake/test/hook.test.ts
+++ b/plugins/codexclaw/components/bg-wake/test/hook.test.ts
@@ -1,0 +1,137 @@
+/**
+ * hook.test.ts — the switch, the wake, and the fail-open contract.
+ *
+ * These three are the ones that can hurt a user: a hook that blocks forever, a hook
+ * that swallows a completion, and a hook that reports an error in a way Codex reads
+ * as a block. Everything else is convenience.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleSessionStart, handleStop, handleUserPromptSubmit } from "../src/hook.ts";
+import { readRecord, writeRecord, type BgRecord } from "../src/registry.ts";
+import { atomicWrite, disabledPath, ensureDir } from "../src/store.ts";
+
+function workspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "bgwake-"));
+  mkdirSync(join(dir, ".codexclaw"), { recursive: true });
+  ensureDir(dir);
+  return dir;
+}
+
+function done(cwd: string, id: string, sessionId: string | null, over: Partial<BgRecord> = {}): BgRecord {
+  const rec: BgRecord = {
+    id,
+    sessionId,
+    adoptedBy: null,
+    cwd,
+    command: ["npm", "run", "build"],
+    note: null,
+    pid: null,
+    startToken: null,
+    status: "complete",
+    exitCode: 0,
+    startedAt: "2026-09-09T00:00:00.000Z",
+    endedAt: "2026-09-09T00:04:12.000Z",
+    deliveredAt: null,
+    ...over,
+  };
+  writeRecord(rec);
+  return rec;
+}
+
+const NO_ENV = {} as NodeJS.ProcessEnv;
+
+test("Stop blocks once for an undelivered completion, then releases", () => {
+  const cwd = workspace();
+  done(cwd, "build1", "S1");
+  const first = handleStop({ session_id: "S1", cwd }, cwd, NO_ENV);
+  const parsed = JSON.parse(first);
+  assert.equal(parsed.decision, "block");
+  assert.ok(parsed.reason.length > 0, "an empty reason is a Failed hook, not a block");
+  assert.match(parsed.reason, /build1/);
+  assert.equal(readRecord(cwd, "build1")?.deliveredAt !== null, true);
+  // The second Stop is the one that would loop forever if deliveredAt were not stamped.
+  assert.equal(handleStop({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+});
+
+test("Stop releases when nothing has completed", () => {
+  const cwd = workspace();
+  // startedAt must be recent: an old pid-less record now reconciles to failed, which
+  // is the point of the spawn-failure backstop.
+  done(cwd, "still", "S1", { status: "running", endedAt: null, exitCode: null, startedAt: new Date().toISOString() });
+  assert.equal(handleStop({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+});
+
+test("Stop does not wake another session's task", () => {
+  const cwd = workspace();
+  done(cwd, "theirs", "OTHER");
+  assert.equal(handleStop({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+});
+
+test("the off flag silences every hook immediately", () => {
+  const cwd = workspace();
+  done(cwd, "build1", "S1");
+  atomicWrite(disabledPath(cwd), new Date().toISOString());
+  assert.equal(handleStop({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+  assert.equal(handleUserPromptSubmit({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+  assert.equal(handleSessionStart({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+  assert.equal(readRecord(cwd, "build1")?.deliveredAt, null, "a silenced hook must not consume the completion");
+});
+
+test("CXC_BGWAKE=0 silences every hook", () => {
+  const cwd = workspace();
+  done(cwd, "build1", "S1");
+  const env = { CXC_BGWAKE: "0" } as NodeJS.ProcessEnv;
+  assert.equal(handleStop({ session_id: "S1", cwd }, cwd, env), "");
+  assert.equal(handleUserPromptSubmit({ session_id: "S1", cwd }, cwd, env), "");
+  assert.equal(readRecord(cwd, "build1")?.deliveredAt, null);
+});
+
+test("UserPromptSubmit injects and never decides", () => {
+  const cwd = workspace();
+  done(cwd, "build1", "S1");
+  const out = handleUserPromptSubmit({ session_id: "S1", cwd }, cwd, NO_ENV);
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.match(parsed.hookSpecificOutput.additionalContext, /build1/);
+  assert.equal("decision" in parsed, false, "a decision here would reject the user's prompt");
+});
+
+test("SessionStart adopts a previous session's undelivered completion", () => {
+  const cwd = workspace();
+  done(cwd, "old", "GONE");
+  const out = handleSessionStart({ session_id: "S2", cwd }, cwd, NO_ENV);
+  assert.match(out, /hookSpecificOutput/);
+  assert.equal(readRecord(cwd, "old")?.adoptedBy, "S2");
+  // Adoption is not delivery: the next Stop is what actually hands it over.
+  assert.equal(readRecord(cwd, "old")?.deliveredAt, null);
+  const parsed = JSON.parse(handleStop({ session_id: "S2", cwd }, cwd, NO_ENV));
+  assert.equal(parsed.decision, "block");
+});
+
+test("a corrupt record never blocks the session", () => {
+  const cwd = workspace();
+  writeFileSync(join(cwd, ".codexclaw", "bg", "broken.json"), "{ not json", "utf8");
+  assert.equal(handleStop({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+  assert.equal(handleUserPromptSubmit({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+  assert.equal(handleSessionStart({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+});
+
+test("a missing registry is silence, not an error", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "bgwake-bare-"));
+  assert.equal(handleStop({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+  assert.equal(handleSessionStart({ session_id: "S1", cwd }, cwd, NO_ENV), "");
+});
+
+test("a wake carries at most five completions", () => {
+  const cwd = workspace();
+  for (let i = 0; i < 8; i += 1) done(cwd, "t" + i, "S1", { endedAt: "2026-09-09T00:0" + i + ":00.000Z" });
+  const parsed = JSON.parse(handleStop({ session_id: "S1", cwd }, cwd, NO_ENV));
+  assert.match(parsed.reason, /5건/);
+  const remaining = ["t0", "t1", "t2", "t3", "t4", "t5", "t6", "t7"].filter((id) => readRecord(cwd, id)?.deliveredAt === null);
+  assert.equal(remaining.length, 3);
+});
+

--- a/plugins/codexclaw/components/bg-wake/test/registry.test.ts
+++ b/plugins/codexclaw/components/bg-wake/test/registry.test.ts
@@ -1,0 +1,98 @@
+/**
+ * registry.test.ts — daemon-free reconciliation and the enable-gate.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { reconcile, selectWake, writeRecord, listRecords, type BgRecord } from "../src/registry.ts";
+import { atomicWrite, enabledAtPath, ensureDir, exitPath } from "../src/store.ts";
+import { buildShell, newId } from "../src/spawn.ts";
+
+function workspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "bgreg-"));
+  ensureDir(dir);
+  return dir;
+}
+
+function running(cwd: string, id: string, pid: number | null): BgRecord {
+  const rec: BgRecord = {
+    id, sessionId: "S1", adoptedBy: null, cwd, command: ["sleep", "1"], note: null,
+    pid, startToken: null, status: "running", exitCode: null,
+    startedAt: "2026-09-09T00:00:00.000Z", endedAt: null, deliveredAt: null,
+  };
+  writeRecord(rec);
+  return rec;
+}
+
+test("an exit file completes the record without any watcher", () => {
+  const cwd = workspace();
+  const rec = running(cwd, "a", 999999);
+  writeFileSync(exitPath(cwd, "a"), "0", "utf8");
+  const out = reconcile(rec);
+  assert.equal(out.status, "complete");
+  assert.equal(out.exitCode, 0);
+  assert.notEqual(out.endedAt, null);
+});
+
+test("a non-zero exit code is a failure, not a completion", () => {
+  const cwd = workspace();
+  const rec = running(cwd, "b", 999999);
+  writeFileSync(exitPath(cwd, "b"), "1", "utf8");
+  assert.equal(reconcile(rec).status, "failed");
+});
+
+test("a vanished shell with no exit file is failed with an unknown code", () => {
+  const cwd = workspace();
+  // PID 0 is never a live child here; the point is the honest 'we do not know' path.
+  const rec = running(cwd, "c", 2147483646);
+  const out = reconcile(rec);
+  assert.equal(out.status, "failed");
+  assert.equal(out.exitCode, null);
+});
+
+test("a fresh record with no pid stays running, an old one does not", () => {
+  const cwd = workspace();
+  const fresh = { ...running(cwd, "d", null), startedAt: new Date().toISOString() };
+  assert.equal(reconcile(fresh).status, "running");
+  // A shell that never spawned leaves no pid and no exit file. The async 'error'
+  // handler can be lost when the CLI exits, so age is the backstop.
+  const old = running(cwd, "e", null);
+  assert.equal(reconcile(old).status, "failed");
+});
+
+test("re-enabling does not stampede completions that finished while off", () => {
+  const cwd = workspace();
+  const rec: BgRecord = {
+    id: "old", sessionId: "S1", adoptedBy: null, cwd, command: ["x"], note: null,
+    pid: null, startToken: null, status: "complete", exitCode: 0,
+    startedAt: "2026-09-09T00:00:00.000Z", endedAt: "2026-09-09T00:01:00.000Z", deliveredAt: null,
+  };
+  writeRecord(rec);
+  atomicWrite(enabledAtPath(cwd), "2026-09-09T00:05:00.000Z");
+  assert.equal(selectWake(cwd, "S1").length, 0, "finished before the switch came back on");
+  writeRecord({ ...rec, id: "new", endedAt: "2026-09-09T00:06:00.000Z" });
+  assert.equal(selectWake(cwd, "S1").length, 1);
+});
+
+test("listRecords tolerates junk in the directory", () => {
+  const cwd = workspace();
+  writeFileSync(join(cwd, ".codexclaw", "bg", "x.json"), "nope", "utf8");
+  assert.deepEqual(listRecords(cwd), []);
+});
+
+test("the posix shell records its own exit code", () => {
+  if (process.platform === "win32") return;
+  const { file, args } = buildShell(["echo", "hi there"], "/tmp/o", "/tmp/e");
+  assert.equal(file, "/bin/sh");
+  assert.match(args[1] ?? "", /printf %s \$\? >/);
+  assert.match(args[1] ?? "", /'hi there'/);
+});
+
+test("ids do not collide with existing records", () => {
+  const cwd = workspace();
+  running(cwd, "taken", null);
+  assert.notEqual(newId(cwd, "taken"), "taken");
+});
+

--- a/plugins/codexclaw/hooks/session-start-adopting-background-completions.json
+++ b/plugins/codexclaw/hooks/session-start-adopting-background-completions.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/components/bg-wake/dist/cli.js\" hook session-start",
+            "timeout": 10,
+            "statusMessage": "(codexclaw) Adopting background completions"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/codexclaw/hooks/stop-waking-on-background-completion.json
+++ b/plugins/codexclaw/hooks/stop-waking-on-background-completion.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/components/bg-wake/dist/cli.js\" hook stop",
+            "timeout": 10,
+            "statusMessage": "(codexclaw) Checking background task completions"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/codexclaw/hooks/user-prompt-submit-delivering-background-completions.json
+++ b/plugins/codexclaw/hooks/user-prompt-submit-delivering-background-completions.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/components/bg-wake/dist/cli.js\" hook user-prompt-submit",
+            "timeout": 10,
+            "statusMessage": "(codexclaw) Delivering background completions"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -197,6 +197,12 @@
       "matcher": "^(apply_patch|Write|Edit)$"
     },
     {
+      "file": "session-start-adopting-background-completions.json",
+      "event": "SessionStart",
+      "component": "bg-wake",
+      "matcher": null
+    },
+    {
       "file": "session-start-announcing-map-affordance.json",
       "event": "SessionStart",
       "component": "cxc-ops",
@@ -245,6 +251,12 @@
       "matcher": null
     },
     {
+      "file": "stop-waking-on-background-completion.json",
+      "event": "Stop",
+      "component": "bg-wake",
+      "matcher": null
+    },
+    {
       "file": "subagent-stop-observing-review.json",
       "event": "SubagentStop",
       "component": "pabcd-state",
@@ -263,6 +275,12 @@
       "matcher": null
     },
     {
+      "file": "user-prompt-submit-delivering-background-completions.json",
+      "event": "UserPromptSubmit",
+      "component": "bg-wake",
+      "matcher": null
+    },
+    {
       "file": "user-prompt-submit-detecting-recall-intent.json",
       "event": "UserPromptSubmit",
       "component": "recall",
@@ -276,6 +294,12 @@
     }
   ],
   "components": [
+    {
+      "folder": "bg-wake",
+      "packageName": "@codexclaw/bg-wake",
+      "version": "0.2.24",
+      "hasTests": true
+    },
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",

--- a/plugins/codexclaw/scripts/build.mjs
+++ b/plugins/codexclaw/scripts/build.mjs
@@ -24,7 +24,13 @@ const here = dirname(fileURLToPath(import.meta.url));
 const pluginRoot = resolve(here, "..");
 export const componentsRoot = join(pluginRoot, "components");
 
-export const COMPONENTS = ["pabcd-state", "config-guard", "provider-bridge", "subagent-config", "cxc-ops", "recall", "messenger-bridge", "skill-search"];
+// Required components are listed unconditionally: a missing directory there is a broken
+// checkout and the build should fail loudly. Only OPTIONAL_COMPONENTS are tolerated when
+// absent, which is what lets bg-wake be uninstalled by deleting its directory without
+// taking the build down before the rest of its checklist is applied.
+export const REQUIRED_COMPONENTS = ["pabcd-state", "config-guard", "provider-bridge", "subagent-config", "cxc-ops", "recall", "messenger-bridge", "skill-search"];
+export const OPTIONAL_COMPONENTS = ["bg-wake"];
+export const COMPONENTS = [...REQUIRED_COMPONENTS, ...OPTIONAL_COMPONENTS.filter((c) => existsSync(join(componentsRoot, c)))];
 
 // Markers that must NOT appear in shipped runtime sources or compiled output or the manifest.
 const PLACEHOLDER_RE = /\[TODO\]|TODO\(|FIXME|\bTBD\b/;

--- a/plugins/codexclaw/test/hook-e2e.test.mjs
+++ b/plugins/codexclaw/test/hook-e2e.test.mjs
@@ -131,7 +131,10 @@ test("WP7/G19: every manifest hook command resolves to an existing dist entrypoi
   // pre-tool-use-guarding-managed-worktree-deletion).
   // 260909 wp1-A: 23 -> 24 with the memory-write gate
   // (pre-tool-use-guarding-memory-write).
-  assert.ok(Array.isArray(manifest.hooks) && manifest.hooks.length === 25, "expected 25 declared hooks");
+  // 260910: 25 -> 28 with bg-wake's three hooks. The pin is deliberate — it is the
+  // machine-checked partner of the README badges and inventory.json, so an optional
+  // component removes itself here too (see `cxc bg removal`).
+  assert.ok(Array.isArray(manifest.hooks) && manifest.hooks.length === 28, "expected 28 declared hooks");
   for (const rel of manifest.hooks) {
     const { distAbs } = readHookCommand(rel);
     // Settle-retry: a concurrent rebuild (C10) may briefly unlink dist mid-run.


### PR DESCRIPTION
## What breaks today

A background subagent or shell can finish after the parent turn is already over, and nothing wakes the agent. V1 injects the notification with `inject_fragment_without_turn`; V2 forwards the child's terminal event with `trigger_turn = false`. Either way the completion sits in history until some unrelated reason opens a turn.

So tracking a long job means one of two bad shapes: hold the turn open polling `wait_agent`, or end the turn and lose the result. Upstream has the same reports — openai/codex#15723, #22003, #42908.

## What this adds

```
cxc bg run --note "nightly build" -- npm run build   # returns an id, does not hold the turn
cxc bg list                                          # the model can see background work; /ps only shows the human
cxc bg get <id> --tail 40
```

When the job finishes, the Stop hook continues the turn once with a summary. If the turn already ended, the next prompt carries it. If the session changed, SessionStart adopts the record so a later turn can deliver it. Each completion wakes at most once, keyed on `deliveredAt`.

## How it is switched off

`cxc bg off` writes a file flag the hooks check on their next run. That is the only switch that reaches a live session: hook processes replay an environment snapshot taken at session start (`hooks/src/registry.rs:71`, `engine/command_runner.rs:425-427`), so `CXC_BGWAKE=0` only affects sessions started afterwards. Both are supported and the difference is documented.

`cxc bg removal` prints a nine-step uninstall. That list was applied for real and then reverted; build, test and gate passed in both states. It is nine steps and not "delete the directory", which the component README says plainly.

## Design notes

No daemon. On POSIX the spawned shell records its own exit code and a reader reconciles from that file plus PID liveness. Nothing reads Codex internals — `unified_exec` sessions and subagent threads are left alone, so an upstream change does not take this with it.

Hook failure is empty stdout and exit 0, never a stack trace: Codex reads exit 2 plus stderr as a Stop block, which is the opposite of failing open.

No existing component's `src/` is touched. The wiring outside the component is the manifest, the build's `OPTIONAL_COMPONENTS` list, the test glob, both dispatchers, inventory and the hook-count pin.

## Windows

The first Windows implementation shipped as a cmd batch redirecting the command's output to a file. On a real Windows host (10.0.26200) that file came back empty every time while the exit code was recorded correctly.

Narrowing it took five variants under the product condition, with the parent exiting immediately:

| variant | result |
|---|---|
| detached + fd, spawn the target directly | captured |
| detached + ignore, spawn the target directly | empty |
| detached + ignore, 1-hop cmd batch redirect | empty (what shipped) |
| detached + ignore, 2-hop nested `cmd /c` | captured |
| detached + ignore, 2-hop Node helper + fd | captured |

A first hop launched by libuv with detached and `stdio: "ignore"` leaves its external children with no usable stdout; a second hop that owns a real handle works. So Windows now uses a Node helper as that second hop, which also removes cmd quoting entirely.

Re-measured on the same host through the product code path: exit codes 0 and 3 recorded, stdout and stderr both captured, arguments preserved byte-for-byte across `a b`, `x&y`, `50%`, `q"uote`, `excl!am`, `semi;colon`, a missing executable recorded as 127, and cancel leaving no live helper.

The `bare exit` limitation is gone with cmd. A different one replaces it: cmd builtins are not executables, so `cxc bg run -- echo hi` fails and `cxc bg run -- cmd /c echo hi` works. That is in the README.

Still unmeasured and written down as such: an interactive Windows session rather than SSH, and whether a cmd wrapper could have been kept.

## Validation

- `npm run build`, `npm test`, `npm run gate` pass on this branch after rebasing onto `dev`
- 39 component tests, three of which execute the Windows helper rather than matching its source text
- Remote unit run on the Windows host: 31 pass, 8 skipped, 0 fail
- Removal checklist applied and reverted, with build, test and gate passing both ways

## Rebase note

`plugins/codexclaw/test/hook-e2e.test.mjs` moves its hook-count pin from 25 to 28. The pin is deliberate upstream, so it is updated rather than loosened, and step 9 of the removal checklist reverses it.
