### PR TITLE
fix(recall): treat dotted versions as VERSION words and relax only the boundary groups that missed

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C951_passing-brightgreen" alt="2,951 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C956_passing-brightgreen" alt="2,956 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C951_passing-brightgreen" alt="2,951 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C956_passing-brightgreen" alt="2,956 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C951_passing-brightgreen" alt="2,951 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C956_passing-brightgreen" alt="2,956 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260910_memory-followup-roadmap/020_wp2_symbol-boundary.md
+++ b/devlog/_plan/260910_memory-followup-roadmap/020_wp2_symbol-boundary.md
@@ -541,3 +541,15 @@ node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/test/dist-freshness.t
 ## A 감사 반영 (round 1, 2026-09-10)
 
 blocker 없음. Low: §2의 "`splitQueryWords`만 쓰고"는 `chat-search.ts:27`이 `splitQueryWords, MAX_WORDS` 둘을 import하므로 "경계 매칭 함수를 쓰지 않고"로 읽는다. 본론(chat 경로에 경계 매칭 부재)은 그대로다.
+
+
+## P 재검증 (wp2 사이클, 2026-09-10)
+
+기준 트리 `91745432`(origin/dev, #124 머지 직후). `git diff --stat 369ed0e1 HEAD -- plugins/codexclaw/components/recall`이 비어 있어 §2 인용 행(`query-words.ts:54-74, 84-90, 126-139`, `memory-search.ts:351-355, 461-471`)은 그대로다. A 감사 반영(Low 1건)이 접혀 있으므로 이 문서를 그대로 실행한다. 브랜치 `codex/memory-l1-wp2-symbol`(origin/dev 위), PR base dev. wp1과 독립.
+
+
+
+## A 감사 반영 (wp2 round 1, 2026-09-10)
+
+리뷰어(grok-4.6) GO-WITH-FIXES(Medium 1): §4.1 after 펜스를 `query-words.ts:126-139`의 교체로 적용하면 `hasBoundaryTerm`(127-129)과 `relaxQueryGroups`(137-139)가 사라져 4.2의 재시도와 기존 테스트(`query-words.test.ts:82`)가 깨진다. 결정: 126-139는 **교체가 아니라 추가**다. `hasBoundaryTerm`은 그대로 두고, `relaxQueryGroups`는 `relaxGroupsAt(groups, new Set(groups.keys()))`에 위임하는 구현으로 유지하며, `relaxGroupsAt`은 그 아래에 추가한다. §4.1의 "after (해당 구간 교체·추가)" 문구는 이 절이 우선한다. Low: 헤더 HEAD는 P 재검증(91745432)이 덮고, 테스트의 `relaxGroupsAt` import는 직접 호출이 없으면 넣지 않는다.
+

--- a/devlog/_plan/260910_memory-followup-roadmap/072_wp2_receipt.md
+++ b/devlog/_plan/260910_memory-followup-roadmap/072_wp2_receipt.md
@@ -1,0 +1,31 @@
+# 072 — wp2 receipt: 심볼 경계 회귀
+
+날짜: 2026-09-10 (KST). 세션 01a0880e-149e-72d0-86db-53bd99bcac0e. 브랜치 `codex/memory-l1-wp2-symbol`(origin/dev 91745432 위), 구현 커밋 `01902837`.
+
+## 결론
+
+`2.49.0 SLSA`가 MEMORY.md의 `v2.49.0` 청크를 완화 경고 없이 다시 찾는다(실인덱스 실측: 설치본 2건 → 워크트리 4건, MEMORY.md 2건 포함). `LSP` 결과는 이전 빌드와 바이트 단위로 같다(c-4 유지). 완화 재시도는 전체가 아니라 코퍼스 어디에도 없는 경계 그룹만 연다.
+
+## 무엇이 바뀌었나
+
+- `recall/src/query-words.ts`: VERSION/VERSION_CORE 정규식, `isVersionWord`, 심볼 판정에 VERSION 선행, `isBoundaryAt`의 v접두 예외(토큰 가장자리의 단독 v), `relaxGroupsAt` 추가, `relaxQueryGroups`는 위임(감사 반영: 126-139는 추가이며 `hasBoundaryTerm` 유지).
+- `recall/src/memory-search.ts`: `groupHit`/`markGroupPresence` 분리, `collect(active, tallyPresence)`, AND=0일 때 `fillStage1Presence`(stage1_outputs 읽기 전용)로 그룹 존재를 보정한 뒤 miss 집합만 완화.
+- `test/query-words.test.ts` +5(VERSION 분류, v접두 경계, 2.49.0 SLSA 복구, c-4 유지, 그룹 단위 완화).
+- dist `query-words.js`, `memory-search.js` 재생성. 테스트 배지 2951→2956.
+
+## 증거
+
+- receipt `.codexclaw/evidence/01a0880e-149e-72d0-86db-53bd99bcac0e/test-receipt.json`: `/tmp/mfu-260910/check-wp2.sh` exit 0 @ 01902837 — 골든 2건(워크트리 dist, 실인덱스 `--no-refresh`) + recall 142 pass + dist-freshness·packaging 5 pass.
+- 감사: 020에 대해 grok-4.6 리뷰어 GO-WITH-FIXES(Medium 1) → 접음(near-pass). 리뷰어가 recall 137/137 실행.
+- 원격 CI: PR 최종 head 전건 통과 후 머지(아래 갱신).
+
+## 개선되지 않은 것 (LOOP-PESSIMIST-01)
+
+- chat 경로는 여전히 경계 매칭이 없다(wp5 범위). 
+- 그룹 단위 완화는 AND=0에서만 열린다. 모든 경계 그룹이 각자 히트하는데 교집합이 빈 경우는 이제 substring으로 열지 않는다(의도된 동작 변경, 020 §4.2).
+- 방향이 틀렸다는 신호: 실사용에서 "lower confidence" 경고가 사라지면서 정답도 같이 사라지는 질의가 보고되면, 그룹 존재 판정이 파일 전체 텍스트 기준이라 청크 단위 교차 공백을 못 여는 것이 원인이다.
+
+## 다음
+
+wp3 P: 030(cxc-recall SKILL.md 재작성 + docs-site)을 현재 트리와 대조. wp1·wp2가 모두 dev에 있어야 문구가 확정된다.
+

--- a/plugins/codexclaw/components/recall/dist/memory-search.js
+++ b/plugins/codexclaw/components/recall/dist/memory-search.js
@@ -19,7 +19,7 @@ import {
   termIncludes,
   countTermOccurrences,
   hasBoundaryTerm,
-  relaxQueryGroups,
+  relaxGroupsAt,
 
 } from "./query-words.js";
 import { expandQueryWords } from "./synonyms.js";
@@ -348,10 +348,24 @@ export function paragraphChunks(content        )                                
   return chunks;
 }
 
