### PR TITLE
fix(pabcd-state): classify memory-write gate shell commands by write destination

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C945_passing-brightgreen" alt="2,945 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C951_passing-brightgreen" alt="2,951 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C945_passing-brightgreen" alt="2,945 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C951_passing-brightgreen" alt="2,951 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C945_passing-brightgreen" alt="2,945 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C951_passing-brightgreen" alt="2,951 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260910_memory-followup-roadmap/010_wp1_memory-write-gate.md
+++ b/devlog/_plan/260910_memory-followup-roadmap/010_wp1_memory-write-gate.md
@@ -85,7 +85,7 @@ export function shellPathTokens(command: string): string[] {
 
 | 파일 | NEW/MODIFY/DELETE | 변경 요지 | 예상 줄수 |
 |---|---|---|---|
-| `plugins/codexclaw/components/pabcd-state/src/shell-write-destinations.ts` | NEW | §4.1의 목적지 파서 전체(`splitShellSegments`, `skipQuoted`, `skipHeredoc`, `readToken`, `redirectDestinations`, `commandDestinations`, `shellWriteDestinations` export). 순수 함수, import 없음 (A/B8 분리) | ~300 |
+| `plugins/codexclaw/components/pabcd-state/src/shell-write-destinations.ts` | NEW | §4.1의 목적지 파서 전체(`splitShellSegments`, `skipQuoted`, `skipHeredoc`, `readToken`, `redirectDestinations`, `verbDestinations`, `shellWriteDestinations` export). 순수 함수, import 없음 (A/B8 분리) | ~300 |
 | `plugins/codexclaw/components/pabcd-state/src/memory-write-gate.ts` | MODIFY | `shellPathTokens`·write-verb 정규식 삭제. `import { shellWriteDestinations } from "./shell-write-destinations.ts"`. 셸 분기가 그 목록만 `isMemoryPath`로 본다 | 삭제 ~25, 추가 ~10 |
 | `plugins/codexclaw/components/pabcd-state/test/shell-write-destinations.test.ts` | NEW | 파서 단위 케이스: 공백 없는 `>`/`>>`/`>|`, `->`, 따옴표, heredoc, `2>/dev/null`, `&>`, tee/cp/mv/sed -i/perl -i | ~120 |
 | `plugins/codexclaw/components/pabcd-state/dist/shell-write-destinations.js` | NEW | `npm run build` 산출, src와 같은 커밋 | compileSource 결과 |
@@ -104,7 +104,7 @@ export function shellPathTokens(command: string): string[] {
 
 before (`:156-170`, `:207-219`): §2 인용과 동일. `export function shellPathTokens`를 지운다. 이 이름을 다른 파일이 import하지 않는다 (워크트리 rg, 2026-09-10).
 
-after: `:156`–`:170`을 아래 블록으로 바꾸고, `classifyMemoryWrite`의 셸 분기를 그 다음 블록으로 바꾼다. 써드파티 import 없음. 기존 `node:os` / `node:path` / `./state.ts` / `./text-lines.ts`만 쓴다. `worktree-guard.ts` tokenizer는 heredoc 본문을 건너뛰지 않아 (`worktree-guard.ts:219-253`) 여기로 가져오지 않는다.
+after (A/B8 분리 기준): 아래 TS 블록은 **새 파일 `src/shell-write-destinations.ts` 전체**다(순수 함수, import 없음). `memory-write-gate.ts`에서는 (a) `:156`–`:170`의 `shellPathTokens`와 `:157-161` 주석을 삭제하고, (b) 상단 import에 `import { shellWriteDestinations } from "./shell-write-destinations.ts";`와 그 아래 `export { shellWriteDestinations } from "./shell-write-destinations.ts";`(re-export, 기존 테스트 파일이 같은 모듈에서 가져오기 위함)를 추가하며, (c) `classifyMemoryWrite`의 셸 분기(`:207-219`)만 이 절 말미의 after 블록으로 바꾼다. 게이트의 다른 import(`node:os` / `node:path` / `./state.ts` / `./text-lines.ts`)는 그대로다. `worktree-guard.ts` tokenizer는 heredoc 본문을 건너뛰지 않아 (`worktree-guard.ts:219-253`) 여기로 가져오지 않는다.
 
 ```ts
 /**
@@ -443,7 +443,7 @@ write-verb 정규식은 제거한다. 목적지가 없으면 surface는 `""`이�
 
 before: `:174-183` 한 테스트. cat/rg 허용, echo 리다이렉트 메모리 거부, 워크트리 허용.
 
-after: 기존 테스트를 남기고, import에 `shellWriteDestinations`를 추가한 뒤 아래를 `:183` 다음에 붙인다. 테스트는 `node:test` + `node:assert/strict`, 소스는 `../src/memory-write-gate.ts` (확장자 포함). 메모리 경로는 픽스처에서 `CODEX_HOME=/h`의 `/h/memories`를 쓰고, 라이브 재현만 본문에 `~/.codex/memories` 물결표를 쓴다.
+after: 기존 테스트를 남기고, import 목록에 `shellWriteDestinations`를 추가하고(게이트가 `export { shellWriteDestinations } from "./shell-write-destinations.ts"`로 re-export하므로 같은 모듈에서 가져올 수 있다; 파서 단위 테스트는 `test/shell-write-destinations.test.ts`가 `../src/shell-write-destinations.ts`를 직접 import한다) 아래를 `:183` 다음에 붙인다. 테스트는 `node:test` + `node:assert/strict`, 소스는 `../src/memory-write-gate.ts` (확장자 포함). 메모리 경로는 픽스처에서 `CODEX_HOME=/h`의 `/h/memories`를 쓰고, 라이브 재현만 본문에 `~/.codex/memories` 물결표를 쓴다.
 
 ```ts
 test("shell surface: destination-based classification, not body path strings", () => {
@@ -469,6 +469,13 @@ test("shell surface: destination-based classification, not body path strings", (
   assert.equal(sedInPlace.target, `${mem}/MEMORY.md`);
   // (5) stdout redirect into memories remains a write.
   assert.equal(classify(`echo hi > ${mem}/notes.md`).surface, "shell");
+  // (A1) no-space redirections and `>|` clobber are real writes (audit round 1 found the
+  // first parser draft returning [] for all three).
+  assert.equal(classify(`echo hi>${mem}/n.md`).surface, "shell");
+  assert.equal(classify(`echo hi>>${mem}/n.md`).surface, "shell");
+  assert.equal(classify(`echo hi >| ${mem}/n.md`).surface, "shell");
+  assert.equal(classify(`echo 'a>b'`).surface, "");
+  assert.equal(classify(`grep -- '->' /w/f`).surface, "");
 
   // Live shape from notes/00 and notes/03 §6: worktree dest, tilde path in the body.
   const live = [
@@ -502,6 +509,10 @@ test("shellWriteDestinations: stderr, arrows in prose, and heredoc bodies are no
   );
   assert.deepEqual(shellWriteDestinations("sed -n '1p' /h/memories/MEMORY.md"), []);
   assert.deepEqual(shellWriteDestinations("sed -i 's/a/b/' /h/memories/MEMORY.md"), ["/h/memories/MEMORY.md"]);
+  assert.deepEqual(shellWriteDestinations("echo hi>/h/memories/n.md"), ["/h/memories/n.md"]);
+  assert.deepEqual(shellWriteDestinations("echo hi>>/h/memories/n.md"), ["/h/memories/n.md"]);
+  assert.deepEqual(shellWriteDestinations("echo hi >| /h/memories/n.md"), ["/h/memories/n.md"]);
+  assert.deepEqual(shellWriteDestinations("x -> y"), []);
 });
 ```
 
@@ -556,8 +567,10 @@ after: `:85` 다음에 항목을 넣는다. 표 `:47` matcher 열은 바꾸지 �
 Build 단계:
 
 ```bash
-cd plugins/codexclaw/components/pabcd-state && node --test test/memory-write-gate.test.ts
-npm run build
+node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/components/pabcd-state/test/*.test.ts"   # 레포 루트
+npm run build                                                                                   # 레포 루트 (scripts/build.mjs)
+git add -f plugins/codexclaw/components/pabcd-state/dist/shell-write-destinations.js plugins/codexclaw/components/pabcd-state/dist/memory-write-gate.js
+node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/test/dist-freshness.test.mjs" "plugins/codexclaw/test/packaging.test.mjs"
 node plugins/codexclaw/scripts/test.mjs plugins/codexclaw/test/dist-freshness.test.mjs
 ```
 
@@ -567,7 +580,7 @@ node plugins/codexclaw/scripts/test.mjs plugins/codexclaw/test/dist-freshness.te
 
 `memory-write-gate.ts`를 고치면 같은 커밋에 `npm run build` 결과 `plugins/codexclaw/components/pabcd-state/dist/memory-write-gate.js`를 담는다. `dist-freshness.test.mjs:40-47`가 이 파일의 커밋 바이트를 `compileSource(src)`와 비교한다. 빠지면 CI F1 실패 (260909 `000_plan.md:325` R-7).
 
-바뀔 dist 파일: `plugins/codexclaw/components/pabcd-state/dist/memory-write-gate.js` 하나. `dist/cli.js` / `dist/hook.js`는 이 src를 import만 하고 자체 바이트는 그대로다.
+바뀔 dist 파일: `plugins/codexclaw/components/pabcd-state/dist/memory-write-gate.js`(MODIFY)와 `dist/shell-write-destinations.js`(NEW). `dist/`는 루트 `.gitignore:2`에 있어 새 파일은 `git add -f`로 추적한다(§6 Build 블록). `packaging.test.mjs` L19가 src마다 tracked dist를 요구하므로 누락되면 CI가 잡는다. `dist/cli.js` / `dist/hook.js`는 이 src를 import만 하고 자체 바이트는 그대로다.
 
 ## 8. 위험·롤백
 
@@ -641,3 +654,22 @@ node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/test/dist-freshness.t
 - §8 known bypass 표에 "공백 없는 리다이렉션 / `>|` clobber"를 9번째 항목으로 추가하고 이 수정으로 닫힘을 명시.
 
 B8(파일 크기): `memory-write-gate.ts`가 315→약 600줄이 되므로 목적지 파서를 `pabcd-state/src/shell-write-destinations.ts`(NEW, 약 300줄)로 분리하고 `memory-write-gate.ts`는 `import { shellWriteDestinations } from "./shell-write-destinations.ts"`로 소비한다. 테스트는 `test/shell-write-destinations.test.ts`(NEW)에 파서 단위 케이스, `memory-write-gate.test.ts`에 게이트 통합 케이스로 나눈다. dist는 `dist/shell-write-destinations.js`가 추가된다(같은 커밋에 빌드).
+
+
+## P 재검증 (wp1 사이클, 2026-09-10 08:05)
+
+기준 트리 `db4e9412`(origin/dev, #123 머지 직후). `git diff --stat 369ed0e1 HEAD -- plugins/`에서 게이트 관련 파일 변경 없음(추가된 것은 `plugins/codexclaw/test/test-shard.test.mjs`뿐). §2 인용 행(`memory-write-gate.ts:156-170, 207-219, 237-245, 312-314`)은 그대로 유효하다. A 감사 반영(A1·B8)이 본문에 접혀 있으므로 이 문서를 그대로 실행한다. 브랜치 `codex/memory-l1-wp1-gate`(origin/dev 위), PR base dev.
+
+
+
+## A 감사 반영 (wp1 round 1, 2026-09-10)
+
+리뷰어(grok-4.6) FAIL 4건을 본문에 접었다.
+
+1. §4.1 인라인 vs B8 분리: §4.1의 TS 블록은 **새 파일 `src/shell-write-destinations.ts` 전용**이다. `memory-write-gate.ts`는 `shellPathTokens`(:156-170)와 write-verb 정규식(:212)을 삭제하고, 상단 import에 `import { shellWriteDestinations } from "./shell-write-destinations.ts";`를 추가하며, 셸 분기(:207-219)만 §4.1 말미의 after 블록으로 교체한다. 게이트는 `export { shellWriteDestinations } from "./shell-write-destinations.ts";`로 re-export해 기존 테스트 파일이 같은 모듈에서 가져올 수 있게 한다(§4.2 문구 수정).
+2. re-export: 위 1과 같다.
+3. dist: 루트 `.gitignore:2`가 `dist/`이므로 새 산출 `dist/shell-write-destinations.js`는 `git add -f`로 추적해야 한다. F1(dist-freshness)은 untracked dist를 건너뛰므로 `packaging.test.mjs` L19(src마다 tracked dist)를 검증에 추가했다(§6 Build 블록 수정).
+4. A1 픽스처: §4.2 게이트 테스트와 파서 단위 테스트에 `echo hi>P` / `>>P` / `>| P` deny와 `echo 'a>b'` / `grep -- '->'` allow를 추가했다.
+
+Medium(빌드 cwd): Build 블록을 레포 루트 명령으로 고쳤다. Low(심볼명): §3의 `commandDestinations`를 `verbDestinations`로 맞췄다.
+

--- a/devlog/_plan/260910_memory-followup-roadmap/071_wp1_receipt.md
+++ b/devlog/_plan/260910_memory-followup-roadmap/071_wp1_receipt.md
@@ -1,0 +1,33 @@
+# 071 — wp1 receipt: memory-write gate 목적지 분류
+
+날짜: 2026-09-10 (KST). 세션 01a0880e-149e-72d0-86db-53bd99bcac0e. 브랜치 `codex/memory-l1-wp1-gate`(origin/dev db4e9412 위), 구현 커밋 `1e4c5897`, PR #124.
+
+## 결론
+
+게이트의 셸 분기가 "명령 본문에 메모리 경로 문자열이 있는가"에서 "명령이 어디에 쓰는가"로 바뀌었다. 이 세션에서 네 번 재현된 오탐(읽기 sed, stderr 리다이렉션, devlog heredoc 본문)이 설치본 dist CLI 스모크에서 allow로 바뀌었고, 진짜 쓰기(`>`, 공백 없는 `>>`, `sed -i`)는 계속 deny다. 툴 이름 분기와 apply_patch/Write/Edit 분기는 손대지 않았다.
+
+## 무엇이 바뀌었나
+
+- NEW `components/pabcd-state/src/shell-write-destinations.ts`(388줄, 순수 함수) + `dist/shell-write-destinations.js`(`git add -f`, dist/는 gitignore).
+- MODIFY `memory-write-gate.ts`: `shellPathTokens`·write-verb 정규식 삭제, import + re-export, 셸 분기 교체(-50/+31).
+- 테스트: `shell-write-destinations.test.ts`(NEW, 4 케이스 — 리다이렉션 14형태, heredoc/herestring 4, 동사 14, 체인 2), `memory-write-gate.test.ts`(+2 테스트, A1 세 형태·라이브 heredoc 포함).
+- docs-site `reference/hooks.md` Pre-tool guards에 memory-write 항목.
+
+계획(010)과의 차이 두 가지. (1) `perl -pe`/`-ne` 같은 옵션 묶음 끝의 `e`가 다음 인자를 프로그램 텍스트로 소비하도록 보강 — 계획 파서는 `'s/a/b/'`를 목적지로 과수집했다(무해하지만 단위 테스트가 잡음). (2) heredoc 본문 제거를 `stripHeredocBodies` 전처리로 분리 — 계획의 `skipHeredoc`은 `cat <<EOF > /w/x.md`에서 같은 줄의 리다이렉션까지 건너뛰어 실제 쓰기를 놓쳤다. 둘 다 파서 단위 테스트가 고정한다.
+
+## 증거
+
+- receipt: `.codexclaw/evidence/01a0880e-149e-72d0-86db-53bd99bcac0e/test-receipt.json` — `/tmp/mfu-260910/check-wp1.sh`, exit 0. 내용: dist CLI `hook pre-tool-use-memory-write`에 stdin 픽스처 6건(allow 3: sed -n, 2>/dev/null, heredoc 본문 devlog; deny 3: `>`, 공백 없는 `>>`, `sed -i`) + pabcd-state 스위트 1216 pass/0 fail + dist-freshness·packaging 5 pass.
+- 원격 CI: PR #124 최종 head 전건 통과 후 머지(아래 갱신).
+- 감사: 010에 대해 grok-4.6 리뷰어 3라운드(FAIL 4 → FAIL 1 → PASS), 000 §A 감사 기록과 010 말미 참조.
+
+## 개선되지 않은 것 (LOOP-PESSIMIST-01)
+
+- 잔여 우회 `echo hi -> P`, 서브셸·변수 확장·`python -c`는 그대로다(early warning). 
+- 라이브 재검증(설치본 재설치 뒤 이 세션 형태의 명령이 실제로 통과하는지)은 머지·재설치 뒤에만 가능하다. 이 문서 시점에는 dist CLI 스모크까지만 확인했다.
+- 방향이 틀렸다는 신호: 재설치 후에도 같은 명령이 막히면 원인은 파서가 아니라 훅 matcher/툴 이름 매핑이다.
+
+## 다음
+
+wp2 P: 020을 현재 트리와 대조. `query-words.ts`의 VERSION 분류와 그룹 단위 완화.
+

--- a/docs-site/src/content/docs/reference/hooks.md
+++ b/docs-site/src/content/docs/reference/hooks.md
@@ -83,6 +83,13 @@ and is also unaffected.
   mentions already present in spawn messages; it never adds omitted role or surface skills.
 - **edit-lint / pre-tool-use (`apply_patch|Write|Edit`)** — lints structured edits before they
   apply.
+- **memory-write / pre-tool-use (`memories[._]?add_ad_hoc_note|apply_patch|Write|Edit|Bash`)** —
+  denies an unauthorized write into the Codex memories directory. The shell leg classifies by
+  write destination (`>`, `>>`, `>|`, `tee`, `sed -i`, `cp`/`mv` target, `perl -i`/`ruby -i`),
+  not by a memories path string in the command body, so `sed -n` reads, `2>/dev/null` stderr
+  redirects, and heredoc bodies that mention the memories path are allowed. Fail-open on crash.
+  Early warning, not enforcement: subshells, variable expansions, and `python -c` writers are
+  residual bypasses.
 
 ### Post-tool capture
 

--- a/plugins/codexclaw/components/pabcd-state/dist/memory-write-gate.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/memory-write-gate.js
@@ -50,6 +50,9 @@ import { homedir } from "node:os";
 import { isAbsolute, join, normalize, resolve, sep } from "node:path";
 import { readState, writeState } from "./state.js";
 import { splitLines } from "./text-lines.js";
+import { shellWriteDestinations } from "./shell-write-destinations.js";
+
+export { shellWriteDestinations } from "./shell-write-destinations.js";
 
 /**
  * Hook-facing names for the memory write tool. `memoriesadd_ad_hoc_note` is what
@@ -153,22 +156,6 @@ export function patchTargets(patchText        )           {
   return out;
 }
 
-/**
- * Shell tokens that could name a write destination. Deliberately BROAD and
- * path-shaped: it collects every token that mentions a memories path rather than
- * modelling redirection, `tee`, `sed -i` and friends separately. Over-collection is
- * safe here — the caller still requires the token to resolve under the memories
- * root, and the remedy for a false deny is one CLI grant.
- */
-export function shellPathTokens(command        )           {
-  const out           = [];
-  for (const token of command.split(/[\s;|&()<>]+/)) {
-    const cleaned = token.replace(/^["']|["']$/g, "");
-    if (cleaned.includes("memories")) out.push(cleaned);
-  }
-  return out;
-}
-
 
 
 
@@ -207,12 +194,12 @@ export function classifyMemoryWrite(
   if (SHELL_TOOLS.has(toolName)) {
     const command = typeof toolInput.command === "string" ? toolInput.command : "";
     if (command === "") return { surface: "", target: "" };
-    // A read is not a write. Only commands that can CREATE or MUTATE bytes are gated,
-    // so `cat`/`rg` over memories (what cxc-recall does constantly) stays free.
-    if (!/>>?|\btee\b|\bsed\b|\bcp\b|\bmv\b|\brm\b|\btouch\b|\bmkdir\b|\bdd\b|\bteee?\b|\bwrite\b|\binstall\b/.test(command)) {
-      return { surface: "", target: "" };
-    }
-    for (const token of shellPathTokens(command)) {
+    // Classify by WRITE DESTINATION (260910 wp1). A memories path that appears only
+    // as a read operand, inside quotes, or in a heredoc body is not a write, so
+    // `sed -n`, `rg ... 2>/dev/null` and a devlog heredoc whose body mentions the
+    // memories root stay free. Redirections, `tee`, `sed -i`, `cp`/`mv` targets and
+    // `perl -i`/`ruby -i` operands are the write surface.
+    for (const token of shellWriteDestinations(command)) {
       const abs = absolutize(token, cwd);
       if (isMemoryPath(abs, root)) return { surface: "shell", target: abs };
     }

--- a/plugins/codexclaw/components/pabcd-state/dist/shell-write-destinations.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/shell-write-destinations.js
@@ -1,0 +1,388 @@
+/**
+ * shell-write-destinations.ts — write-destination parser for MEMORY-WRITE-GATE-01
+ * (260910 wp1). Replaces the body-string token scan (`shellPathTokens`) that
+ * classified read-only `sed`, `2>/dev/null` and heredoc bodies mentioning the
+ * memories path as writes. Plan: devlog/_plan/260910_memory-followup-roadmap/010.
+ *
+ * Pure functions, no imports. The gate only asks one question of a shell command:
+ * which paths does it WRITE to? Everything else (reads, arguments that are not a
+ * destination, text inside quotes or heredoc bodies) is ignored.
+ */
+
+/**
+ * Write destinations named by a shell command. Quote- and heredoc-aware.
+ * A memories path that appears only in a heredoc body, a quoted pattern, or
+ * an argument that is not the write target is ignored.
+ *
+ * Counted as writes: stdout redirect `>`/`>>` (fd omitted or 1), `tee`
+ * operands, `sed -i`/`--in-place` file operands, `cp`/`mv` destination,
+ * `perl -i`/`ruby -i` file operands.
+ * Not writes: `2>`/`2>>`, `<<` heredoc, `<<<` herestring, `sed -n`.
+ */
+export function shellWriteDestinations(command        )           {
+  const dests           = [];
+  for (const segment of splitShellSegments(stripHeredocBodies(command))) {
+    dests.push(...redirectDestinations(segment));
+    dests.push(...verbDestinations(segment));
+  }
+  return dests;
+}
+
+/**
+ * Remove every heredoc BODY (the lines after a `<<DELIM` line up to and including
+ * the terminator line). The `<<DELIM` operator and the rest of its own line stay,
+ * so `cat <<EOF > /w/x.md` still shows its redirect target. Body text is exactly
+ * what must never count as a destination: a devlog brief whose body quotes the
+ * memories path is the false positive this parser exists to remove.
+ */
+function stripHeredocBodies(command        )         {
+  let out = "";
+  let i = 0;
+  while (i < command.length) {
+    const ch = command[i];
+    if (ch === "'" || ch === '"') {
+      const next = skipQuoted(command, i);
+      out += command.slice(i, next);
+      i = next;
+      continue;
+    }
+    if (ch === "<" && command[i + 1] === "<" && command[i + 2] !== "<") {
+      const afterDelim = skipHeredoc(command, i);
+      const delim = heredocDelimiter(command, i);
+      out += command.slice(i, afterDelim);
+      i = afterDelim;
+      if (delim === "") continue;
+      // Keep the rest of the operator's line, then drop the body.
+      let eol = command.indexOf("\n", i);
+      if (eol === -1) return out + command.slice(i);
+      out += command.slice(i, eol);
+      let j = eol + 1;
+      for (;;) {
+        const nl = command.indexOf("\n", j);
+        const line = nl === -1 ? command.slice(j) : command.slice(j, nl);
+        if (line === delim) {
+          j = nl === -1 ? command.length : nl + 1;
+          break;
+        }
+        if (nl === -1) {
+          j = command.length;
+          break;
+        }
+        j = nl + 1;
+      }
+      out += "\n";
+      i = j;
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/** The heredoc delimiter word at `<<` position `i`, unquoted; "" when absent. */
+function heredocDelimiter(s        , i        )         {
+  i += 2;
+  if (s[i] === "-") i++;
+  while (i < s.length && /\s/.test(s[i])) i++;
+  if (s[i] === "'" || s[i] === '"') {
+    const q = s[i++];
+    const start = i;
+    while (i < s.length && s[i] !== q) i++;
+    return s.slice(start, i);
+  }
+  const start = i;
+  while (i < s.length && /[A-Za-z0-9_]/.test(s[i])) i++;
+  return s.slice(start, i);
+}
+
+function splitShellSegments(command        )           {
+  const segments           = [];
+  let cur = "";
+  let i = 0;
+  while (i < command.length) {
+    const ch = command[i];
+    if (ch === "'" || ch === '"') {
+      const next = skipQuoted(command, i);
+      cur += command.slice(i, next);
+      i = next;
+      continue;
+    }
+    if (ch === "<" && command[i + 1] === "<" && command[i + 2] !== "<") {
+      const next = skipHeredoc(command, i);
+      cur += command.slice(i, next);
+      i = next;
+      continue;
+    }
+    if (ch === "|" && i > 0 && command[i - 1] === ">") {
+      // `>|` clobber redirection: keep the bar inside the current segment.
+      cur += ch;
+      i++;
+      continue;
+    }
+    if (ch === ";" || ch === "|" || (ch === "&" && command[i + 1] === "&")) {
+      if (cur.trim() !== "") segments.push(cur);
+      cur = "";
+      if (ch === "&") i++;
+      if (ch === "|" && command[i + 1] === "|") i++;
+      i++;
+      continue;
+    }
+    cur += ch;
+    i++;
+  }
+  if (cur.trim() !== "") segments.push(cur);
+  return segments;
+}
+
+function skipQuoted(s        , i        )         {
+  const q = s[i];
+  i++;
+  while (i < s.length) {
+    if (q === '"' && s[i] === "\\" && i + 1 < s.length) {
+      i += 2;
+      continue;
+    }
+    if (s[i] === q) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Skip a `<<` / `<<-` operator and its delimiter word only. Bodies are removed
+ * beforehand by stripHeredocBodies, so the rest of the line stays visible.
+ */
+function skipHeredoc(s        , i        )         {
+  i += 2;
+  if (s[i] === "-") i++;
+  while (i < s.length && /\s/.test(s[i])) i++;
+  if (s[i] === "'" || s[i] === '"') {
+    const q = s[i++];
+    while (i < s.length && s[i] !== q) i++;
+    if (s[i] === q) i++;
+    return i;
+  }
+  while (i < s.length && /[A-Za-z0-9_]/.test(s[i])) i++;
+  return i;
+}
+
+function readToken(s        , i        )                                  {
+  while (i < s.length && /\s/.test(s[i])) i++;
+  if (i >= s.length) return { token: "", next: i };
+  if (s[i] === "'" || s[i] === '"') {
+    const q = s[i];
+    const start = i + 1;
+    const end = skipQuoted(s, i) - 1;
+    return { token: s.slice(start, Math.max(start, end)), next: end + 1 };
+  }
+  const start = i;
+  while (i < s.length && !/\s/.test(s[i])) i++;
+  return { token: s.slice(start, i), next: i };
+}
+
+function redirectDestinations(segment        )           {
+  const dests           = [];
+  let i = 0;
+  while (i < segment.length) {
+    const ch = segment[i];
+    if (ch === "'" || ch === '"') {
+      i = skipQuoted(segment, i);
+      continue;
+    }
+    if (ch === "<" && segment[i + 1] === "<") {
+      if (segment[i + 2] === "<") {
+        const r = readToken(segment, i + 3);
+        i = r.next;
+        continue;
+      }
+      i = skipHeredoc(segment, i);
+      continue;
+    }
+    if (ch !== ">") {
+      i++;
+      continue;
+    }
+    let k = i - 1;
+    let fd = "";
+    if (k >= 0 && segment[k] === "&") {
+      fd = "&";
+      k--;
+    } else {
+      while (k >= 0 && segment[k] >= "0" && segment[k] <= "9") k--;
+      fd = segment.slice(k + 1, i);
+    }
+    const before = k < 0 ? "" : segment[k];
+    // A1 (audit round 1): no token-boundary requirement. `echo hi>PATH` is a real
+    // write. Only `->` (arrow) and `<>` are not redirections; quoted spans never
+    // reach here (skipQuoted).
+    if (before === "-" || before === "<") {
+      i++;
+      continue;
+    }
+    let opEnd = i + 1;
+    if (segment[opEnd] === ">") opEnd++;
+    else if (segment[opEnd] === "|") opEnd++; // `>|` clobber
+    if (segment[opEnd] === "&") {
+      const r = readToken(segment, opEnd + 1);
+      i = r.next;
+      continue;
+    }
+    const dest = readToken(segment, opEnd);
+    if (fd !== "2" && dest.token !== "" && !dest.token.startsWith("&")) dests.push(dest.token);
+    i = dest.next;
+  }
+  return dests;
+}
+
+function tokenize(segment        )           {
+  const tokens           = [];
+  let i = 0;
+  while (i < segment.length) {
+    if (segment[i] === "'" || segment[i] === '"') {
+      const r = readToken(segment, i);
+      tokens.push(r.token);
+      i = r.next;
+      continue;
+    }
+    if (segment[i] === "<" && segment[i + 1] === "<" && segment[i + 2] !== "<") {
+      i = skipHeredoc(segment, i);
+      continue;
+    }
+    if (/\s/.test(segment[i])) {
+      i++;
+      continue;
+    }
+    const r = readToken(segment, i);
+    if (r.token !== "") tokens.push(r.token);
+    i = r.next === i ? i + 1 : r.next;
+  }
+  return tokens;
+}
+
+function basename(p        )         {
+  const norm = p.replace(/\\/g, "/");
+  const idx = norm.lastIndexOf("/");
+  return idx === -1 ? norm : norm.slice(idx + 1);
+}
+
+function stripPrefixes(tokens          )           {
+  let rest = tokens;
+  for (;;) {
+    const head = rest[0] ? basename(rest[0]) : "";
+    if (head === "sudo" || head === "command" || head === "builtin") {
+      rest = rest.slice(1);
+      continue;
+    }
+    if (head === "env") {
+      rest = rest.slice(1);
+      while (rest.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(rest[0])) rest = rest.slice(1);
+      continue;
+    }
+    return rest;
+  }
+}
+
+function verbDestinations(segment        )           {
+  const rest = stripPrefixes(tokenize(segment));
+  const verb = rest[0] ? basename(rest[0]) : "";
+  const args = rest.slice(1);
+  if (verb === "tee") return teeDestinations(args);
+  if (verb === "sed") return sedInPlaceDestinations(args);
+  if (verb === "cp" || verb === "mv") return cpMvDestinations(args);
+  if (verb === "perl" || verb === "ruby") return interpInPlaceDestinations(args);
+  return [];
+}
+
+function teeDestinations(args          )           {
+  const out           = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--") {
+      out.push(...args.slice(i + 1));
+      break;
+    }
+    if (a.startsWith("-") && a !== "-") continue;
+    out.push(a);
+  }
+  return out;
+}
+
+function sedInPlaceDestinations(args          )           {
+  let inPlace = false;
+  let sawExpression = false;
+  const positional           = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--") {
+      positional.push(...args.slice(i + 1));
+      break;
+    }
+    if (a === "-i" || a === "--in-place" || a.startsWith("--in-place=") || (a.startsWith("-i") && a.length > 2)) {
+      inPlace = true;
+      if (a === "-i" && args[i + 1] !== undefined && (args[i + 1] === "" || /^\./.test(args[i + 1]))) i++;
+      continue;
+    }
+    if (a === "-e" || a === "-f" || a === "--expression" || a === "--file") {
+      sawExpression = true;
+      i++;
+      continue;
+    }
+    if (a.startsWith("-")) continue;
+    positional.push(a);
+  }
+  if (!inPlace) return [];
+  return sawExpression ? positional : positional.slice(1);
+}
+
+function cpMvDestinations(args          )           {
+  let targetDir                    ;
+  const positional           = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "-t" || a === "--target-directory") {
+      targetDir = args[++i];
+      continue;
+    }
+    if (a.startsWith("--target-directory=")) {
+      targetDir = a.slice("--target-directory=".length);
+      continue;
+    }
+    if (a === "--") {
+      positional.push(...args.slice(i + 1));
+      break;
+    }
+    if (a.startsWith("-")) continue;
+    positional.push(a);
+  }
+  if (targetDir) return [targetDir];
+  if (positional.length >= 2) return [positional[positional.length - 1]];
+  return [];
+}
+
+function interpInPlaceDestinations(args          )           {
+  let inPlace = false;
+  const positional           = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--") {
+      positional.push(...args.slice(i + 1));
+      break;
+    }
+    if (/^-[a-zA-Z]*i/.test(a)) {
+      inPlace = true;
+      // A bundle whose LAST letter is `e` (`-pie`, `-nie`) still takes the next
+      // argument as the program text.
+      if (/e$/.test(a) && !/^-i/.test(a)) i++;
+      continue;
+    }
+    if (a === "-e" || /^-[a-zA-Z]*e$/.test(a)) {
+      // `-e`, `-pe`, `-ne`: the program text is the next argument, never a file.
+      i++;
+      continue;
+    }
+    if (a.startsWith("-")) continue;
+    positional.push(a);
+  }
+  return inPlace ? positional : [];
+}

--- a/plugins/codexclaw/components/pabcd-state/src/memory-write-gate.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/memory-write-gate.ts
@@ -50,6 +50,9 @@ import { homedir } from "node:os";
 import { isAbsolute, join, normalize, resolve, sep } from "node:path";
 import { readState, writeState } from "./state.ts";
 import { splitLines } from "./text-lines.ts";
+import { shellWriteDestinations } from "./shell-write-destinations.ts";
+
+export { shellWriteDestinations } from "./shell-write-destinations.ts";
 
 /**
  * Hook-facing names for the memory write tool. `memoriesadd_ad_hoc_note` is what
@@ -153,22 +156,6 @@ export function patchTargets(patchText: string): string[] {
   return out;
 }
 
-/**
- * Shell tokens that could name a write destination. Deliberately BROAD and
- * path-shaped: it collects every token that mentions a memories path rather than
- * modelling redirection, `tee`, `sed -i` and friends separately. Over-collection is
- * safe here — the caller still requires the token to resolve under the memories
- * root, and the remedy for a false deny is one CLI grant.
- */
-export function shellPathTokens(command: string): string[] {
-  const out: string[] = [];
-  for (const token of command.split(/[\s;|&()<>]+/)) {
-    const cleaned = token.replace(/^["']|["']$/g, "");
-    if (cleaned.includes("memories")) out.push(cleaned);
-  }
-  return out;
-}
-
 export interface MemoryWriteAttempt {
   /** Why this call counts as a memory write; "" when it does not. */
   surface: "tool" | "edit" | "shell" | "";
@@ -207,12 +194,12 @@ export function classifyMemoryWrite(
   if (SHELL_TOOLS.has(toolName)) {
     const command = typeof toolInput.command === "string" ? toolInput.command : "";
     if (command === "") return { surface: "", target: "" };
-    // A read is not a write. Only commands that can CREATE or MUTATE bytes are gated,
-    // so `cat`/`rg` over memories (what cxc-recall does constantly) stays free.
-    if (!/>>?|\btee\b|\bsed\b|\bcp\b|\bmv\b|\brm\b|\btouch\b|\bmkdir\b|\bdd\b|\bteee?\b|\bwrite\b|\binstall\b/.test(command)) {
-      return { surface: "", target: "" };
-    }
-    for (const token of shellPathTokens(command)) {
+    // Classify by WRITE DESTINATION (260910 wp1). A memories path that appears only
+    // as a read operand, inside quotes, or in a heredoc body is not a write, so
+    // `sed -n`, `rg ... 2>/dev/null` and a devlog heredoc whose body mentions the
+    // memories root stay free. Redirections, `tee`, `sed -i`, `cp`/`mv` targets and
+    // `perl -i`/`ruby -i` operands are the write surface.
+    for (const token of shellWriteDestinations(command)) {
       const abs = absolutize(token, cwd);
       if (isMemoryPath(abs, root)) return { surface: "shell", target: abs };
     }

--- a/plugins/codexclaw/components/pabcd-state/src/shell-write-destinations.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/shell-write-destinations.ts
@@ -1,0 +1,388 @@
+/**
+ * shell-write-destinations.ts — write-destination parser for MEMORY-WRITE-GATE-01
+ * (260910 wp1). Replaces the body-string token scan (`shellPathTokens`) that
+ * classified read-only `sed`, `2>/dev/null` and heredoc bodies mentioning the
+ * memories path as writes. Plan: devlog/_plan/260910_memory-followup-roadmap/010.
+ *
+ * Pure functions, no imports. The gate only asks one question of a shell command:
+ * which paths does it WRITE to? Everything else (reads, arguments that are not a
+ * destination, text inside quotes or heredoc bodies) is ignored.
+ */
+
+/**
+ * Write destinations named by a shell command. Quote- and heredoc-aware.
+ * A memories path that appears only in a heredoc body, a quoted pattern, or
+ * an argument that is not the write target is ignored.
+ *
+ * Counted as writes: stdout redirect `>`/`>>` (fd omitted or 1), `tee`
+ * operands, `sed -i`/`--in-place` file operands, `cp`/`mv` destination,
+ * `perl -i`/`ruby -i` file operands.
+ * Not writes: `2>`/`2>>`, `<<` heredoc, `<<<` herestring, `sed -n`.
+ */
+export function shellWriteDestinations(command: string): string[] {
+  const dests: string[] = [];
+  for (const segment of splitShellSegments(stripHeredocBodies(command))) {
+    dests.push(...redirectDestinations(segment));
+    dests.push(...verbDestinations(segment));
+  }
+  return dests;
+}
+
+/**
+ * Remove every heredoc BODY (the lines after a `<<DELIM` line up to and including
+ * the terminator line). The `<<DELIM` operator and the rest of its own line stay,
+ * so `cat <<EOF > /w/x.md` still shows its redirect target. Body text is exactly
+ * what must never count as a destination: a devlog brief whose body quotes the
+ * memories path is the false positive this parser exists to remove.
+ */
+function stripHeredocBodies(command: string): string {
+  let out = "";
+  let i = 0;
+  while (i < command.length) {
+    const ch = command[i];
+    if (ch === "'" || ch === '"') {
+      const next = skipQuoted(command, i);
+      out += command.slice(i, next);
+      i = next;
+      continue;
+    }
+    if (ch === "<" && command[i + 1] === "<" && command[i + 2] !== "<") {
+      const afterDelim = skipHeredoc(command, i);
+      const delim = heredocDelimiter(command, i);
+      out += command.slice(i, afterDelim);
+      i = afterDelim;
+      if (delim === "") continue;
+      // Keep the rest of the operator's line, then drop the body.
+      let eol = command.indexOf("\n", i);
+      if (eol === -1) return out + command.slice(i);
+      out += command.slice(i, eol);
+      let j = eol + 1;
+      for (;;) {
+        const nl = command.indexOf("\n", j);
+        const line = nl === -1 ? command.slice(j) : command.slice(j, nl);
+        if (line === delim) {
+          j = nl === -1 ? command.length : nl + 1;
+          break;
+        }
+        if (nl === -1) {
+          j = command.length;
+          break;
+        }
+        j = nl + 1;
+      }
+      out += "\n";
+      i = j;
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/** The heredoc delimiter word at `<<` position `i`, unquoted; "" when absent. */
+function heredocDelimiter(s: string, i: number): string {
+  i += 2;
+  if (s[i] === "-") i++;
+  while (i < s.length && /\s/.test(s[i])) i++;
+  if (s[i] === "'" || s[i] === '"') {
+    const q = s[i++];
+    const start = i;
+    while (i < s.length && s[i] !== q) i++;
+    return s.slice(start, i);
+  }
+  const start = i;
+  while (i < s.length && /[A-Za-z0-9_]/.test(s[i])) i++;
+  return s.slice(start, i);
+}
+
+function splitShellSegments(command: string): string[] {
+  const segments: string[] = [];
+  let cur = "";
+  let i = 0;
+  while (i < command.length) {
+    const ch = command[i];
+    if (ch === "'" || ch === '"') {
+      const next = skipQuoted(command, i);
+      cur += command.slice(i, next);
+      i = next;
+      continue;
+    }
+    if (ch === "<" && command[i + 1] === "<" && command[i + 2] !== "<") {
+      const next = skipHeredoc(command, i);
+      cur += command.slice(i, next);
+      i = next;
+      continue;
+    }
+    if (ch === "|" && i > 0 && command[i - 1] === ">") {
+      // `>|` clobber redirection: keep the bar inside the current segment.
+      cur += ch;
+      i++;
+      continue;
+    }
+    if (ch === ";" || ch === "|" || (ch === "&" && command[i + 1] === "&")) {
+      if (cur.trim() !== "") segments.push(cur);
+      cur = "";
+      if (ch === "&") i++;
+      if (ch === "|" && command[i + 1] === "|") i++;
+      i++;
+      continue;
+    }
+    cur += ch;
+    i++;
+  }
+  if (cur.trim() !== "") segments.push(cur);
+  return segments;
+}
+
+function skipQuoted(s: string, i: number): number {
+  const q = s[i];
+  i++;
+  while (i < s.length) {
+    if (q === '"' && s[i] === "\\" && i + 1 < s.length) {
+      i += 2;
+      continue;
+    }
+    if (s[i] === q) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Skip a `<<` / `<<-` operator and its delimiter word only. Bodies are removed
+ * beforehand by stripHeredocBodies, so the rest of the line stays visible.
+ */
+function skipHeredoc(s: string, i: number): number {
+  i += 2;
+  if (s[i] === "-") i++;
+  while (i < s.length && /\s/.test(s[i])) i++;
+  if (s[i] === "'" || s[i] === '"') {
+    const q = s[i++];
+    while (i < s.length && s[i] !== q) i++;
+    if (s[i] === q) i++;
+    return i;
+  }
+  while (i < s.length && /[A-Za-z0-9_]/.test(s[i])) i++;
+  return i;
+}
+
+function readToken(s: string, i: number): { token: string; next: number } {
+  while (i < s.length && /\s/.test(s[i])) i++;
+  if (i >= s.length) return { token: "", next: i };
+  if (s[i] === "'" || s[i] === '"') {
+    const q = s[i];
+    const start = i + 1;
+    const end = skipQuoted(s, i) - 1;
+    return { token: s.slice(start, Math.max(start, end)), next: end + 1 };
+  }
+  const start = i;
+  while (i < s.length && !/\s/.test(s[i])) i++;
+  return { token: s.slice(start, i), next: i };
+}
+
+function redirectDestinations(segment: string): string[] {
+  const dests: string[] = [];
+  let i = 0;
+  while (i < segment.length) {
+    const ch = segment[i];
+    if (ch === "'" || ch === '"') {
+      i = skipQuoted(segment, i);
+      continue;
+    }
+    if (ch === "<" && segment[i + 1] === "<") {
+      if (segment[i + 2] === "<") {
+        const r = readToken(segment, i + 3);
+        i = r.next;
+        continue;
+      }
+      i = skipHeredoc(segment, i);
+      continue;
+    }
+    if (ch !== ">") {
+      i++;
+      continue;
+    }
+    let k = i - 1;
+    let fd = "";
+    if (k >= 0 && segment[k] === "&") {
+      fd = "&";
+      k--;
+    } else {
+      while (k >= 0 && segment[k] >= "0" && segment[k] <= "9") k--;
+      fd = segment.slice(k + 1, i);
+    }
+    const before = k < 0 ? "" : segment[k];
+    // A1 (audit round 1): no token-boundary requirement. `echo hi>PATH` is a real
+    // write. Only `->` (arrow) and `<>` are not redirections; quoted spans never
+    // reach here (skipQuoted).
+    if (before === "-" || before === "<") {
+      i++;
+      continue;
+    }
+    let opEnd = i + 1;
+    if (segment[opEnd] === ">") opEnd++;
+    else if (segment[opEnd] === "|") opEnd++; // `>|` clobber
+    if (segment[opEnd] === "&") {
+      const r = readToken(segment, opEnd + 1);
+      i = r.next;
+      continue;
+    }
+    const dest = readToken(segment, opEnd);
+    if (fd !== "2" && dest.token !== "" && !dest.token.startsWith("&")) dests.push(dest.token);
+    i = dest.next;
+  }
+  return dests;
+}
+
+function tokenize(segment: string): string[] {
+  const tokens: string[] = [];
+  let i = 0;
+  while (i < segment.length) {
+    if (segment[i] === "'" || segment[i] === '"') {
+      const r = readToken(segment, i);
+      tokens.push(r.token);
+      i = r.next;
+      continue;
+    }
+    if (segment[i] === "<" && segment[i + 1] === "<" && segment[i + 2] !== "<") {
+      i = skipHeredoc(segment, i);
+      continue;
+    }
+    if (/\s/.test(segment[i])) {
+      i++;
+      continue;
+    }
+    const r = readToken(segment, i);
+    if (r.token !== "") tokens.push(r.token);
+    i = r.next === i ? i + 1 : r.next;
+  }
+  return tokens;
+}
+
+function basename(p: string): string {
+  const norm = p.replace(/\\/g, "/");
+  const idx = norm.lastIndexOf("/");
+  return idx === -1 ? norm : norm.slice(idx + 1);
+}
+
+function stripPrefixes(tokens: string[]): string[] {
+  let rest = tokens;
+  for (;;) {
+    const head = rest[0] ? basename(rest[0]) : "";
+    if (head === "sudo" || head === "command" || head === "builtin") {
+      rest = rest.slice(1);
+      continue;
+    }
+    if (head === "env") {
+      rest = rest.slice(1);
+      while (rest.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(rest[0])) rest = rest.slice(1);
+      continue;
+    }
+    return rest;
+  }
+}
+
+function verbDestinations(segment: string): string[] {
+  const rest = stripPrefixes(tokenize(segment));
+  const verb = rest[0] ? basename(rest[0]) : "";
+  const args = rest.slice(1);
+  if (verb === "tee") return teeDestinations(args);
+  if (verb === "sed") return sedInPlaceDestinations(args);
+  if (verb === "cp" || verb === "mv") return cpMvDestinations(args);
+  if (verb === "perl" || verb === "ruby") return interpInPlaceDestinations(args);
+  return [];
+}
+
+function teeDestinations(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--") {
+      out.push(...args.slice(i + 1));
+      break;
+    }
+    if (a.startsWith("-") && a !== "-") continue;
+    out.push(a);
+  }
+  return out;
+}
+
+function sedInPlaceDestinations(args: string[]): string[] {
+  let inPlace = false;
+  let sawExpression = false;
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--") {
+      positional.push(...args.slice(i + 1));
+      break;
+    }
+    if (a === "-i" || a === "--in-place" || a.startsWith("--in-place=") || (a.startsWith("-i") && a.length > 2)) {
+      inPlace = true;
+      if (a === "-i" && args[i + 1] !== undefined && (args[i + 1] === "" || /^\./.test(args[i + 1]))) i++;
+      continue;
+    }
+    if (a === "-e" || a === "-f" || a === "--expression" || a === "--file") {
+      sawExpression = true;
+      i++;
+      continue;
+    }
+    if (a.startsWith("-")) continue;
+    positional.push(a);
+  }
+  if (!inPlace) return [];
+  return sawExpression ? positional : positional.slice(1);
+}
+
+function cpMvDestinations(args: string[]): string[] {
+  let targetDir: string | undefined;
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "-t" || a === "--target-directory") {
+      targetDir = args[++i];
+      continue;
+    }
+    if (a.startsWith("--target-directory=")) {
+      targetDir = a.slice("--target-directory=".length);
+      continue;
+    }
+    if (a === "--") {
+      positional.push(...args.slice(i + 1));
+      break;
+    }
+    if (a.startsWith("-")) continue;
+    positional.push(a);
+  }
+  if (targetDir) return [targetDir];
+  if (positional.length >= 2) return [positional[positional.length - 1]];
+  return [];
+}
+
+function interpInPlaceDestinations(args: string[]): string[] {
+  let inPlace = false;
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--") {
+      positional.push(...args.slice(i + 1));
+      break;
+    }
+    if (/^-[a-zA-Z]*i/.test(a)) {
+      inPlace = true;
+      // A bundle whose LAST letter is `e` (`-pie`, `-nie`) still takes the next
+      // argument as the program text.
+      if (/e$/.test(a) && !/^-i/.test(a)) i++;
+      continue;
+    }
+    if (a === "-e" || /^-[a-zA-Z]*e$/.test(a)) {
+      // `-e`, `-pe`, `-ne`: the program text is the next argument, never a file.
+      i++;
+      continue;
+    }
+    if (a.startsWith("-")) continue;
+    positional.push(a);
+  }
+  return inPlace ? positional : [];
+}

--- a/plugins/codexclaw/components/pabcd-state/test/memory-write-gate.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/memory-write-gate.test.ts
@@ -11,7 +11,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import {
   classifyMemoryWrite,
   detectMemoryWriteRequest,
@@ -226,7 +226,8 @@ test("shell surface: destination-based classification, not body path strings", (
   // (4) sed -i of a memory file remains a write.
   const sedInPlace = classify(`sed -i 's/a/b/' ${mem}/MEMORY.md`);
   assert.equal(sedInPlace.surface, "shell");
-  assert.equal(sedInPlace.target, `${mem}/MEMORY.md`);
+  // target is absolutized with path.resolve, so compare on the platform form (D:\h\... on Windows).
+  assert.equal(sedInPlace.target, resolve(`${mem}/MEMORY.md`));
   // (5) stdout redirect into memories remains a write.
   assert.equal(classify(`echo hi > ${mem}/notes.md`).surface, "shell");
   // (A1) no-space redirections and `>|` clobber are real writes (audit round 1 found the

--- a/plugins/codexclaw/components/pabcd-state/test/memory-write-gate.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/memory-write-gate.test.ts
@@ -19,6 +19,7 @@ import {
   isMemoryPath,
   memoriesRoot,
   patchTargets,
+  shellWriteDestinations,
   MEMORY_WRITE_TOOL_NAMES,
 } from "../src/memory-write-gate.ts";
 import { handleUserPromptSubmit } from "../src/hook.ts";
@@ -203,4 +204,73 @@ test("old state files read as unauthorized (no retroactive standing grant)", () 
   assert.equal(state.memoryWriteRequested, false);
   assert.equal(state.memoryWriteGrant, false);
   assert.equal(state.memoryWriteTurn, null);
+});
+
+test("shell surface: destination-based classification, not body path strings", () => {
+  const root = memoriesRoot({ CODEX_HOME: "/h" });
+  const mem = "/h/memories";
+  const classify = (command: string, tool = "Bash") =>
+    classifyMemoryWrite(tool, { command }, "/w", root);
+
+  // (1) sed -n is a read.
+  assert.equal(classify(`sed -n '1p' ${mem}/MEMORY.md`).surface, "");
+  // (2) stderr redirect is not a write destination.
+  assert.equal(classify(`rg foo ${mem}/MEMORY.md 2>/dev/null`).surface, "");
+  // (3) heredoc body names the memories root; the write destination is devlog.
+  const heredoc = [
+    "mkdir -p /w/devlog/_plan/notes",
+    `&& cat > /w/devlog/_plan/notes/00_brief.md <<'EOF'`,
+    `\n${mem}\nEOF`,
+  ].join(" ");
+  assert.equal(classify(heredoc).surface, "");
+  // (4) sed -i of a memory file remains a write.
+  const sedInPlace = classify(`sed -i 's/a/b/' ${mem}/MEMORY.md`);
+  assert.equal(sedInPlace.surface, "shell");
+  assert.equal(sedInPlace.target, `${mem}/MEMORY.md`);
+  // (5) stdout redirect into memories remains a write.
+  assert.equal(classify(`echo hi > ${mem}/notes.md`).surface, "shell");
+  // (A1) no-space redirections and `>|` clobber are real writes (audit round 1 found the
+  // first parser draft returning [] for all three).
+  assert.equal(classify(`echo hi>${mem}/n.md`).surface, "shell");
+  assert.equal(classify(`echo hi>>${mem}/n.md`).surface, "shell");
+  assert.equal(classify(`echo hi >| ${mem}/n.md`).surface, "shell");
+  assert.equal(classify(`echo 'a>b'`).surface, "");
+  assert.equal(classify(`grep -- '->' /w/f`).surface, "");
+
+  // Live shape from notes/00 and notes/03 §6: worktree dest, tilde path in the body.
+  const live = [
+    "mkdir -p /Users/jun/.codex/worktrees/3412/codexclaw/devlog/_plan/260910_memory-followup-roadmap/notes /tmp/mfu-260910",
+    "&& cat > /Users/jun/.codex/worktrees/3412/codexclaw/devlog/_plan/260910_memory-followup-roadmap/notes/00_brief.md <<'EOF'",
+    "\n~/.codex/memories\nEOF",
+  ].join(" ");
+  assert.equal(classify(live).surface, "");
+
+  // Old >>? regex false-denies (notes/03 §4, §6 table).
+  assert.equal(classify(`python3 -c "from pathlib import Path; print(Path('${mem}/MEMORY.md').read_text()); print('x -> y')"`).surface, "");
+  assert.equal(classify(`rg '<prose>' ${mem}/MEMORY.md`).surface, "");
+
+  assert.equal(classify(`rg foo /w | tee ${mem}/out.md`).surface, "shell");
+  assert.equal(classify(`cp /w/a.md ${mem}/b.md`).surface, "shell");
+  assert.equal(classify(`cp ${mem}/a.md /w/b.md`).surface, "");
+  assert.equal(classify(`mv /w/a.md ${mem}/b.md`).surface, "shell");
+  assert.equal(classify(`perl -i -pe 's/a/b/' ${mem}/MEMORY.md`).surface, "shell");
+  assert.equal(classify(`ruby -i -pe 's/a/b/' ${mem}/MEMORY.md`).surface, "shell");
+  assert.equal(classify(`sed -n '1p' ${mem}/MEMORY.md`, "exec_command").surface, "");
+  assert.equal(classify(`echo hi > ${mem}/notes.md`, "exec_command").surface, "shell");
+});
+
+test("shellWriteDestinations: stderr, arrows in prose, and heredoc bodies are not dests", () => {
+  assert.deepEqual(shellWriteDestinations("rg foo /h/memories 2>/dev/null"), []);
+  assert.deepEqual(shellWriteDestinations("echo 'a > b'"), []);
+  assert.deepEqual(shellWriteDestinations("echo hi > /tmp/out.md"), ["/tmp/out.md"]);
+  assert.deepEqual(
+    shellWriteDestinations("cat > /tmp/out.md <<'EOF'\n~/.codex/memories\nEOF"),
+    ["/tmp/out.md"],
+  );
+  assert.deepEqual(shellWriteDestinations("sed -n '1p' /h/memories/MEMORY.md"), []);
+  assert.deepEqual(shellWriteDestinations("sed -i 's/a/b/' /h/memories/MEMORY.md"), ["/h/memories/MEMORY.md"]);
+  assert.deepEqual(shellWriteDestinations("echo hi>/h/memories/n.md"), ["/h/memories/n.md"]);
+  assert.deepEqual(shellWriteDestinations("echo hi>>/h/memories/n.md"), ["/h/memories/n.md"]);
+  assert.deepEqual(shellWriteDestinations("echo hi >| /h/memories/n.md"), ["/h/memories/n.md"]);
+  assert.deepEqual(shellWriteDestinations("x -> y"), []);
 });

--- a/plugins/codexclaw/components/pabcd-state/test/shell-write-destinations.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/shell-write-destinations.test.ts
@@ -1,0 +1,61 @@
+/**
+ * shell-write-destinations.test.ts — parser unit cases for MEMORY-WRITE-GATE-01
+ * (260910 wp1). The gate integration cases live in memory-write-gate.test.ts;
+ * this file pins the parser alone, including the audit-round-1 forms
+ * (no-space `>`/`>>` and `>|`) that the first draft returned [] for.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shellWriteDestinations } from "../src/shell-write-destinations.ts";
+
+const mem = "/h/memories";
+
+test("redirections: stdout forms are writes, stderr and arrows are not", () => {
+  assert.deepEqual(shellWriteDestinations(`echo hi > ${mem}/n.md`), [`${mem}/n.md`]);
+  assert.deepEqual(shellWriteDestinations(`echo hi >> ${mem}/n.md`), [`${mem}/n.md`]);
+  assert.deepEqual(shellWriteDestinations(`echo hi>${mem}/n.md`), [`${mem}/n.md`]);
+  assert.deepEqual(shellWriteDestinations(`echo hi>>${mem}/n.md`), [`${mem}/n.md`]);
+  assert.deepEqual(shellWriteDestinations(`echo hi >| ${mem}/n.md`), [`${mem}/n.md`]);
+  assert.deepEqual(shellWriteDestinations(`echo hi 1> ${mem}/n.md`), [`${mem}/n.md`]);
+  assert.deepEqual(shellWriteDestinations(`cmd &> ${mem}/n.md`), [`${mem}/n.md`]);
+  assert.deepEqual(shellWriteDestinations(`rg foo ${mem}/M.md 2>/dev/null`), []);
+  assert.deepEqual(shellWriteDestinations(`cmd 2>&1`), []);
+  assert.deepEqual(shellWriteDestinations("x -> y"), []);
+  assert.deepEqual(shellWriteDestinations("grep -- '->' /w/f"), []);
+  assert.deepEqual(shellWriteDestinations("echo 'a>b'"), []);
+  assert.deepEqual(shellWriteDestinations("echo 'a > b'"), []);
+  assert.deepEqual(shellWriteDestinations("rg '<prose>' /w/f"), []);
+});
+
+test("heredoc bodies and herestrings are not destinations; the redirect target is", () => {
+  assert.deepEqual(shellWriteDestinations(`cat > /w/x.md <<'EOF'\n${mem}\nEOF`), ["/w/x.md"]);
+  assert.deepEqual(shellWriteDestinations(`cat <<EOF > /w/x.md\n${mem}/n.md\nEOF`), ["/w/x.md"]);
+  assert.deepEqual(shellWriteDestinations(`cat <<< "${mem}/n.md"`), []);
+  assert.deepEqual(
+    shellWriteDestinations(`mkdir -p /w/notes && cat > /w/notes/00.md <<'EOF'\n~/.codex/memories\nEOF`),
+    ["/w/notes/00.md"],
+  );
+});
+
+test("verbs: tee, sed -i, cp/mv destination, perl -i, ruby -i", () => {
+  assert.deepEqual(shellWriteDestinations(`rg foo /w | tee ${mem}/out.md`), [`${mem}/out.md`]);
+  assert.deepEqual(shellWriteDestinations(`tee -a ${mem}/out.md`), [`${mem}/out.md`]);
+  assert.deepEqual(shellWriteDestinations(`sed -n '1p' ${mem}/M.md`), []);
+  assert.deepEqual(shellWriteDestinations(`sed -i 's/a/b/' ${mem}/M.md`), [`${mem}/M.md`]);
+  assert.deepEqual(shellWriteDestinations(`sed -i '' 's/a/b/' ${mem}/M.md`), [`${mem}/M.md`]);
+  assert.deepEqual(shellWriteDestinations(`sed -i.bak -e 's/a/b/' ${mem}/M.md`), [`${mem}/M.md`]);
+  assert.deepEqual(shellWriteDestinations(`cp /w/a.md ${mem}/b.md`), [`${mem}/b.md`]);
+  assert.deepEqual(shellWriteDestinations(`cp ${mem}/a.md /w/b.md`), ["/w/b.md"]);
+  assert.deepEqual(shellWriteDestinations(`mv /w/a.md ${mem}/b.md`), [`${mem}/b.md`]);
+  assert.deepEqual(shellWriteDestinations(`cp -t ${mem} /w/a.md`), [mem]);
+  assert.deepEqual(shellWriteDestinations(`perl -i -pe 's/a/b/' ${mem}/M.md`), [`${mem}/M.md`]);
+  assert.deepEqual(shellWriteDestinations(`ruby -i -pe 's/a/b/' ${mem}/M.md`), [`${mem}/M.md`]);
+  assert.deepEqual(shellWriteDestinations(`sudo tee ${mem}/out.md`), [`${mem}/out.md`]);
+  assert.deepEqual(shellWriteDestinations(`cat ${mem}/M.md`), []);
+});
+
+test("segments: every command in a chain is inspected", () => {
+  assert.deepEqual(shellWriteDestinations(`cat /w/a && echo x > ${mem}/n.md; ls`), [`${mem}/n.md`]);
+  assert.deepEqual(shellWriteDestinations(`cat /w/a || echo x>${mem}/n.md`), [`${mem}/n.md`]);
+});
+


### PR DESCRIPTION
The memory-write gate (#102) classified shell commands by scanning every token for a memories path string. That denied read-only `sed -n`, `2>/dev/null` stderr redirects, and any heredoc whose *body* quoted the memories path — a devlog brief was blocked four times in one session, and an independent reviewer hit the same false positive while building a read-only harness.

**After:** the shell leg asks one question — which paths does the command *write* to? A new pure parser (`shell-write-destinations.ts`) collects stdout redirections (`>`, `>>`, `>|`, `&>`, `N>`, including the no-space forms), `tee` operands, `sed -i` files, `cp`/`mv` targets, and `perl -i`/`ruby -i` operands. Quoted text, heredoc bodies, herestrings, stderr redirects and read operands are never destinations. Only a destination under the memories root is denied.

| command | before | after |
|---|---|---|
| `sed -n '1p' <mem>/MEMORY.md` | deny | allow |
| `rg foo <mem>/x 2>/dev/null` | deny | allow |
| `cat > devlog/notes/00.md <<'EOF' … <mem> … EOF` | deny | allow |
| `echo hi > <mem>/n.md`, `echo hi>><mem>/n.md`, `echo hi >\| <mem>/n.md` | deny | deny |
| `sed -i … <mem>/MEMORY.md`, `tee <mem>/x`, `cp a <mem>/b` | deny | deny |

The tool-name leg (`memories.add_ad_hoc_note`) and the apply_patch/Write/Edit leg are unchanged. The gate stays an early warning: subshells, variable expansions, `python -c` writers and `echo hi -> P` are named residual bypasses (plan 010 §8).

**Validation.** `pabcd-state` suite 1216 pass / 0 fail via `scripts/test.mjs`; dist-freshness + packaging 5 pass; new parser unit tests (4) and gate integration cases (2) including the audit-round-1 no-space forms. Activation smoke through `dist/cli.js hook pre-tool-use-memory-write` with stdin fixtures: 3 allow (empty stdout), 3 deny (`permissionDecision: deny`). Receipt bound to `1e4c5897`.

**Stack** (merge order; all PRs target `dev` because of `enforce-pr-target`):
| # | PR | layer |
|---|---|---|
| 0 | #123 (merged) | roadmap + decade docs |
| 1 | this PR | wp1 gate destination parser |
| 2 | next | wp2 symbol boundary (independent of wp1) |

Plan: `devlog/_plan/260910_memory-followup-roadmap/010_wp1_memory-write-gate.md`.