+function groupHit(lowerText        , group            )          {
+  return group.some((term) => termIncludes(lowerText, term));
+}
+
 /** AND across groups, OR within a group; anyMode = any member of any group. */
 function matches(lowerText        , groups              , anyMode         )          {
-  const groupHit = (group            ) => group.some((term) => termIncludes(lowerText, term));
-  return anyMode ? groups.some(groupHit) : groups.every(groupHit);
+  return anyMode ? groups.some((g) => groupHit(lowerText, g)) : groups.every((g) => groupHit(lowerText, g));
+}
+
+/**
+ * Record which groups occur anywhere in this text (independently of the other
+ * groups). Drives the per-group relaxed retry: only a boundary group that is
+ * absent from the WHOLE corpus is opened to substring matching.
+ */
+function markGroupPresence(lowerText        , groups              , present           )       {
+  for (let i = 0; i < groups.length; i++) {
+    if (!present[i] && groupHit(lowerText, groups[i])) present[i] = true;
+  }
 }
 
 /** First group member actually present in the text (excerpt anchor), else the lead word. */
@@ -399,7 +413,8 @@ export function searchMemory(query        , opts                      = {})     
   const files = listMarkdownFiles(root);
   const scope = buildCwdScope(home, opts, warnings);
 
-  const collect = (active              )              => {
+  const present            = groups.map(() => false);
+  const collect = (active              , tallyPresence         )              => {
     const candidates              = [];
     const matchedThreadIds = new Set        ();
     scannedFiles = 0;
@@ -415,7 +430,9 @@ export function searchMemory(query        , opts                      = {})     
       }
       if (cutoffMs && mtimeMs < cutoffMs) continue;
       scannedFiles += 1;
-      if (!matches(content.toLowerCase(), active, anyMode)) continue;
+      const lowerFile = content.toLowerCase();
+      if (tallyPresence) markGroupPresence(lowerFile, groups, present);
+      if (!matches(lowerFile, active, anyMode)) continue;
       const threadId = frontmatterThreadId(content);
       if (threadId) matchedThreadIds.add(threadId);
       const relpath = relative(root, file).split(sep).join("/");
@@ -458,16 +475,25 @@ export function searchMemory(query        , opts                      = {})     
     return candidates;
   };
 
-  let candidates = collect(groups);
-  // Relaxed retry: a symbol query that lands nowhere on token boundaries is
-  // better answered with low-confidence substring hits than with nothing. This
-  // is the fallback half of R1 — `3956` written as `PR3956` has no boundary in
-  // front of the digits, and a strict-only gate would hide it.
+  let candidates = collect(groups, true);
+  // Relaxed retry (per group, 260910 wp2): a symbol query that lands nowhere on
+  // token boundaries is better answered with low-confidence substring hits than
+  // with nothing — `3956` written as `PR3956` has no boundary in front of the
+  // digits. Only the boundary groups absent from the whole corpus are relaxed;
+  // a group that does hit somewhere keeps its precision (c-4: `LSP` must not
+  // start matching NaiControlsPanel because another group missed).
   if (candidates.length === 0 && hasBoundaryTerm(groups)) {
-    candidates = collect(relaxQueryGroups(groups));
-    if (candidates.length > 0) {
-      for (const hit of candidates) hit.score -= RELAXED_PENALTY;
-      warnings.push("no word-boundary matches — showing substring matches (lower confidence)");
+    fillStage1Presence(home, groups, present, cutoffMs, warnings);
+    const miss = new Set        ();
+    for (let i = 0; i < groups.length; i++) {
+      if (groups[i].some((t) => t.boundary) && !present[i]) miss.add(i);
+    }
+    if (miss.size > 0) {
+      candidates = collect(relaxGroupsAt(groups, miss), false);
+      if (candidates.length > 0) {
+        for (const hit of candidates) hit.score -= RELAXED_PENALTY;
+        warnings.push("no word-boundary matches — showing substring matches (lower confidence)");
+      }
     }
   }
   const hits = rankAndTrim(candidates, limit);
@@ -552,6 +578,37 @@ function backfillFromChat(
   } catch (err) {
     warnings.push(`chat fallback unavailable (${err instanceof Error ? err.message : String(err)})`);
     return hits;
+  }
+}
+
+/** stage1_outputs holds per-thread raw_memory + rollout_summary; read-only, fail-soft. */
+function fillStage1Presence(
+  home        ,
+  groups              ,
+  present           ,
+  cutoffMs               ,
+  warnings          ,
+)       {
+  if (present.every(Boolean)) return;
+  const dbPath = memoriesDbPath(home);
+  if (!dbPath) return;
+  let db                                           = null;
+  try {
+    db = openReadOnlyDb(dbPath);
+    const rows = db
+      .prepare("SELECT raw_memory, rollout_summary, source_updated_at FROM stage1_outputs")
+      .all()                                  ;
+    for (const r of rows) {
+      const updatedSec = typeof r.source_updated_at === "number" ? r.source_updated_at : null;
+      if (cutoffMs && updatedSec !== null && updatedSec * 1000 < cutoffMs) continue;
+      const body = `${String(r.raw_memory ?? "")}\n${String(r.rollout_summary ?? "")}`.toLowerCase();
+      markGroupPresence(body, groups, present);
+      if (present.every(Boolean)) return;
+    }
+  } catch (err) {
+    warnings.push(`memories db unreadable (${err instanceof Error ? err.message : String(err)})`);
+  } finally {
+    db?.close();
   }
 }
 

--- a/plugins/codexclaw/components/recall/dist/query-words.js
+++ b/plugins/codexclaw/components/recall/dist/query-words.js
@@ -51,10 +51,24 @@ const SHORT_ASCII = /^[a-z]{1,3}$/;
 const NUMERIC_ID = /^#?\d{2,10}$/;
 /** Abbreviated or full commit SHA. */
 const SHA = /^[0-9a-f]{7,40}$/;
+/**
+ * Dotted version: 2.49, 2.49.0, 2.49.0-rc.1, with an optional leading v. Judged
+ * BEFORE the filename rule (260910 wp2): `2.49.0` ends in `.0`, which FILENAME
+ * read as an extension, and a version written as `v2.49.0` in the corpus then
+ * failed the token-boundary test because the `v` is a token character.
+ */
+const VERSION = /^v?\d+\.\d+(?:\.\d+)*(?:-[a-z0-9.]+)?$/;
+/** Version core without the v — the slice looked up in the haystack for "2.49.0". */
+const VERSION_CORE = /^\d+\.\d+(?:\.\d+)*(?:-[a-z0-9.]+)?$/;
 /** Filename with an extension: hook.ts, plan.md. */
 const FILENAME = /\.[a-z0-9]{1,5}$/;
 /** Anything carrying a path separator: src/hook.ts. */
 const PATH_LIKE = /[/\\]/;
+
+/** Is this query word a dotted version (optionally v-prefixed)? */
+export function isVersionWord(rawWord        )          {
+  return VERSION.test(rawWord.toLowerCase());
+}
 
 /**
  * Is this query word symbol-shaped, i.e. should it match on token boundaries?
@@ -65,6 +79,7 @@ export function isSymbolWord(rawWord        )          {
   if (UPPER_ACRONYM.test(rawWord)) return true;
   const lower = rawWord.toLowerCase();
   return (
+    isVersionWord(rawWord) ||
     SHORT_ASCII.test(lower) ||
     NUMERIC_ID.test(lower) ||
     SHA.test(lower) ||
@@ -83,11 +98,21 @@ export function isSymbolWord(rawWord        )          {
  */
 const TOKEN_CHAR = /[A-Za-z0-9_]/;
 
+function isTokenEdge(ch        )          {
+  return ch === "" || !TOKEN_CHAR.test(ch);
+}
+
 function isBoundaryAt(lowerText        , at        , length        )          {
   const before = at > 0 ? lowerText[at - 1] : "";
   const after = at + length < lowerText.length ? lowerText[at + length] : "";
-  // Empty string (start/end of text) is a boundary: TOKEN_CHAR never matches "".
-  return !TOKEN_CHAR.test(before) && !TOKEN_CHAR.test(after);
+  if (isTokenEdge(before) && isTokenEdge(after)) return true;
+  // v2.49.0 / (v2.49.0): a lone v immediately before a VERSION core counts as a
+  // boundary iff that v itself sits on a token edge. av2.49.0 and 12.49.0 stay out.
+  if (before === "v" && isTokenEdge(after) && VERSION_CORE.test(lowerText.slice(at, at + length))) {
+    const beforeV = at >= 2 ? lowerText[at - 2] : "";
+    return isTokenEdge(beforeV);
+  }
+  return false;
 }
 
 /**
@@ -135,7 +160,18 @@ export function hasBoundaryTerm(groups              )          {
  * `PR3956` has no boundary before the digits).
  */
 export function relaxQueryGroups(groups              )               {
-  return groups.map((group) => group.map((term) => ({ text: term.text, boundary: false })));
+  return relaxGroupsAt(groups, new Set(groups.keys()));
+}
+
+/**
+ * Drop boundary gating only for the groups at `indexes`. The per-group retry
+ * (260910 wp2) relaxes just the symbol groups that found nothing anywhere in the
+ * corpus, so a group that does hit on boundaries keeps its precision.
+ */
+export function relaxGroupsAt(groups              , indexes                     )               {
+  return groups.map((group, i) =>
+    indexes.has(i) ? group.map((term) => ({ text: term.text, boundary: false })) : group,
+  );
 }
 
 /** Plain member texts of a group — for assertions and diagnostics. */

--- a/plugins/codexclaw/components/recall/src/memory-search.ts
+++ b/plugins/codexclaw/components/recall/src/memory-search.ts
@@ -19,7 +19,7 @@ import {
   termIncludes,
   countTermOccurrences,
   hasBoundaryTerm,
-  relaxQueryGroups,
+  relaxGroupsAt,
   type QueryGroup,
 } from "./query-words.ts";
 import { expandQueryWords } from "./synonyms.ts";
@@ -348,10 +348,24 @@ export function paragraphChunks(content: string): Array<{ text: string; startLin
   return chunks;
 }
 
+function groupHit(lowerText: string, group: QueryGroup): boolean {
+  return group.some((term) => termIncludes(lowerText, term));
+}
+
 /** AND across groups, OR within a group; anyMode = any member of any group. */
 function matches(lowerText: string, groups: QueryGroup[], anyMode: boolean): boolean {
-  const groupHit = (group: QueryGroup) => group.some((term) => termIncludes(lowerText, term));
-  return anyMode ? groups.some(groupHit) : groups.every(groupHit);
+  return anyMode ? groups.some((g) => groupHit(lowerText, g)) : groups.every((g) => groupHit(lowerText, g));
+}
+
+/**
+ * Record which groups occur anywhere in this text (independently of the other
+ * groups). Drives the per-group relaxed retry: only a boundary group that is
+ * absent from the WHOLE corpus is opened to substring matching.
+ */
+function markGroupPresence(lowerText: string, groups: QueryGroup[], present: boolean[]): void {
+  for (let i = 0; i < groups.length; i++) {
+    if (!present[i] && groupHit(lowerText, groups[i])) present[i] = true;
+  }
 }
 
 /** First group member actually present in the text (excerpt anchor), else the lead word. */
@@ -399,7 +413,8 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
   const files = listMarkdownFiles(root);
   const scope = buildCwdScope(home, opts, warnings);
 
-  const collect = (active: QueryGroup[]): MemoryHit[] => {
+  const present: boolean[] = groups.map(() => false);
+  const collect = (active: QueryGroup[], tallyPresence: boolean): MemoryHit[] => {
     const candidates: MemoryHit[] = [];
     const matchedThreadIds = new Set<string>();
     scannedFiles = 0;
@@ -415,7 +430,9 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
       }
       if (cutoffMs && mtimeMs < cutoffMs) continue;
       scannedFiles += 1;
-      if (!matches(content.toLowerCase(), active, anyMode)) continue;
+      const lowerFile = content.toLowerCase();
+      if (tallyPresence) markGroupPresence(lowerFile, groups, present);
+      if (!matches(lowerFile, active, anyMode)) continue;
       const threadId = frontmatterThreadId(content);
       if (threadId) matchedThreadIds.add(threadId);
       const relpath = relative(root, file).split(sep).join("/");
@@ -458,16 +475,25 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
     return candidates;
   };
 
-  let candidates = collect(groups);
-  // Relaxed retry: a symbol query that lands nowhere on token boundaries is
-  // better answered with low-confidence substring hits than with nothing. This
-  // is the fallback half of R1 — `3956` written as `PR3956` has no boundary in
-  // front of the digits, and a strict-only gate would hide it.
+  let candidates = collect(groups, true);
+  // Relaxed retry (per group, 260910 wp2): a symbol query that lands nowhere on
+  // token boundaries is better answered with low-confidence substring hits than
+  // with nothing — `3956` written as `PR3956` has no boundary in front of the
+  // digits. Only the boundary groups absent from the whole corpus are relaxed;
+  // a group that does hit somewhere keeps its precision (c-4: `LSP` must not
+  // start matching NaiControlsPanel because another group missed).
   if (candidates.length === 0 && hasBoundaryTerm(groups)) {
-    candidates = collect(relaxQueryGroups(groups));
-    if (candidates.length > 0) {
-      for (const hit of candidates) hit.score -= RELAXED_PENALTY;
-      warnings.push("no word-boundary matches — showing substring matches (lower confidence)");
+    fillStage1Presence(home, groups, present, cutoffMs, warnings);
+    const miss = new Set<number>();
+    for (let i = 0; i < groups.length; i++) {
+      if (groups[i].some((t) => t.boundary) && !present[i]) miss.add(i);
+    }
+    if (miss.size > 0) {
+      candidates = collect(relaxGroupsAt(groups, miss), false);
+      if (candidates.length > 0) {
+        for (const hit of candidates) hit.score -= RELAXED_PENALTY;
+        warnings.push("no word-boundary matches — showing substring matches (lower confidence)");
+      }
     }
   }
   const hits = rankAndTrim(candidates, limit);
@@ -552,6 +578,37 @@ function backfillFromChat(
   } catch (err) {
     warnings.push(`chat fallback unavailable (${err instanceof Error ? err.message : String(err)})`);
     return hits;
+  }
+}
+
+/** stage1_outputs holds per-thread raw_memory + rollout_summary; read-only, fail-soft. */
+function fillStage1Presence(
+  home: string,
+  groups: QueryGroup[],
+  present: boolean[],
+  cutoffMs: number | null,
+  warnings: string[],
+): void {
+  if (present.every(Boolean)) return;
+  const dbPath = memoriesDbPath(home);
+  if (!dbPath) return;
+  let db: ReturnType<typeof openReadOnlyDb> | null = null;
+  try {
+    db = openReadOnlyDb(dbPath);
+    const rows = db
+      .prepare("SELECT raw_memory, rollout_summary, source_updated_at FROM stage1_outputs")
+      .all() as Array<Record<string, unknown>>;
+    for (const r of rows) {
+      const updatedSec = typeof r.source_updated_at === "number" ? r.source_updated_at : null;
+      if (cutoffMs && updatedSec !== null && updatedSec * 1000 < cutoffMs) continue;
+      const body = `${String(r.raw_memory ?? "")}\n${String(r.rollout_summary ?? "")}`.toLowerCase();
+      markGroupPresence(body, groups, present);
+      if (present.every(Boolean)) return;
+    }
+  } catch (err) {
+    warnings.push(`memories db unreadable (${err instanceof Error ? err.message : String(err)})`);
+  } finally {
+    db?.close();
   }
 }
 

--- a/plugins/codexclaw/components/recall/src/query-words.ts
+++ b/plugins/codexclaw/components/recall/src/query-words.ts
@@ -51,10 +51,24 @@ const SHORT_ASCII = /^[a-z]{1,3}$/;
 const NUMERIC_ID = /^#?\d{2,10}$/;
 /** Abbreviated or full commit SHA. */
 const SHA = /^[0-9a-f]{7,40}$/;
+/**
+ * Dotted version: 2.49, 2.49.0, 2.49.0-rc.1, with an optional leading v. Judged
+ * BEFORE the filename rule (260910 wp2): `2.49.0` ends in `.0`, which FILENAME
+ * read as an extension, and a version written as `v2.49.0` in the corpus then
+ * failed the token-boundary test because the `v` is a token character.
+ */
+const VERSION = /^v?\d+\.\d+(?:\.\d+)*(?:-[a-z0-9.]+)?$/;
+/** Version core without the v — the slice looked up in the haystack for "2.49.0". */
+const VERSION_CORE = /^\d+\.\d+(?:\.\d+)*(?:-[a-z0-9.]+)?$/;
 /** Filename with an extension: hook.ts, plan.md. */
 const FILENAME = /\.[a-z0-9]{1,5}$/;
 /** Anything carrying a path separator: src/hook.ts. */
 const PATH_LIKE = /[/\\]/;
+
+/** Is this query word a dotted version (optionally v-prefixed)? */
+export function isVersionWord(rawWord: string): boolean {
+  return VERSION.test(rawWord.toLowerCase());
+}
 
 /**
  * Is this query word symbol-shaped, i.e. should it match on token boundaries?
@@ -65,6 +79,7 @@ export function isSymbolWord(rawWord: string): boolean {
   if (UPPER_ACRONYM.test(rawWord)) return true;
   const lower = rawWord.toLowerCase();
   return (
+    isVersionWord(rawWord) ||
     SHORT_ASCII.test(lower) ||
     NUMERIC_ID.test(lower) ||
     SHA.test(lower) ||
@@ -83,11 +98,21 @@ export function isSymbolWord(rawWord: string): boolean {
  */
 const TOKEN_CHAR = /[A-Za-z0-9_]/;
 
+function isTokenEdge(ch: string): boolean {
+  return ch === "" || !TOKEN_CHAR.test(ch);
+}
+
 function isBoundaryAt(lowerText: string, at: number, length: number): boolean {
   const before = at > 0 ? lowerText[at - 1] : "";
   const after = at + length < lowerText.length ? lowerText[at + length] : "";
-  // Empty string (start/end of text) is a boundary: TOKEN_CHAR never matches "".
-  return !TOKEN_CHAR.test(before) && !TOKEN_CHAR.test(after);
+  if (isTokenEdge(before) && isTokenEdge(after)) return true;
+  // v2.49.0 / (v2.49.0): a lone v immediately before a VERSION core counts as a
+  // boundary iff that v itself sits on a token edge. av2.49.0 and 12.49.0 stay out.
+  if (before === "v" && isTokenEdge(after) && VERSION_CORE.test(lowerText.slice(at, at + length))) {
+    const beforeV = at >= 2 ? lowerText[at - 2] : "";
+    return isTokenEdge(beforeV);
+  }
+  return false;
 }
 
 /**
@@ -135,7 +160,18 @@ export function hasBoundaryTerm(groups: QueryGroup[]): boolean {
  * `PR3956` has no boundary before the digits).
  */
 export function relaxQueryGroups(groups: QueryGroup[]): QueryGroup[] {
-  return groups.map((group) => group.map((term) => ({ text: term.text, boundary: false })));
+  return relaxGroupsAt(groups, new Set(groups.keys()));
+}
+
+/**
+ * Drop boundary gating only for the groups at `indexes`. The per-group retry
+ * (260910 wp2) relaxes just the symbol groups that found nothing anywhere in the
+ * corpus, so a group that does hit on boundaries keeps its precision.
+ */
+export function relaxGroupsAt(groups: QueryGroup[], indexes: ReadonlySet<number>): QueryGroup[] {
+  return groups.map((group, i) =>
+    indexes.has(i) ? group.map((term) => ({ text: term.text, boundary: false })) : group,
+  );
 }
 
 /** Plain member texts of a group — for assertions and diagnostics. */

--- a/plugins/codexclaw/components/recall/test/query-words.test.ts
+++ b/plugins/codexclaw/components/recall/test/query-words.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   isSymbolWord,
+  isVersionWord,
   splitQueryWords,
   splitQueryWordsRaw,
   termIncludes,
@@ -204,6 +205,93 @@ test("memory search: --no-synonyms drops expansion but keeps boundary gating", (
     const r = searchMemory("LSP", { home, synonyms: false });
     assert.equal(r.hits.length, 1);
     assert.ok(r.hits[0].excerpt.includes("LSP server"));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("isVersionWord: dotted versions are VERSION, not prose or filenames", () => {
+  for (const w of ["2.49.0", "2.49", "2.49.0-rc.1", "v2.49.0", "V2.49.0"]) {
+    assert.ok(isVersionWord(w), `${w} is VERSION`);
+    assert.ok(isSymbolWord(w), `${w} stays a symbol`);
+  }
+  for (const w of ["hook.ts", "plan.md", "package.json", "src/hook.ts", "LSP", "3956", "deploy"]) {
+    assert.ok(!isVersionWord(w), `${w} is not VERSION`);
+  }
+  assert.ok(isSymbolWord("hook.ts"));
+  assert.ok(!isSymbolWord("deploy"));
+});
+
+test("termIndexOf: VERSION core allows a lone v/V prefix as a boundary", () => {
+  const v = bounded("2.49.0");
+  assert.ok(termIncludes("slsa provenance, v2.49.0", v));
+  assert.ok(termIncludes("released (v2.49.0) today", v));
+  assert.ok(termIncludes("V2.49.0".toLowerCase(), v));
+  assert.ok(termIncludes("2.49.0", v), "bare form still matches");
+  assert.ok(!termIncludes("av2.49.0", v), "v must itself be a token edge");
+  assert.ok(!termIncludes("12.49.0", v), "leading digit stays a token char");
+  assert.ok(!termIncludes("2.49.00", v), "trailing digit is inside the token");
+  assert.ok(!termIncludes("vci runner", bounded("ci")), "v-prefix exception is VERSION-only");
+  assert.ok(termIncludes("see hook.ts for details", bounded("hook.ts")));
+  assert.ok(!termIncludes("edit my-hook.tsx now", bounded("hook.ts")));
+});
+
+test("memory search: 2.49.0 SLSA recovers v2.49.0 handbook while summary already matches", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-r1-version-"));
+  try {
+    const mem = join(home, "memories");
+    mkdirSync(mem, { recursive: true });
+    writeFileSync(
+      join(mem, "memory_summary.md"),
+      "# Summary\n\nOpenCodex 2.49.0 HOTL release, SLSA provenance.\n",
+    );
+    writeFileSync(
+      join(mem, "MEMORY.md"),
+      "# Handbook\n\nSLSA provenance, v2.49.0\n\nFor v2.49.0, main SHA verified with SLSA.\n",
+    );
+    writeFileSync(join(mem, "noise.md"), "# Noise\n\nNaiControlsPanel notes, no version.\n");
+    const r = searchMemory("2.49.0 SLSA", { home });
+    const paths = new Set(r.hits.map((h) => h.relpath));
+    assert.ok(paths.has("memory_summary.md"), "summary keep");
+    assert.ok(paths.has("MEMORY.md"), "handbook v-prefix recovered");
+    assert.ok(!paths.has("noise.md"));
+    assert.ok(!r.warnings.some((w) => w.includes("lower confidence")), "strict v-prefix, no relax");
+    assert.ok(r.hits.some((h) => h.relpath === "MEMORY.md" && /v2\.49\.0/i.test(h.excerpt)));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("memory search: c-4 LSP still excludes NaiControlsPanel when a real hit exists", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-r1-c4-"));
+  try {
+    const mem = join(home, "memories");
+    mkdirSync(mem, { recursive: true });
+    writeFileSync(join(mem, "MEMORY.md"), "# Notes\n\nTouched NaiControlsPanel and negativePrompt.\n");
+    writeFileSync(join(mem, "real.md"), "# Real\n\nThe LSP server crashed.\n");
+    const r = searchMemory("LSP", { home });
+    assert.ok(r.hits.length >= 1);
+    assert.ok(r.hits.every((h) => h.relpath === "real.md"));
+    assert.ok(!r.warnings.some((w) => w.includes("lower confidence")));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("memory search: relaxes only the boundary group that missed the whole corpus", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-r1-group-miss-"));
+  try {
+    const mem = join(home, "memories");
+    mkdirSync(mem, { recursive: true });
+    writeFileSync(join(mem, "real-lsp.md"), "# Real\n\nThe LSP server crashed.\n");
+    writeFileSync(join(mem, "glued.md"), "# Glued\n\nNaiControlsPanel and PR3956 together.\n");
+    writeFileSync(join(mem, "both.md"), "# Both\n\nThe LSP server and PR3956 shipped.\n");
+    const r = searchMemory("3956 LSP", { home });
+    const paths = r.hits.map((h) => h.relpath);
+    assert.ok(paths.includes("both.md"), "substring 3956 + boundary LSP");
+    assert.ok(!paths.includes("glued.md"), "NaiControlsPanel must not satisfy LSP after group-miss relax");
+    assert.ok(!paths.includes("real-lsp.md"), "no 3956 in the standalone LSP file");
+    assert.ok(r.warnings.some((w) => w.includes("lower confidence")));
   } finally {
     rmSync(home, { recursive: true, force: true });
   }


### PR DESCRIPTION
`cxc memory search "2.49.0 SLSA"` lost the MEMORY.md chunks after #105: `2.49.0` matched the FILENAME rule (the `.0` looked like an extension) and was boundary-gated, but the corpus writes `v2.49.0`, and the `v` is a token character — so the boundary test failed. The relaxed retry did not help because it only opens when *every* source misses, and memory_summary.md already matched.

**After.** Dotted versions (optional `v` prefix) are a VERSION class judged before FILENAME, and a lone token-edge `v` before a version core counts as a boundary. The zero-result retry tallies which query groups occur anywhere in the corpus (markdown + stage1_outputs) and relaxes only the boundary groups absent everywhere; a group that hits on boundaries keeps its precision when a sibling misses (c-4: `LSP` never matches inside NaiControlsPanel).

| query (live index, read-only) | before | after |
|---|---|---|
| `2.49.0 SLSA` | 2 hits, MEMORY.md missing | 4 hits, MEMORY.md ×2, no relax warning |
| `LSP` | 2 boundary hits | identical |

**Validation.** recall suite 142 pass (5 new: VERSION classification, v-prefix boundary, golden recovery, c-4 retained, per-group relax); dist-freshness + packaging 5 pass; receipt bound to `497d573d`. Tests badge 2951→2956.

**Stack** (merge order; all PRs target `dev`):
| # | PR | layer |
|---|---|---|
| 0 | #123 (merged) | roadmap |
| 1 | #124 (merged) | wp1 gate parser |
| 2 | this PR | wp2 symbol boundary (independent of wp1) |
| 3 | next | wp3 recall skill (after wp1 + wp2) |

Plan: `devlog/_plan/260910_memory-followup-roadmap/020_wp2_symbol-boundary.md`.

