### PR TITLE
feat(recall): relax long natural-language queries with a required/optional match plan

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C974_passing-brightgreen" alt="2,974 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C993_passing-brightgreen" alt="2,993 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C974_passing-brightgreen" alt="2,974 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C993_passing-brightgreen" alt="2,993 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-2%2C974_passing-brightgreen" alt="2,974 tests passing">
+  <img src="https://img.shields.io/badge/tests-2%2C993_passing-brightgreen" alt="2,993 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260910_memory-followup-roadmap/050_wp5_natural-language-query.md
+++ b/devlog/_plan/260910_memory-followup-roadmap/050_wp5_natural-language-query.md
@@ -631,3 +631,21 @@ node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/test/dist-freshness.t
 blocker #3(index/scan 동등성): `index-search.ts:243-249`의 recent 경로에는 JS 술어가 없고, top-up 스윕(:213-221)도 `textMatches`를 적용하지 않는다. 선택 그룹을 SQL WHERE에서 빼면 필수어 0개 질의에서 recent 모드가 "최신 limit+1건"으로 퇴화한다. 수정: `planMatches(plan, text)`를 (1) 관련도 경로의 후보 필터, (2) recent 경로의 행 필터, (3) top-up 스윕의 행 필터 세 곳 모두에 최종 술어로 적용한다. §4.4에 이 세 지점을 path:line으로 적고, §5 테스트 표에 "필수어 0개 9단어 질의를 relevance/recent 두 모드로 돌려 히트 집합이 같다"(index/scan 동등성 확장, `test/index.test.ts:65` 비교 함수 재사용) 케이스를 추가한다. 오라클 문장은 필수어가 최소 1개 있는 것과 0개인 것 두 종류를 둔다.
 
 행 번호 정정: §4 before 인용 `chat-search.ts:116-118`은 117행(`const source = ...`)을 생략 표시 없이 뺐다. 전체 인용으로 읽는다.
+
+
+## P 재검증 (wp5 사이클, 2026-09-10)
+
+기준 트리 `19e2dd5d`(origin/dev, #127 머지 직후). 계획 이후 recall src가 wp2(#125: query-words VERSION/relaxGroupsAt, memory-search groupHit/markGroupPresence/fillStage1Presence/collect(active,tallyPresence))와 wp4(#127: repo-key.ts, rollout readRolloutMeta.repoKey, index-search candidateFilter repo_key/repoThreadIds, memory-search scopeAdjust repoKey, chat-search scan 필터, cli 도움말)로 바뀌었다. 이 문서의 §2 인용 행 번호는 밀렸고 일부 before 블록은 현재 코드와 다르다. B는 심볼로 찾아 patch하며 다음을 지킨다: (1) `planMatches`를 relevance 후보 재검사·recent 행 필터·top-up 스윕 세 지점에 최종 술어로(A3), recent fetch는 `poolSize`로 올린 뒤 술어 적용 후 `limit+1` 절단; (2) `splitQueryWordsRaw`/`MAX_WORDS`는 VERSION 분류·relaxGroupsAt와 공존(자르지 않고 완화 임계로); (3) chat `--synonyms`는 기본 off; (4) 불용어는 `그/이/저/것/문제/방법`만; (5) 골든셋 픽스처는 합성 홈만 쓰고(`--home`·`--index-path` 고정) 실인덱스를 읽지 않는다; (6) index/scan 동등성 테스트에 필수어 0개·1개 이상 오라클을 relevance/recent 두 모드로. 브랜치 `codex/memory-l1-wp5-nl-query`(origin/dev 위).
+
+
+
+## A 감사 반영 (wp5 round 1, 2026-09-10)
+
+리뷰어(grok-4.6) GO-WITH-FIXES(blocker 3, Medium 2). 전부 구현 제약으로 접는다(B가 준수, C가 테스트로 확인).
+
+1. memory-search: `planMatches`를 검색 시작 시 한 번 컴파일한 고정 plan에 묶지 않는다. `collect(active, tallyPresence)` 안에서 `compileMatchPlan(active, raw, anyMode, relax)`를 다시 만들어 #125의 `relaxGroupsAt(groups, miss)` 재시도가 boundary:false 그룹으로 매칭되게 한다. `markGroupPresence`는 원본 groups 기준 유지. `searchStage1`은 필수어 0개면 `WHERE 1`(빈 conds로 잘못된 SQL 금지).
+2. index-search: `candidateFilter`(시그니처 `ResolvedQuery`)는 withWords 분기만 교체한다. #127의 synthetic/tools/role/cutoff/source 조건과 cwd 접두사 OR `f.repo_key` OR `repoThreadIds IN` 꼬리는 원문 유지, 필수어 SQL과 AND로 결합. `laneRanks` 입력은 필수 lead(필수 0이면 선택 ≥3자 lead OR, 상한 6). A3 세 지점(relevance 재검사·top-up 스윕·recent 행 필터) + recent `poolSize` fetch 후 `limit+1` 절단 유지.
+3. 픽스처 G-R2-chat: R2 assistant 문장에 선택 원형을 3개 이상 넣는다(예: `2.49.0 npm 패키지가 진짜 그 소스인지 검증한 기록. 배포하고 provenance`)여야 synonyms-off minOptional=3을 채운다.
+4. Medium: 회귀 범위 문구를 "E 분기(필수/선택)는 8단어 이하에서 꺼진다; 불용어·시드·`인지` 어미는 8단어 이하에도 적용되며 P2(5토큰)는 그 층으로 복구된다"로 정정. `query-words.test.ts:34`의 MAX_WORDS 절단 핀은 새 동작(자르지 않고 완화 임계)에 맞게 갱신.
+5. Medium: `planMatches` 인자 순서는 §4.1 타입대로 `planMatches(lowerText, plan)`로 세 지점 통일.
+

--- a/devlog/_plan/260910_memory-followup-roadmap/075_wp5_receipt.md
+++ b/devlog/_plan/260910_memory-followup-roadmap/075_wp5_receipt.md
@@ -1,0 +1,31 @@
+# 075 — wp5 receipt: 자연어 질의 완화
+
+날짜: 2026-09-10 (KST). 세션 01a0880e-149e-72d0-86db-53bd99bcac0e. 브랜치 `codex/memory-l1-wp5-nl-query`(origin/dev 19e2dd5d 위), 구현 커밋 `69a3115c`. 구현은 opus-5 실행 서브에이전트, 검증·통합은 메인.
+
+## 결론
+
+9단어 이상 질의가 잘리지 않고, 심볼·버전·고유명사를 필수(AND), 나머지를 ceil(n/2) 쿼터로 매칭하는 MatchPlan 하나를 chat index·chat scan·memory가 공유한다. 8단어 이하는 이전 전항 AND 그대로다. 합성 골든셋(D3/P2/R2 chat+memory n≥1, c-4·c-5 유지, index/scan 동등성 오라클 2종×2모드)이 테스트로 고정됐고, 실인덱스에서는 D3 chat 0→2(7.3초→0.75초), D3 memory 0→3, P2 chat `--synonyms` 0→3이 됐다.
+
+## 무엇이 바뀌었나
+
+- `query-words.ts`: `MatchPlan`/`compileMatchPlan`/`planMatches(lowerText, plan)`/`isRequiredTerm`/`dropStopwords`(그/이/저/것/문제/방법)/`MAX_QUERY_TERMS=16`; `MAX_WORDS=8`은 절단이 아니라 완화 임계.
+- `chat-search.ts` `--synonyms`(기본 off) + `chatMatchPlan`; `index-search.ts` 세 지점(relevance 재검사·top-up·recent)에 `planMatches` 최종 술어, recent는 `planPoolSize`(필수 0개면 2000)로 fetch 후 `limit+1` 절단, `candidateFilter`는 withWords 분기만 교체(#127 cwd/repo_key 꼬리 유지), `laneQuery` 헬퍼; `rollout.ts` scan 경로 같은 predicate; `memory-search.ts` `collect` 안에서 plan 재컴파일(#125 `relaxGroupsAt` 재시도 유지), stage1 필수 0개 `WHERE 1`; `synonyms.ts` 시드 5그룹 + 어미 `인지`; `cli.ts` 플래그·USAGE.
+- 테스트 +19(177): NEW `nl-query.test.ts`, `fixtures.ts addNlGoldenCorpus`, query-words/synonyms/index 테스트 갱신(MAX_WORDS 절단 핀 → 임계). SKILL.md Commands 펜스에 `--synonyms`, Two engines·사다리 문단 갱신. 배지 2974→2993.
+
+계획과의 차이: 상수명 `QUERY_STOPWORDS`; R2 픽스처는 옛 8단어 AND로도 매칭되는 문장을 피해 선택 원형 4개만 포함(회귀 증명 유지); `matchesFilePrefilter`에 `planIsEmpty` 가드; CLI 플래그 배선 테스트 1건 추가.
+
+## 증거
+
+- receipt `.codexclaw/evidence/01a0880e-149e-72d0-86db-53bd99bcac0e/test-receipt.json`: `/tmp/mfu-260910/check-wp5.sh` exit 0 @ 69a3115c — 합성 골든 58 pass, 실인덱스 D3 chat 2 / D3 memory 3 / P2 chat --synonyms 3 / LSP 전부 경계 / `2.49.0 SLSA` MEMORY.md 포함, recall 177 pass, dist-freshness·packaging·synopsis 7 pass.
+- 감사: grok-4.6 리뷰어 GO-WITH-FIXES(3 High + 2 Medium) → 구현 제약으로 접음, C 테스트가 확인(relax 재시도 테스트, cwd-scope 테스트, nl-query 골든).
+
+## 개선되지 않은 것 (LOOP-PESSIMIST-01)
+
+- 실인덱스에서 P2(5토큰, 완화 분기 꺼짐)와 R2(필수 `2.49.0∧npm`과 굴절형이 한 메시지에 없음)는 여전히 0. 합격 기준은 합성 골든셋이고 라이브는 참고다.
+- D3 chat의 히트 2건은 어절 겹침 순위라 정답 스레드가 아니다. 스킬 사다리(재작성)는 여전히 필요하다.
+- 방향이 틀렸다는 신호: 필수어 0개 긴 질의가 recent 모드에서 pool 2000 이상을 요구해 지연이 통제의 20배를 넘으면 쿼터 규칙이 아니라 SQL 측 절단이 원인이다.
+
+## 다음
+
+wp6(네이티브 통합 보강)만 남았다.
+

--- a/plugins/codexclaw/components/recall/dist/chat-search.js
+++ b/plugins/codexclaw/components/recall/dist/chat-search.js
@@ -2,8 +2,10 @@
  * chat-search.ts — cli-jaw-parity chat search over Codex rollout JSONL files.
  *
  * Matching model (superset of cli-jaw's dashboard chat search):
- *   - query splits into <=8 case-insensitive words; AND by default, OR with `any`
- *     (cli-jaw only offers OR over <=5 words);
+ *   - query splits into <=16 case-insensitive words; AND by default, OR with
+ *     `any` (cli-jaw only offers OR over <=5 words). Past MAX_WORDS the AND
+ *     relaxes into required + half-of-optional (see query-words.ts MatchPlan);
+ *   - `synonyms` opts into memory's ko/en table and Korean stemmer (default off);
  *   - content AND tool_log both match (parity with cli-jaw's match_field);
  *   - `days` prunes by the sessions/YYYY/MM/DD directory date (default 7, 0 = all);
  *   - `source` filters main vs subagent rollouts (cli-jaw has no subagent corpus);
@@ -26,7 +28,18 @@ import { repoKeyForCwd, repoKeysEqual, readOriginUrl,                    } from 
 import { openIndex, openIndexReadOnly, indexPath, indexStatus } from "./index-db.js";
 import { ingest } from "./ingest.js";
 import { queryIndex,                } from "./index-search.js";
-import { splitQueryWords, MAX_WORDS } from "./query-words.js";
+import { expandQueryWords } from "./synonyms.js";
+import {
+  splitQueryWords,
+  splitQueryWordsRaw,
+  dropStopwords,
+  compileMatchPlan,
+  planMatches,
+  planIsEmpty,
+  MAX_WORDS,
+
+
+} from "./query-words.js";
 
 
 
@@ -105,14 +118,34 @@ export { splitQueryWords, MAX_WORDS };
 
 
 
+
+
+
+
+
+
 /**
- * Chat matching stays substring on raw lowercase words. R1's boundary gating is
- * scoped to memory search on purpose: the index path resolves words through
- * trigram MATCH, and changing chat semantics without changing the index query
- * would break the index/scan equivalence oracle (test/index.test.ts:46).
+ * Chat groups. Boundary gating stays OFF on every chat term, symbol-shaped ones
+ * included: the index path resolves words through trigram MATCH, and a boundary
+ * rule only the JS side knew about would break the index/scan equivalence
+ * oracle (test/index.test.ts). R1 boundary matching stays memory-search's.
  */
-function entryMatches(lowerText        , words          , anyMode         )          {
-  return anyMode ? words.some((w) => lowerText.includes(w)) : words.every((w) => lowerText.includes(w));
+function groupsForChat(raw          , synonyms         )               {
+  if (!synonyms) return raw.map((w) => [{ text: w.toLowerCase(), boundary: false }]);
+  return expandQueryWords(raw).map((g) => g.map((t) => ({ text: t.text, boundary: false })));
+}
+
+/**
+ * The match plan for one chat query, compiled once and handed to both engines.
+ *
+ * Relaxation is decided on the ORIGINAL token count: a 9-word query that loses
+ * one stopword still relaxes, because otherwise the threshold would move under
+ * the query depending on how much padding it happened to carry.
+ */
+export function chatMatchPlan(query        , anyMode         , synonyms         )            {
+  const rawAll = splitQueryWordsRaw(query);
+  const raw = dropStopwords(rawAll);
+  return compileMatchPlan(groupsForChat(raw, synonyms), raw, anyMode, rawAll.length > MAX_WORDS);
 }
 
 export function searchChat(query        , opts                    = {})                   {
@@ -122,18 +155,17 @@ export function searchChat(query        , opts                    = {})         
   const contextN = Math.max(opts.context ?? 0, 0);
   const anyMode = opts.any ?? false;
   const source = opts.source ?? "main";
-  const words = splitQueryWords(query);
+  const plan = chatMatchPlan(query, anyMode, opts.synonyms === true);
   const cutoffIsoShared = days > 0 ? new Date(Date.now() - days * 86_400_000).toISOString() : null;
   // One git call per search, never one per file: --cwd names a project, and the
   // remote of that project cannot change while the query runs.
   const repoKey = opts.cwd ? repoKeyForCwd(opts.cwd, opts.readOriginUrl ?? readOriginUrl) : null;
 
-  if (!opts.scan && words.length > 0) {
+  if (!opts.scan && !planIsEmpty(plan)) {
     try {
       return searchViaIndex(query, opts, {
         home,
-        words,
-        anyMode,
+        plan,
         limit,
         contextN,
         cutoffIso: cutoffIsoShared,
@@ -141,21 +173,20 @@ export function searchChat(query        , opts                    = {})         
         repoKey,
       });
     } catch (err) {
-      const scan = searchViaScan(query, opts, { home, days, limit, contextN, anyMode, source, repoKey });
+      const scan = searchViaScan(query, opts, { home, days, limit, contextN, plan, source, repoKey });
       scan.warnings.unshift(
         `index unavailable (${err instanceof Error ? err.message : String(err)}) — served by scan`,
       );
       return scan;
     }
   }
-  return searchViaScan(query, opts, { home, days, limit, contextN, anyMode, source, repoKey });
+  return searchViaScan(query, opts, { home, days, limit, contextN, plan, source, repoKey });
 }
 
 function searchViaIndex(
   query        ,
   opts                   ,
   shared
-
 
 
 
@@ -202,8 +233,7 @@ function searchViaIndex(
       refreshed = r.ingested + r.appended;
     }
     const result = queryIndex(db, {
-      words: shared.words,
-      anyMode: shared.anyMode,
+      plan: shared.plan,
       limit: shared.limit,
       contextN: shared.contextN,
       cutoffIso: shared.cutoffIso,
@@ -250,9 +280,8 @@ function searchViaScan(
    ,
 )                   {
   const started = Date.now();
-  const { home, days, limit, contextN, anyMode, source, repoKey } = shared;
+  const { home, days, limit, contextN, plan, source, repoKey } = shared;
   const includeTools = opts.includeTools ?? true;
-  const words = splitQueryWords(query);
   const warnings           = [];
 
   const result                   = {
@@ -264,7 +293,7 @@ function searchViaScan(
     elapsedMs: 0,
     mode: "scan",
   };
-  if (words.length === 0) {
+  if (planIsEmpty(plan)) {
     warnings.push("empty query");
     result.elapsedMs = Date.now() - started;
     return result;
@@ -302,7 +331,7 @@ function searchViaScan(
       warnings.push(`unreadable rollout: ${file.path} (${err instanceof Error ? err.message : String(err)})`);
       continue;
     }
-    if (!matchesFilePrefilter(content.toLowerCase(), words, anyMode)) continue;
+    if (!matchesFilePrefilter(content.toLowerCase(), plan)) continue;
 
     const entries = parseRollout(content, includeTools);
     const visible = entries.filter(
@@ -317,7 +346,7 @@ function searchViaScan(
       const e = visible[i];
       if (opts.role && e.role !== opts.role) continue;
       if (cutoffIso && e.ts !== "" && e.ts < cutoffIso) continue;
-      if (!entryMatches(e.text.toLowerCase(), words, anyMode)) continue;
+      if (!planMatches(e.text.toLowerCase(), plan)) continue;
       fileMatched = true;
       const tm = meta.threadId ? threadMeta.byId.get(meta.threadId) : undefined;
       result.hits.push({

--- a/plugins/codexclaw/components/recall/dist/cli.js
+++ b/plugins/codexclaw/components/recall/dist/cli.js
@@ -25,7 +25,7 @@ import {
 const USAGE = [
   "cxc chat search \"<query>\" [--days N] [--cwd PATH] [--role r] [--source main|subagent|all]",
   "                           [--limit N] [--context N] [--any] [--all] [--no-tools]",
-  "                           [--recent] [--scan] [--no-refresh] [--json]",
+  "                           [--recent] [--scan] [--no-refresh] [--synonyms] [--json]",
   "cxc chat index [--rebuild] [--status] [--json]",
   "cxc memory search \"<query>\" [--days N] [--limit N] [--any] [--no-synonyms]",
   "                             [--cwd PATH] [--cwd-only PATH] [--no-chat] [--json]",
@@ -47,6 +47,7 @@ const USAGE = [
   "  --scan       force the raw JSONL scan path (skip the sidecar index)",
   "  --no-refresh skip refresh-on-query ingest (fastest, index may be stale)",
   "  --no-synonyms memory search: raw words only — no ko/en synonyms, no korean stem",
+  "  --synonyms   chat search: expand ko/en synonyms + korean stems (default off)",
   "  --json       machine-readable output (text fields clipped at 500 chars)",
   "  --full       with --json: emit unclipped text fields",
   "  --home PATH  search an alternate Codex home (default $CODEX_HOME ?? ~/.codex)",
@@ -76,6 +77,7 @@ function parseFlags(args          )              {
       scan: { type: "boolean", default: false },
       "no-refresh": { type: "boolean", default: false },
       "no-synonyms": { type: "boolean", default: false },
+      synonyms: { type: "boolean", default: false },
       "no-chat": { type: "boolean", default: false },
       full: { type: "boolean", default: false },
       rebuild: { type: "boolean", default: false },
@@ -114,6 +116,9 @@ function runChatSearch(args          )         {
     limit: numFlag(values, "limit"),
     context: numFlag(values, "context"),
     any: values.any === true,
+    // Default off: chat is the raw corpus, and expanding every word there
+    // widens a multi-GB scan (memory search defaults the other way).
+    synonyms: values.synonyms === true,
     role: typeof values.role === "string" ? values.role : null,
     cwd: typeof values.cwd === "string" ? values.cwd : null,
     source,

--- a/plugins/codexclaw/components/recall/dist/index-search.js
+++ b/plugins/codexclaw/components/recall/dist/index-search.js
@@ -6,7 +6,10 @@
  *     and CJK alike; the WP2 spike verified 2-char CJK words return nothing);
  *   - shorter words fall back to LIKE over msgs.text (indexed table, still far
  *     smaller than raw JSONL);
- *   - AND intersects per-word id sets, OR unions them (scan-path semantics).
+ *   - AND intersects per-word id sets, OR unions them (scan-path semantics);
+ *   - a relaxed plan (query-words.ts MatchPlan) puts only its REQUIRED groups in
+ *     SQL and leaves the optional quota to the JS predicate, so SQL is a
+ *     candidate generator and `textMatches` is the authority.
  * Filters (synthetic/source/cwd/role/days/tools) compile to SQL.
  *
  * Ordering has two modes. "recent" is the original pure ts-DESC query with
@@ -26,6 +29,7 @@ import { loadThreadMeta,                       } from "./threads-db.js";
 import { stateDbPath } from "./paths.js";
 import { filesHasColumn } from "./index-db.js";
 import { normalizeRepoKey, repoKeysEqual } from "./repo-key.js";
+import { planMatches, allGroups,                                 } from "./query-words.js";
 
 /** Result ordering: fused relevance (default) or the original pure recency. */
 
@@ -97,6 +101,45 @@ function poolSize(limit        )         {
   return Math.min(500, Math.max(100, limit * 10));
 }
 
+/**
+ * Depth for a plan whose WHERE clause carries no word condition at all — a
+ * relaxed query with no required symbol, where the JS predicate is the only
+ * thing narrowing the corpus. It has to look deeper before throwing rows away.
+ */
+const RELAXED_POOL = 2_000;
+
+/** Lane/sweep depth for this plan. */
+function planPoolSize(plan           , limit        )         {
+  const base = poolSize(limit);
+  const noWordSql = !plan.anyMode && plan.required.length === 0 && plan.optional.length > 0;
+  return noWordSql ? Math.max(base, RELAXED_POOL) : base;
+}
+
+/** Optional lead words fed to a lane when the plan has no required group. */
+const MAX_OPTIONAL_LANE_WORDS = 6;
+
+/**
+ * Which words rank the lanes and how they join. Lane membership is NOT the
+ * match test, so a lane only needs a cheap, selective approximation: the
+ * required leads ANDed when there are any, otherwise an OR over the longest-
+ * serviceable optional leads (a lane MATCH over nine ORed Korean words costs
+ * more than it ranks). Group leads only — the word the user typed is the one
+ * whose BM25 rank is worth having.
+ */
+function laneQuery(plan           )                                        {
+  const lead = (g            ) => g[0]?.text ?? "";
+  const nonEmpty = (w        ) => w !== "";
+  if (plan.anyMode) return { words: allGroups(plan).map(lead).filter(nonEmpty), anyMode: true };
+  if (plan.required.length > 0) return { words: plan.required.map(lead).filter(nonEmpty), anyMode: false };
+  return {
+    words: plan.optional
+      .map(lead)
+      .filter((w) => [...w].length >= 3)
+      .slice(0, MAX_OPTIONAL_LANE_WORDS),
+    anyMode: true,
+  };
+}
+
 /** RRF contribution of one lane; ranks are 0-based, the formula is 1-based. */
 export function rrfScore(rank                    , weight        )         {
   return rank === undefined ? 0 : weight / (RRF_K + rank + 1);
@@ -148,17 +191,34 @@ function wordCondition(word        , params           )         {
   return "lower(m.text) LIKE ? ESCAPE '\\'";
 }
 
+/** One OR-group: any member present satisfies it. */
+function groupCondition(group            , params           )         {
+  if (group.length === 0) return "1";
+  return `(${group.map((t) => wordCondition(t.text, params)).join(" OR ")})`;
+}
+
 /**
- * The candidate WHERE clause: word matching plus every filter. This is the sole
- * definition of what "matches", shared by both ordering modes, so ranking can
- * never widen or narrow recall.
+ * The candidate WHERE clause: word matching plus every filter, shared by both
+ * ordering modes so ranking can never widen or narrow recall.
+ *
+ * Only the plan's REQUIRED groups enter SQL. The optional groups are a quota,
+ * not a requirement, and ANDing them here would re-impose exactly the AND the
+ * relaxation exists to break; ORing them would widen the candidate set for no
+ * gain. When there is no required group the word clause is omitted entirely and
+ * `textMatches` narrows the sweep instead.
  */
 function candidateFilter(opts               , withWords = true)                                       {
   const params            = [];
   const conds           = [];
   if (withWords) {
-    const wordConds = opts.words.map((w) => wordCondition(w, params));
-    conds.push(`(${wordConds.join(opts.anyMode ? " OR " : " AND ")})`);
+    if (opts.plan.anyMode) {
+      const groups = allGroups(opts.plan);
+      if (groups.length > 0) {
+        conds.push(`(${groups.map((g) => groupCondition(g, params)).join(" OR ")})`);
+      }
+    } else if (opts.plan.required.length > 0) {
+      conds.push(`(${opts.plan.required.map((g) => groupCondition(g, params)).join(" AND ")})`);
+    }
   }
   if (!opts.includeSynthetic) conds.push("m.synthetic = 0");
   if (!opts.includeTools) conds.push("m.match_field = 'content'");
@@ -202,14 +262,13 @@ function candidateFilter(opts               , withWords = true)                 
 }
 
 /**
- * Scan-path word semantics: case-insensitive substring, AND by default.
- * Applied in JS to the small lane-candidate set instead of re-running the
- * trigram subqueries in SQL — same answer, and it drops ~250ms on the 12GB
- * index because the expensive MATCH is not evaluated twice.
+ * Scan-path semantics, in JS, on every row that could become a hit. Applied
+ * here instead of re-running the trigram subqueries in SQL — same answer, and
+ * it drops ~250ms on the 12GB index because the expensive MATCH is not
+ * evaluated twice. It is also the only place the optional quota is enforced.
  */
-function textMatches(text        , words          , anyMode         )          {
-  const lower = text.toLowerCase();
-  return anyMode ? words.some((w) => lower.includes(w)) : words.every((w) => lower.includes(w));
+function textMatches(text        , plan           )          {
+  return planMatches(text.toLowerCase(), plan);
 }
 
 const ROW_COLUMNS = `SELECT m.id, m.path, m.ord, m.ts, m.role, m.match_field, m.text,
@@ -248,11 +307,12 @@ function laneRanks(db      , table                         , words          , an
  * degenerates cleanly to the old recency order).
  */
 function rankedRows(db      , opts               )                                           {
-  const k = poolSize(opts.limit);
+  const k = planPoolSize(opts.plan, opts.limit);
   const nowMs = opts.nowMs ?? Date.now();
-  const triWords = opts.words.filter((w) => [...w].length >= 3);
-  const ftsRanks = laneRanks(db, "msgs_fts", opts.words, opts.anyMode, k);
-  const triRanks = laneRanks(db, "msgs_tri", triWords, opts.anyMode, k);
+  const lane = laneQuery(opts.plan);
+  const triWords = lane.words.filter((w) => [...w].length >= 3);
+  const ftsRanks = laneRanks(db, "msgs_fts", lane.words, lane.anyMode, k);
+  const triRanks = laneRanks(db, "msgs_tri", triWords, lane.anyMode, k);
 
   const byId = new Map                  ();
   const laneIds = [...new Set([...ftsRanks.keys(), ...triRanks.keys()])];
@@ -266,7 +326,7 @@ function rankedRows(db      , opts               )                              
       // Lane membership is not the match test: FTS tokenization is coarser than
       // the scan path's substring rule ("releases" tokenizes away from
       // "release"). Re-checking here keeps index/scan parity exact.
-      if (textMatches(String(r.text), opts.words, opts.anyMode)) byId.set(Number(r.id), r);
+      if (textMatches(String(r.text), opts.plan)) byId.set(Number(r.id), r);
     }
   }
   // Top-up sweep. Only runs when the lanes could not fill the page: a query no
@@ -280,7 +340,10 @@ function rankedRows(db      , opts               )                              
       .all(...full.params, k)              ;
     for (const r of recent) {
       const id = Number(r.id);
-      if (!byId.has(id)) byId.set(id, r);
+      // The sweep bypasses the lanes, so it needs the predicate too: a relaxed
+      // plan puts no word condition in SQL, and an unfiltered sweep would top
+      // the page up with the newest messages in the corpus.
+      if (!byId.has(id) && textMatches(String(r.text), opts.plan)) byId.set(id, r);
     }
   }
 
@@ -314,9 +377,13 @@ export function queryIndex(db      , opts                   )                   
   let truncated         ;
   if ((query.order ?? "relevance") === "recent") {
     const { where, params } = candidateFilter(query);
-    rows = db
+    // A pool, not limit+1: the optional quota lives in JS, so rows have to pass
+    // the predicate before the page is cut. Without this, "recent" ordering on
+    // a relaxed query degrades into "the newest limit+1 messages there are".
+    const pool = db
       .prepare(`${ROW_COLUMNS}${where} ORDER BY m.ts DESC LIMIT ?`)
-      .all(...params, query.limit + 1)              ;
+      .all(...params, planPoolSize(query.plan, query.limit))              ;
+    rows = pool.filter((r) => textMatches(String(r.text), query.plan)).slice(0, query.limit + 1);
     truncated = rows.length > query.limit;
     if (truncated) rows.length = query.limit;
   } else {

--- a/plugins/codexclaw/components/recall/dist/memory-search.js
+++ b/plugins/codexclaw/components/recall/dist/memory-search.js
@@ -27,6 +27,12 @@ import {
   countTermOccurrences,
   hasBoundaryTerm,
   relaxGroupsAt,
+  dropStopwords,
+  compileMatchPlan,
+  planMatches,
+  allGroups,
+  MAX_WORDS,
+
 
 } from "./query-words.js";
 import { expandQueryWords } from "./synonyms.js";
@@ -380,11 +386,6 @@ function groupHit(lowerText        , group            )          {
   return group.some((term) => termIncludes(lowerText, term));
 }
 
-/** AND across groups, OR within a group; anyMode = any member of any group. */
-function matches(lowerText        , groups              , anyMode         )          {
-  return anyMode ? groups.some((g) => groupHit(lowerText, g)) : groups.every((g) => groupHit(lowerText, g));
-}
-
 /**
  * Record which groups occur anywhere in this text (independently of the other
  * groups). Drives the per-group relaxed retry: only a boundary group that is
@@ -424,7 +425,12 @@ export function searchMemory(query        , opts                      = {})     
   const cutoffMs = days > 0 ? nowMs - days * 86_400_000 : null;
   // Original case survives to expansion: the uppercase-acronym rule is the only
   // thing separating `CI` from a two-letter fragment (query-words.ts).
-  const words = splitQueryWordsRaw(query);
+  const rawAll = splitQueryWordsRaw(query);
+  // Padding removal and the relaxation threshold are both wp5. The threshold is
+  // judged on the ORIGINAL count so dropping `그` or `문제` cannot move it: the
+  // 9-word release query still relaxes after losing its one stopword.
+  const words = dropStopwords(rawAll);
+  const relax = rawAll.length > MAX_WORDS;
   const groups               = (opts.synonyms ?? true)
     ? expandQueryWords(words)
     : expandQueryWords(words).map((group) => [group[0]]);
@@ -443,6 +449,10 @@ export function searchMemory(query        , opts                      = {})     
 
   const present            = groups.map(() => false);
   const collect = (active              , tallyPresence         )              => {
+    // Recompiled per pass on purpose: the relaxed retry below hands in groups
+    // whose boundary flags were dropped, and a plan captured once before that
+    // retry would still be matching on token boundaries.
+    const plan = compileMatchPlan(active, words, anyMode, relax);
     const candidates              = [];
     const matchedThreadIds = new Set        ();
     scannedFiles = 0;
@@ -460,7 +470,7 @@ export function searchMemory(query        , opts                      = {})     
       scannedFiles += 1;
       const lowerFile = content.toLowerCase();
       if (tallyPresence) markGroupPresence(lowerFile, groups, present);
-      if (!matches(lowerFile, active, anyMode)) continue;
+      if (!planMatches(lowerFile, plan)) continue;
       const threadId = frontmatterThreadId(content);
       if (threadId) matchedThreadIds.add(threadId);
       const relpath = relative(root, file).split(sep).join("/");
@@ -474,7 +484,7 @@ export function searchMemory(query        , opts                      = {})     
       const fileRepoKey = normalizeRepoKey(threadMeta?.gitOriginUrl);
       for (const chunk of paragraphChunks(content)) {
         const lower = chunk.text.toLowerCase();
-        if (!matches(lower, active, anyMode)) continue;
+        if (!planMatches(lower, plan)) continue;
         const scoped = scopeAdjust(scope, fileCwd, lower, fileRepoKey);
         if (!scoped.keep) continue;
         candidates.push({
@@ -493,8 +503,8 @@ export function searchMemory(query        , opts                      = {})     
     }
     searchStage1(
       home,
+      plan,
       active,
-      anyMode,
       cutoffMs,
       lowerPhrase,
       nowMs,
@@ -649,8 +659,8 @@ function fillStage1Presence(
 /** stage1_outputs holds per-thread raw_memory + rollout_summary; read-only, fail-soft. */
 function searchStage1(
   home        ,
+  plan           ,
   groups              ,
-  anyMode         ,
   cutoffMs               ,
   lowerPhrase        ,
   nowMs        ,
@@ -675,15 +685,23 @@ function searchStage1(
     // prefilter, and the row body is re-checked with the same `matches`
     // predicate the file path uses, so boundary semantics hold either way.
     const params           = [];
-    const conds = groups.map((group) => {
+    const groupCond = (group            )         => {
       const members = group.map((w) => {
         params.push(`%${w.text}%`);
         const n = params.length;
         return `(lower(raw_memory) LIKE ?${n} OR lower(rollout_summary) LIKE ?${n})`;
       });
-      return `(${members.join(" OR ")})`;
-    });
-    const where = conds.join(anyMode ? " OR " : " AND ");
+      return members.length > 0 ? `(${members.join(" OR ")})` : "1";
+    };
+    // Required groups only. The optional quota is enforced by planMatches
+    // below; ANDing optional groups here is what kept the long release query at
+    // zero hits, and a plan with no required group prefilters nothing at all —
+    // `WHERE 1`, never an empty condition list that would be invalid SQL.
+    const where = plan.anyMode
+      ? allGroups(plan).map(groupCond).join(" OR ") || "1"
+      : plan.required.length > 0
+        ? plan.required.map(groupCond).join(" AND ")
+        : "1";
     const sql = `SELECT thread_id, raw_memory, rollout_summary, source_updated_at FROM stage1_outputs
       WHERE ${where} ORDER BY source_updated_at DESC`;
     const rows = db.prepare(sql).all(...params)                                  ;
@@ -694,8 +712,9 @@ function searchStage1(
       if (cutoffMs && updatedSec !== null && updatedSec * 1000 < cutoffMs) continue;
       const body = `${String(r.raw_memory ?? "")}\n${String(r.rollout_summary ?? "")}`;
       const lowerBody = body.toLowerCase();
-      // The LIKE prefilter above ignores boundaries; enforce them here.
-      if (!matches(lowerBody, groups, anyMode)) continue;
+      // The LIKE prefilter above ignores boundaries and skips the optional
+      // groups; the plan predicate enforces both here.
+      if (!planMatches(lowerBody, plan)) continue;
       // stage1_outputs has no cwd column (schema dump, 011 4.3); threads.cwd is
       // the accurate substitute and it covered all 516 rows in the live store.
       const rowThread = threadId ? scope?.threadCwd.get(threadId) : undefined;

--- a/plugins/codexclaw/components/recall/dist/query-words.js
+++ b/plugins/codexclaw/components/recall/dist/query-words.js
@@ -17,8 +17,26 @@
  * every symbol rule, which is exactly why they keep the behavior they need.
  */
 
-/** Query words beyond this count are dropped (cli-jaw parity). */
+/**
+ * Relaxation threshold, NOT a truncation cap (260910 wp5). A query longer than
+ * this keeps every token up to MAX_QUERY_TERMS but stops requiring all of them:
+ * compileMatchPlan splits the groups into required (symbols, versions,
+ * mixed-case proper nouns) and optional, and a text matches when it carries
+ * every required group plus half of the optional ones.
+ *
+ * Truncating instead (the pre-wp5 cli-jaw parity behavior) silently discarded
+ * the tail of a sentence query, which is where its symbols usually sit: the
+ * measured 10-word Korean query lost `확인한 방법` and the 9-word release query
+ * lost `기록` before matching even started, and all six evaluation paths
+ * returned zero hits.
+ */
 export const MAX_WORDS = 8;
+
+/**
+ * Hard tokenizer cap. Tokens past this point are dropped for real, because the
+ * per-word SQL conditions and OR-group expansion both grow with the count.
+ */
+export const MAX_QUERY_TERMS = 16;
 
 /**
  * One matchable term: lowercase text plus whether it must land on a token
@@ -35,7 +53,7 @@ export function splitQueryWordsRaw(query        )           {
   return query
     .split(/\s+/)
     .filter((w) => w.length > 0)
-    .slice(0, MAX_WORDS);
+    .slice(0, MAX_QUERY_TERMS);
 }
 
 /** Lowercase query words (the historical tokenizer, unchanged behavior). */
@@ -177,4 +195,107 @@ export function relaxGroupsAt(groups              , indexes                     
 /** Plain member texts of a group — for assertions and diagnostics. */
 export function groupTexts(group            )           {
   return group.map((term) => term.text);
+}
+
+/**
+ * Minimal stopword list (260910 wp5). Six words, all measured on the
+ * evaluation queries as padding the user never meant as a search term:
+ * `진짜 그 소스인지`, `사라지는 문제`, `확인한 방법`. Kept this small on purpose —
+ * a longer list starts deciding which content words matter.
+ */
+export const QUERY_STOPWORDS                      = new Set(["그", "이", "저", "것", "문제", "방법"]);
+
+/**
+ * Must this word be present, rather than merely count toward the optional
+ * quota? Symbol-shaped words (versions, numeric ids, SHAs, filenames,
+ * acronyms, short ASCII) plus mixed-case ASCII proper nouns (`Codex`,
+ * `BundledPluginsMarketplace`) are what make a long query specific; Korean
+ * prose and lowercase English words are the padding around them.
+ *
+ * Judged on the raw word because case is the only signal separating a proper
+ * noun from an ordinary word.
+ */
+export function isRequiredTerm(rawWord        )          {
+  if (isSymbolWord(rawWord)) return true;
+  return /^[A-Za-z][A-Za-z0-9]*$/.test(rawWord) && /[A-Z]/.test(rawWord) && /[a-z]/.test(rawWord);
+}
+
+/**
+ * Drop stopwords, unless that would empty the query. A symbol or otherwise
+ * required-shaped word is never dropped (`CI` is two characters but it is the
+ * whole query), and a query made only of stopwords keeps its original words
+ * instead of degenerating into "match everything".
+ */
+export function dropStopwords(rawWords          )           {
+  const kept = rawWords.filter((w) => !QUERY_STOPWORDS.has(w.toLowerCase()) || isRequiredTerm(w));
+  return kept.length > 0 ? kept : rawWords;
+}
+
+/**
+ * What a text has to carry to count as a match. `required` groups are ANDed,
+ * `optional` groups contribute a quota (`minOptional`), and `anyMode` is the
+ * explicit `--any` OR that overrides both. One plan is compiled per search and
+ * used by every engine, so the index path, the JSONL scan path and the memory
+ * store cannot drift apart.
+ */
+
+
+
+
+
+
+
+/**
+ * Build the plan. `relax` is the caller's decision (chat and memory both derive
+ * it from the ORIGINAL token count against MAX_WORDS, before stopword removal)
+ * so a 9-word query that drops one stopword still relaxes; without that, the
+ * threshold would move under the query.
+ *
+ * `rawWords` is index-aligned with `groups`: the shape judgment needs the word
+ * the user typed, not the lowercased, stemmed, synonym-expanded group.
+ */
+export function compileMatchPlan(
+  groups              ,
+  rawWords          ,
+  anyMode         ,
+  relax         ,
+)            {
+  if (anyMode || !relax) return { required: groups, optional: [], minOptional: 0, anyMode };
+  const required               = [];
+  const optional               = [];
+  for (let i = 0; i < groups.length; i++) {
+    const raw = rawWords[i] ?? groups[i][0]?.text ?? "";
+    if (isRequiredTerm(raw)) required.push(groups[i]);
+    else optional.push(groups[i]);
+  }
+  return { required, optional, minOptional: Math.ceil(optional.length / 2), anyMode: false };
+}
+
+/** Every group in the plan, for scoring and diagnostics (order: required first). */
+export function allGroups(plan           )               {
+  return plan.optional.length === 0 ? plan.required : [...plan.required, ...plan.optional];
+}
+
+/** A plan with no groups at all — an empty query, which must match nothing. */
+export function planIsEmpty(plan           )          {
+  return plan.required.length === 0 && plan.optional.length === 0;
+}
+
+/**
+ * The single match predicate. Every engine ends here, which is what keeps the
+ * index/scan equivalence oracle meaningful once SQL stops carrying the whole
+ * requirement.
+ */
+export function planMatches(lowerText        , plan           )          {
+  const hit = (group            ) => group.some((term) => termIncludes(lowerText, term));
+  if (plan.anyMode) return plan.required.some(hit) || plan.optional.some(hit);
+  if (planIsEmpty(plan)) return false;
+  if (!plan.required.every(hit)) return false;
+  if (plan.optional.length === 0) return true;
+  // Early exit matters: this runs per message over a multi-GB corpus.
+  let seen = 0;
+  for (const group of plan.optional) {
+    if (hit(group) && ++seen >= plan.minOptional) return true;
+  }
+  return seen >= plan.minOptional;
 }

--- a/plugins/codexclaw/components/recall/dist/rollout.js
+++ b/plugins/codexclaw/components/recall/dist/rollout.js
@@ -15,6 +15,7 @@ import { readdirSync, existsSync, openSync, readSync, closeSync } from "node:fs"
 import { join, basename } from "node:path";
 import { splitLines } from "./text-lines.js";
 import { normalizeRepoKey } from "./repo-key.js";
+import { planMatches, planIsEmpty,                } from "./query-words.js";
 
 
 
@@ -233,14 +234,16 @@ function readFirstLine(path        )         {
 }
 
 /**
- * File-level prefilter: one lowercase pass, no line split / JSON.parse.
- * AND mode requires every word; OR mode any word.
+ * File-level prefilter: one lowercase pass, no line split / JSON.parse. Runs
+ * the SAME plan predicate the per-message test uses, so a file can never be
+ * skipped for a requirement the messages inside it would have satisfied.
+ *
+ * Sound as a prefilter because the plan is monotone in the text: whatever a
+ * single message satisfies, the whole-file concatenation satisfies too.
  */
-export function matchesFilePrefilter(lowerContent        , words          , anyMode         )          {
-  if (words.length === 0) return false;
-  return anyMode
-    ? words.some((w) => lowerContent.includes(w))
-    : words.every((w) => lowerContent.includes(w));
+export function matchesFilePrefilter(lowerContent        , plan           )          {
+  if (planIsEmpty(plan)) return false;
+  return planMatches(lowerContent, plan);
 }
 
 /** function_call_output.output: string, {content|text} object, or content array. */

--- a/plugins/codexclaw/components/recall/dist/synonyms.js
+++ b/plugins/codexclaw/components/recall/dist/synonyms.js
@@ -55,6 +55,14 @@ export const SYNONYM_GROUPS             = [
   ["commit", "commits", "커밋"],
   ["review", "reviews", "리뷰", "검토"],
   ["branch", "branches", "브랜치"],
+  // 260910 wp5 seeds: the ko/en pairs the evaluation sentences turned on.
+  // `도그 푸딩` (two tokens) is deliberately absent — it already survives as an
+  // ordinary two-word AND, and a seed cannot span a space.
+  ["dogfooding", "도그푸딩"],
+  ["codex", "코덱스"],
+  ["restart", "재시작"],
+  ["verify", "verification", "verified", "검증", "provenance"],
+  ["source", "소스"],
 ];
 
 /** Max members per expanded group (original word + synonyms). */
@@ -89,6 +97,9 @@ const KOREAN_ENDINGS           = [
   "해서",
   "하는",
   "한테",
+  // `소스인지`, `무엇인지` — the interrogative nominalizer. `한` stays out: it
+  // would trim `검증한` to `검증` but also every noun ending in 한.
+  "인지",
   "들을",
   "들이",
   "에게",

--- a/plugins/codexclaw/components/recall/src/chat-search.ts
+++ b/plugins/codexclaw/components/recall/src/chat-search.ts
@@ -2,8 +2,10 @@
  * chat-search.ts — cli-jaw-parity chat search over Codex rollout JSONL files.
  *
  * Matching model (superset of cli-jaw's dashboard chat search):
- *   - query splits into <=8 case-insensitive words; AND by default, OR with `any`
- *     (cli-jaw only offers OR over <=5 words);
+ *   - query splits into <=16 case-insensitive words; AND by default, OR with
+ *     `any` (cli-jaw only offers OR over <=5 words). Past MAX_WORDS the AND
+ *     relaxes into required + half-of-optional (see query-words.ts MatchPlan);
+ *   - `synonyms` opts into memory's ko/en table and Korean stemmer (default off);
  *   - content AND tool_log both match (parity with cli-jaw's match_field);
  *   - `days` prunes by the sessions/YYYY/MM/DD directory date (default 7, 0 = all);
  *   - `source` filters main vs subagent rollouts (cli-jaw has no subagent corpus);
@@ -26,7 +28,18 @@ import { repoKeyForCwd, repoKeysEqual, readOriginUrl, type ReadOriginUrl } from 
 import { openIndex, openIndexReadOnly, indexPath, indexStatus } from "./index-db.ts";
 import { ingest } from "./ingest.ts";
 import { queryIndex, type ChatOrder } from "./index-search.ts";
-import { splitQueryWords, MAX_WORDS } from "./query-words.ts";
+import { expandQueryWords } from "./synonyms.ts";
+import {
+  splitQueryWords,
+  splitQueryWordsRaw,
+  dropStopwords,
+  compileMatchPlan,
+  planMatches,
+  planIsEmpty,
+  MAX_WORDS,
+  type MatchPlan,
+  type QueryGroup,
+} from "./query-words.ts";
 
 export type { ChatOrder } from "./index-search.ts";
 
@@ -43,6 +56,12 @@ export type ChatSearchOptions = {
   limit?: number;
   context?: number;
   any?: boolean;
+  /**
+   * ko/en synonym + Korean stem expansion, as memory search does it. Default
+   * OFF: chat is the raw corpus, and widening every word there costs a 12GB
+   * scan. Opt in when a Korean sentence has to reach an English transcript.
+   */
+  synonyms?: boolean;
   role?: string | null;
   cwd?: string | null;
   source?: RolloutSource | "all";
@@ -106,13 +125,27 @@ export type ChatSearchResult = {
 };
 
 /**
- * Chat matching stays substring on raw lowercase words. R1's boundary gating is
- * scoped to memory search on purpose: the index path resolves words through
- * trigram MATCH, and changing chat semantics without changing the index query
- * would break the index/scan equivalence oracle (test/index.test.ts:46).
+ * Chat groups. Boundary gating stays OFF on every chat term, symbol-shaped ones
+ * included: the index path resolves words through trigram MATCH, and a boundary
+ * rule only the JS side knew about would break the index/scan equivalence
+ * oracle (test/index.test.ts). R1 boundary matching stays memory-search's.
  */
-function entryMatches(lowerText: string, words: string[], anyMode: boolean): boolean {
-  return anyMode ? words.some((w) => lowerText.includes(w)) : words.every((w) => lowerText.includes(w));
+function groupsForChat(raw: string[], synonyms: boolean): QueryGroup[] {
+  if (!synonyms) return raw.map((w) => [{ text: w.toLowerCase(), boundary: false }]);
+  return expandQueryWords(raw).map((g) => g.map((t) => ({ text: t.text, boundary: false })));
+}
+
+/**
+ * The match plan for one chat query, compiled once and handed to both engines.
+ *
+ * Relaxation is decided on the ORIGINAL token count: a 9-word query that loses
+ * one stopword still relaxes, because otherwise the threshold would move under
+ * the query depending on how much padding it happened to carry.
+ */
+export function chatMatchPlan(query: string, anyMode: boolean, synonyms: boolean): MatchPlan {
+  const rawAll = splitQueryWordsRaw(query);
+  const raw = dropStopwords(rawAll);
+  return compileMatchPlan(groupsForChat(raw, synonyms), raw, anyMode, rawAll.length > MAX_WORDS);
 }
 
 export function searchChat(query: string, opts: ChatSearchOptions = {}): ChatSearchResult {
@@ -122,18 +155,17 @@ export function searchChat(query: string, opts: ChatSearchOptions = {}): ChatSea
   const contextN = Math.max(opts.context ?? 0, 0);
   const anyMode = opts.any ?? false;
   const source = opts.source ?? "main";
-  const words = splitQueryWords(query);
+  const plan = chatMatchPlan(query, anyMode, opts.synonyms === true);
   const cutoffIsoShared = days > 0 ? new Date(Date.now() - days * 86_400_000).toISOString() : null;
   // One git call per search, never one per file: --cwd names a project, and the
   // remote of that project cannot change while the query runs.
   const repoKey = opts.cwd ? repoKeyForCwd(opts.cwd, opts.readOriginUrl ?? readOriginUrl) : null;
 
-  if (!opts.scan && words.length > 0) {
+  if (!opts.scan && !planIsEmpty(plan)) {
     try {
       return searchViaIndex(query, opts, {
         home,
-        words,
-        anyMode,
+        plan,
         limit,
         contextN,
         cutoffIso: cutoffIsoShared,
@@ -141,14 +173,14 @@ export function searchChat(query: string, opts: ChatSearchOptions = {}): ChatSea
         repoKey,
       });
     } catch (err) {
-      const scan = searchViaScan(query, opts, { home, days, limit, contextN, anyMode, source, repoKey });
+      const scan = searchViaScan(query, opts, { home, days, limit, contextN, plan, source, repoKey });
       scan.warnings.unshift(
         `index unavailable (${err instanceof Error ? err.message : String(err)}) — served by scan`,
       );
       return scan;
     }
   }
-  return searchViaScan(query, opts, { home, days, limit, contextN, anyMode, source, repoKey });
+  return searchViaScan(query, opts, { home, days, limit, contextN, plan, source, repoKey });
 }
 
 function searchViaIndex(
@@ -156,8 +188,7 @@ function searchViaIndex(
   opts: ChatSearchOptions,
   shared: {
     home: string;
-    words: string[];
-    anyMode: boolean;
+    plan: MatchPlan;
     limit: number;
     contextN: number;
     cutoffIso: string | null;
@@ -202,8 +233,7 @@ function searchViaIndex(
       refreshed = r.ingested + r.appended;
     }
     const result = queryIndex(db, {
-      words: shared.words,
-      anyMode: shared.anyMode,
+      plan: shared.plan,
       limit: shared.limit,
       contextN: shared.contextN,
       cutoffIso: shared.cutoffIso,
@@ -244,15 +274,14 @@ function searchViaScan(
     days: number;
     limit: number;
     contextN: number;
-    anyMode: boolean;
+    plan: MatchPlan;
     source: RolloutSource | "all";
     repoKey: string | null;
   },
 ): ChatSearchResult {
   const started = Date.now();
-  const { home, days, limit, contextN, anyMode, source, repoKey } = shared;
+  const { home, days, limit, contextN, plan, source, repoKey } = shared;
   const includeTools = opts.includeTools ?? true;
-  const words = splitQueryWords(query);
   const warnings: string[] = [];
 
   const result: ChatSearchResult = {
@@ -264,7 +293,7 @@ function searchViaScan(
     elapsedMs: 0,
     mode: "scan",
   };
-  if (words.length === 0) {
+  if (planIsEmpty(plan)) {
     warnings.push("empty query");
     result.elapsedMs = Date.now() - started;
     return result;
@@ -302,7 +331,7 @@ function searchViaScan(
       warnings.push(`unreadable rollout: ${file.path} (${err instanceof Error ? err.message : String(err)})`);
       continue;
     }
-    if (!matchesFilePrefilter(content.toLowerCase(), words, anyMode)) continue;
+    if (!matchesFilePrefilter(content.toLowerCase(), plan)) continue;
 
     const entries = parseRollout(content, includeTools);
     const visible = entries.filter(
@@ -317,7 +346,7 @@ function searchViaScan(
       const e = visible[i];
       if (opts.role && e.role !== opts.role) continue;
       if (cutoffIso && e.ts !== "" && e.ts < cutoffIso) continue;
-      if (!entryMatches(e.text.toLowerCase(), words, anyMode)) continue;
+      if (!planMatches(e.text.toLowerCase(), plan)) continue;
       fileMatched = true;
       const tm = meta.threadId ? threadMeta.byId.get(meta.threadId) : undefined;
       result.hits.push({

--- a/plugins/codexclaw/components/recall/src/cli.ts
+++ b/plugins/codexclaw/components/recall/src/cli.ts
@@ -25,7 +25,7 @@ import {
 const USAGE = [
   "cxc chat search \"<query>\" [--days N] [--cwd PATH] [--role r] [--source main|subagent|all]",
   "                           [--limit N] [--context N] [--any] [--all] [--no-tools]",
-  "                           [--recent] [--scan] [--no-refresh] [--json]",
+  "                           [--recent] [--scan] [--no-refresh] [--synonyms] [--json]",
   "cxc chat index [--rebuild] [--status] [--json]",
   "cxc memory search \"<query>\" [--days N] [--limit N] [--any] [--no-synonyms]",
   "                             [--cwd PATH] [--cwd-only PATH] [--no-chat] [--json]",
@@ -47,6 +47,7 @@ const USAGE = [
   "  --scan       force the raw JSONL scan path (skip the sidecar index)",
   "  --no-refresh skip refresh-on-query ingest (fastest, index may be stale)",
   "  --no-synonyms memory search: raw words only — no ko/en synonyms, no korean stem",
+  "  --synonyms   chat search: expand ko/en synonyms + korean stems (default off)",
   "  --json       machine-readable output (text fields clipped at 500 chars)",
   "  --full       with --json: emit unclipped text fields",
   "  --home PATH  search an alternate Codex home (default $CODEX_HOME ?? ~/.codex)",
@@ -76,6 +77,7 @@ function parseFlags(args: string[]): ParsedFlags {
       scan: { type: "boolean", default: false },
       "no-refresh": { type: "boolean", default: false },
       "no-synonyms": { type: "boolean", default: false },
+      synonyms: { type: "boolean", default: false },
       "no-chat": { type: "boolean", default: false },
       full: { type: "boolean", default: false },
       rebuild: { type: "boolean", default: false },
@@ -114,6 +116,9 @@ function runChatSearch(args: string[]): number {
     limit: numFlag(values, "limit"),
     context: numFlag(values, "context"),
     any: values.any === true,
+    // Default off: chat is the raw corpus, and expanding every word there
+    // widens a multi-GB scan (memory search defaults the other way).
+    synonyms: values.synonyms === true,
     role: typeof values.role === "string" ? values.role : null,
     cwd: typeof values.cwd === "string" ? values.cwd : null,
     source,

--- a/plugins/codexclaw/components/recall/src/index-search.ts
+++ b/plugins/codexclaw/components/recall/src/index-search.ts
@@ -6,7 +6,10 @@
  *     and CJK alike; the WP2 spike verified 2-char CJK words return nothing);
  *   - shorter words fall back to LIKE over msgs.text (indexed table, still far
  *     smaller than raw JSONL);
- *   - AND intersects per-word id sets, OR unions them (scan-path semantics).
+ *   - AND intersects per-word id sets, OR unions them (scan-path semantics);
+ *   - a relaxed plan (query-words.ts MatchPlan) puts only its REQUIRED groups in
+ *     SQL and leaves the optional quota to the JS predicate, so SQL is a
+ *     candidate generator and `textMatches` is the authority.
  * Filters (synthetic/source/cwd/role/days/tools) compile to SQL.
  *
  * Ordering has two modes. "recent" is the original pure ts-DESC query with
@@ -26,13 +29,14 @@ import { loadThreadMeta, type ThreadMetaResult } from "./threads-db.ts";
 import { stateDbPath } from "./paths.ts";
 import { filesHasColumn } from "./index-db.ts";
 import { normalizeRepoKey, repoKeysEqual } from "./repo-key.ts";
+import { planMatches, allGroups, type MatchPlan, type QueryGroup } from "./query-words.ts";
 
 /** Result ordering: fused relevance (default) or the original pure recency. */
 export type ChatOrder = "relevance" | "recent";
 
 export type IndexQueryOptions = {
-  words: string[];
-  anyMode: boolean;
+  /** compiled match plan; the sole definition of what counts as a hit. */
+  plan: MatchPlan;
   limit: number;
   contextN: number;
   cutoffIso: string | null;
@@ -97,6 +101,45 @@ function poolSize(limit: number): number {
   return Math.min(500, Math.max(100, limit * 10));
 }
 
+/**
+ * Depth for a plan whose WHERE clause carries no word condition at all — a
+ * relaxed query with no required symbol, where the JS predicate is the only
+ * thing narrowing the corpus. It has to look deeper before throwing rows away.
+ */
+const RELAXED_POOL = 2_000;
+
+/** Lane/sweep depth for this plan. */
+function planPoolSize(plan: MatchPlan, limit: number): number {
+  const base = poolSize(limit);
+  const noWordSql = !plan.anyMode && plan.required.length === 0 && plan.optional.length > 0;
+  return noWordSql ? Math.max(base, RELAXED_POOL) : base;
+}
+
+/** Optional lead words fed to a lane when the plan has no required group. */
+const MAX_OPTIONAL_LANE_WORDS = 6;
+
+/**
+ * Which words rank the lanes and how they join. Lane membership is NOT the
+ * match test, so a lane only needs a cheap, selective approximation: the
+ * required leads ANDed when there are any, otherwise an OR over the longest-
+ * serviceable optional leads (a lane MATCH over nine ORed Korean words costs
+ * more than it ranks). Group leads only — the word the user typed is the one
+ * whose BM25 rank is worth having.
+ */
+function laneQuery(plan: MatchPlan): { words: string[]; anyMode: boolean } {
+  const lead = (g: QueryGroup) => g[0]?.text ?? "";
+  const nonEmpty = (w: string) => w !== "";
+  if (plan.anyMode) return { words: allGroups(plan).map(lead).filter(nonEmpty), anyMode: true };
+  if (plan.required.length > 0) return { words: plan.required.map(lead).filter(nonEmpty), anyMode: false };
+  return {
+    words: plan.optional
+      .map(lead)
+      .filter((w) => [...w].length >= 3)
+      .slice(0, MAX_OPTIONAL_LANE_WORDS),
+    anyMode: true,
+  };
+}
+
 /** RRF contribution of one lane; ranks are 0-based, the formula is 1-based. */
 export function rrfScore(rank: number | undefined, weight: number): number {
   return rank === undefined ? 0 : weight / (RRF_K + rank + 1);
@@ -148,17 +191,34 @@ function wordCondition(word: string, params: unknown[]): string {
   return "lower(m.text) LIKE ? ESCAPE '\\'";
 }
 
+/** One OR-group: any member present satisfies it. */
+function groupCondition(group: QueryGroup, params: unknown[]): string {
+  if (group.length === 0) return "1";
+  return `(${group.map((t) => wordCondition(t.text, params)).join(" OR ")})`;
+}
+
 /**
- * The candidate WHERE clause: word matching plus every filter. This is the sole
- * definition of what "matches", shared by both ordering modes, so ranking can
- * never widen or narrow recall.
+ * The candidate WHERE clause: word matching plus every filter, shared by both
+ * ordering modes so ranking can never widen or narrow recall.
+ *
+ * Only the plan's REQUIRED groups enter SQL. The optional groups are a quota,
+ * not a requirement, and ANDing them here would re-impose exactly the AND the
+ * relaxation exists to break; ORing them would widen the candidate set for no
+ * gain. When there is no required group the word clause is omitted entirely and
+ * `textMatches` narrows the sweep instead.
  */
 function candidateFilter(opts: ResolvedQuery, withWords = true): { where: string; params: unknown[] } {
   const params: unknown[] = [];
   const conds: string[] = [];
   if (withWords) {
-    const wordConds = opts.words.map((w) => wordCondition(w, params));
-    conds.push(`(${wordConds.join(opts.anyMode ? " OR " : " AND ")})`);
+    if (opts.plan.anyMode) {
+      const groups = allGroups(opts.plan);
+      if (groups.length > 0) {
+        conds.push(`(${groups.map((g) => groupCondition(g, params)).join(" OR ")})`);
+      }
+    } else if (opts.plan.required.length > 0) {
+      conds.push(`(${opts.plan.required.map((g) => groupCondition(g, params)).join(" AND ")})`);
+    }
   }
   if (!opts.includeSynthetic) conds.push("m.synthetic = 0");
   if (!opts.includeTools) conds.push("m.match_field = 'content'");
@@ -202,14 +262,13 @@ function candidateFilter(opts: ResolvedQuery, withWords = true): { where: string
 }
 
 /**
- * Scan-path word semantics: case-insensitive substring, AND by default.
- * Applied in JS to the small lane-candidate set instead of re-running the
- * trigram subqueries in SQL — same answer, and it drops ~250ms on the 12GB
- * index because the expensive MATCH is not evaluated twice.
+ * Scan-path semantics, in JS, on every row that could become a hit. Applied
+ * here instead of re-running the trigram subqueries in SQL — same answer, and
+ * it drops ~250ms on the 12GB index because the expensive MATCH is not
+ * evaluated twice. It is also the only place the optional quota is enforced.
  */
-function textMatches(text: string, words: string[], anyMode: boolean): boolean {
-  const lower = text.toLowerCase();
-  return anyMode ? words.some((w) => lower.includes(w)) : words.every((w) => lower.includes(w));
+function textMatches(text: string, plan: MatchPlan): boolean {
+  return planMatches(text.toLowerCase(), plan);
 }
 
 const ROW_COLUMNS = `SELECT m.id, m.path, m.ord, m.ts, m.role, m.match_field, m.text,
@@ -248,11 +307,12 @@ function laneRanks(db: RwDb, table: "msgs_fts" | "msgs_tri", words: string[], an
  * degenerates cleanly to the old recency order).
  */
 function rankedRows(db: RwDb, opts: ResolvedQuery): { rows: IndexRow[]; truncated: boolean } {
-  const k = poolSize(opts.limit);
+  const k = planPoolSize(opts.plan, opts.limit);
   const nowMs = opts.nowMs ?? Date.now();
-  const triWords = opts.words.filter((w) => [...w].length >= 3);
-  const ftsRanks = laneRanks(db, "msgs_fts", opts.words, opts.anyMode, k);
-  const triRanks = laneRanks(db, "msgs_tri", triWords, opts.anyMode, k);
+  const lane = laneQuery(opts.plan);
+  const triWords = lane.words.filter((w) => [...w].length >= 3);
+  const ftsRanks = laneRanks(db, "msgs_fts", lane.words, lane.anyMode, k);
+  const triRanks = laneRanks(db, "msgs_tri", triWords, lane.anyMode, k);
 
   const byId = new Map<number, IndexRow>();
   const laneIds = [...new Set([...ftsRanks.keys(), ...triRanks.keys()])];
@@ -266,7 +326,7 @@ function rankedRows(db: RwDb, opts: ResolvedQuery): { rows: IndexRow[]; truncate
       // Lane membership is not the match test: FTS tokenization is coarser than
       // the scan path's substring rule ("releases" tokenizes away from
       // "release"). Re-checking here keeps index/scan parity exact.
-      if (textMatches(String(r.text), opts.words, opts.anyMode)) byId.set(Number(r.id), r);
+      if (textMatches(String(r.text), opts.plan)) byId.set(Number(r.id), r);
     }
   }
   // Top-up sweep. Only runs when the lanes could not fill the page: a query no
@@ -280,7 +340,10 @@ function rankedRows(db: RwDb, opts: ResolvedQuery): { rows: IndexRow[]; truncate
       .all(...full.params, k) as IndexRow[];
     for (const r of recent) {
       const id = Number(r.id);
-      if (!byId.has(id)) byId.set(id, r);
+      // The sweep bypasses the lanes, so it needs the predicate too: a relaxed
+      // plan puts no word condition in SQL, and an unfiltered sweep would top
+      // the page up with the newest messages in the corpus.
+      if (!byId.has(id) && textMatches(String(r.text), opts.plan)) byId.set(id, r);
     }
   }
 
@@ -314,9 +377,13 @@ export function queryIndex(db: RwDb, opts: IndexQueryOptions): ChatSearchResult 
   let truncated: boolean;
   if ((query.order ?? "relevance") === "recent") {
     const { where, params } = candidateFilter(query);
-    rows = db
+    // A pool, not limit+1: the optional quota lives in JS, so rows have to pass
+    // the predicate before the page is cut. Without this, "recent" ordering on
+    // a relaxed query degrades into "the newest limit+1 messages there are".
+    const pool = db
       .prepare(`${ROW_COLUMNS}${where} ORDER BY m.ts DESC LIMIT ?`)
-      .all(...params, query.limit + 1) as IndexRow[];
+      .all(...params, planPoolSize(query.plan, query.limit)) as IndexRow[];
+    rows = pool.filter((r) => textMatches(String(r.text), query.plan)).slice(0, query.limit + 1);
     truncated = rows.length > query.limit;
     if (truncated) rows.length = query.limit;
   } else {

--- a/plugins/codexclaw/components/recall/src/memory-search.ts
+++ b/plugins/codexclaw/components/recall/src/memory-search.ts
@@ -27,6 +27,12 @@ import {
   countTermOccurrences,
   hasBoundaryTerm,
   relaxGroupsAt,
+  dropStopwords,
+  compileMatchPlan,
+  planMatches,
+  allGroups,
+  MAX_WORDS,
+  type MatchPlan,
   type QueryGroup,
 } from "./query-words.ts";
 import { expandQueryWords } from "./synonyms.ts";
@@ -380,11 +386,6 @@ function groupHit(lowerText: string, group: QueryGroup): boolean {
   return group.some((term) => termIncludes(lowerText, term));
 }
 
-/** AND across groups, OR within a group; anyMode = any member of any group. */
-function matches(lowerText: string, groups: QueryGroup[], anyMode: boolean): boolean {
-  return anyMode ? groups.some((g) => groupHit(lowerText, g)) : groups.every((g) => groupHit(lowerText, g));
-}
-
 /**
  * Record which groups occur anywhere in this text (independently of the other
  * groups). Drives the per-group relaxed retry: only a boundary group that is
@@ -424,7 +425,12 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
   const cutoffMs = days > 0 ? nowMs - days * 86_400_000 : null;
   // Original case survives to expansion: the uppercase-acronym rule is the only
   // thing separating `CI` from a two-letter fragment (query-words.ts).
-  const words = splitQueryWordsRaw(query);
+  const rawAll = splitQueryWordsRaw(query);
+  // Padding removal and the relaxation threshold are both wp5. The threshold is
+  // judged on the ORIGINAL count so dropping `그` or `문제` cannot move it: the
+  // 9-word release query still relaxes after losing its one stopword.
+  const words = dropStopwords(rawAll);
+  const relax = rawAll.length > MAX_WORDS;
   const groups: QueryGroup[] = (opts.synonyms ?? true)
     ? expandQueryWords(words)
     : expandQueryWords(words).map((group) => [group[0]]);
@@ -443,6 +449,10 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
 
   const present: boolean[] = groups.map(() => false);
   const collect = (active: QueryGroup[], tallyPresence: boolean): MemoryHit[] => {
+    // Recompiled per pass on purpose: the relaxed retry below hands in groups
+    // whose boundary flags were dropped, and a plan captured once before that
+    // retry would still be matching on token boundaries.
+    const plan = compileMatchPlan(active, words, anyMode, relax);
     const candidates: MemoryHit[] = [];
     const matchedThreadIds = new Set<string>();
     scannedFiles = 0;
@@ -460,7 +470,7 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
       scannedFiles += 1;
       const lowerFile = content.toLowerCase();
       if (tallyPresence) markGroupPresence(lowerFile, groups, present);
-      if (!matches(lowerFile, active, anyMode)) continue;
+      if (!planMatches(lowerFile, plan)) continue;
       const threadId = frontmatterThreadId(content);
       if (threadId) matchedThreadIds.add(threadId);
       const relpath = relative(root, file).split(sep).join("/");
@@ -474,7 +484,7 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
       const fileRepoKey = normalizeRepoKey(threadMeta?.gitOriginUrl);
       for (const chunk of paragraphChunks(content)) {
         const lower = chunk.text.toLowerCase();
-        if (!matches(lower, active, anyMode)) continue;
+        if (!planMatches(lower, plan)) continue;
         const scoped = scopeAdjust(scope, fileCwd, lower, fileRepoKey);
         if (!scoped.keep) continue;
         candidates.push({
@@ -493,8 +503,8 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
     }
     searchStage1(
       home,
+      plan,
       active,
-      anyMode,
       cutoffMs,
       lowerPhrase,
       nowMs,
@@ -649,8 +659,8 @@ function fillStage1Presence(
 /** stage1_outputs holds per-thread raw_memory + rollout_summary; read-only, fail-soft. */
 function searchStage1(
   home: string,
+  plan: MatchPlan,
   groups: QueryGroup[],
-  anyMode: boolean,
   cutoffMs: number | null,
   lowerPhrase: string,
   nowMs: number,
@@ -675,15 +685,23 @@ function searchStage1(
     // prefilter, and the row body is re-checked with the same `matches`
     // predicate the file path uses, so boundary semantics hold either way.
     const params: string[] = [];
-    const conds = groups.map((group) => {
+    const groupCond = (group: QueryGroup): string => {
       const members = group.map((w) => {
         params.push(`%${w.text}%`);
         const n = params.length;
         return `(lower(raw_memory) LIKE ?${n} OR lower(rollout_summary) LIKE ?${n})`;
       });
-      return `(${members.join(" OR ")})`;
-    });
-    const where = conds.join(anyMode ? " OR " : " AND ");
+      return members.length > 0 ? `(${members.join(" OR ")})` : "1";
+    };
+    // Required groups only. The optional quota is enforced by planMatches
+    // below; ANDing optional groups here is what kept the long release query at
+    // zero hits, and a plan with no required group prefilters nothing at all —
+    // `WHERE 1`, never an empty condition list that would be invalid SQL.
+    const where = plan.anyMode
+      ? allGroups(plan).map(groupCond).join(" OR ") || "1"
+      : plan.required.length > 0
+        ? plan.required.map(groupCond).join(" AND ")
+        : "1";
     const sql = `SELECT thread_id, raw_memory, rollout_summary, source_updated_at FROM stage1_outputs
       WHERE ${where} ORDER BY source_updated_at DESC`;
     const rows = db.prepare(sql).all(...params) as Array<Record<string, unknown>>;
@@ -694,8 +712,9 @@ function searchStage1(
       if (cutoffMs && updatedSec !== null && updatedSec * 1000 < cutoffMs) continue;
       const body = `${String(r.raw_memory ?? "")}\n${String(r.rollout_summary ?? "")}`;
       const lowerBody = body.toLowerCase();
-      // The LIKE prefilter above ignores boundaries; enforce them here.
-      if (!matches(lowerBody, groups, anyMode)) continue;
+      // The LIKE prefilter above ignores boundaries and skips the optional
+      // groups; the plan predicate enforces both here.
+      if (!planMatches(lowerBody, plan)) continue;
       // stage1_outputs has no cwd column (schema dump, 011 4.3); threads.cwd is
       // the accurate substitute and it covered all 516 rows in the live store.
       const rowThread = threadId ? scope?.threadCwd.get(threadId) : undefined;

--- a/plugins/codexclaw/components/recall/src/query-words.ts
+++ b/plugins/codexclaw/components/recall/src/query-words.ts
@@ -17,8 +17,26 @@
  * every symbol rule, which is exactly why they keep the behavior they need.
  */
 
-/** Query words beyond this count are dropped (cli-jaw parity). */
+/**
+ * Relaxation threshold, NOT a truncation cap (260910 wp5). A query longer than
+ * this keeps every token up to MAX_QUERY_TERMS but stops requiring all of them:
+ * compileMatchPlan splits the groups into required (symbols, versions,
+ * mixed-case proper nouns) and optional, and a text matches when it carries
+ * every required group plus half of the optional ones.
+ *
+ * Truncating instead (the pre-wp5 cli-jaw parity behavior) silently discarded
+ * the tail of a sentence query, which is where its symbols usually sit: the
+ * measured 10-word Korean query lost `확인한 방법` and the 9-word release query
+ * lost `기록` before matching even started, and all six evaluation paths
+ * returned zero hits.
+ */
 export const MAX_WORDS = 8;
+
+/**
+ * Hard tokenizer cap. Tokens past this point are dropped for real, because the
+ * per-word SQL conditions and OR-group expansion both grow with the count.
+ */
+export const MAX_QUERY_TERMS = 16;
 
 /**
  * One matchable term: lowercase text plus whether it must land on a token
@@ -35,7 +53,7 @@ export function splitQueryWordsRaw(query: string): string[] {
   return query
     .split(/\s+/)
     .filter((w) => w.length > 0)
-    .slice(0, MAX_WORDS);
+    .slice(0, MAX_QUERY_TERMS);
 }
 
 /** Lowercase query words (the historical tokenizer, unchanged behavior). */
@@ -177,4 +195,107 @@ export function relaxGroupsAt(groups: QueryGroup[], indexes: ReadonlySet<number>
 /** Plain member texts of a group — for assertions and diagnostics. */
 export function groupTexts(group: QueryGroup): string[] {
   return group.map((term) => term.text);
+}
+
+/**
+ * Minimal stopword list (260910 wp5). Six words, all measured on the
+ * evaluation queries as padding the user never meant as a search term:
+ * `진짜 그 소스인지`, `사라지는 문제`, `확인한 방법`. Kept this small on purpose —
+ * a longer list starts deciding which content words matter.
+ */
+export const QUERY_STOPWORDS: ReadonlySet<string> = new Set(["그", "이", "저", "것", "문제", "방법"]);
+
+/**
+ * Must this word be present, rather than merely count toward the optional
+ * quota? Symbol-shaped words (versions, numeric ids, SHAs, filenames,
+ * acronyms, short ASCII) plus mixed-case ASCII proper nouns (`Codex`,
+ * `BundledPluginsMarketplace`) are what make a long query specific; Korean
+ * prose and lowercase English words are the padding around them.
+ *
+ * Judged on the raw word because case is the only signal separating a proper
+ * noun from an ordinary word.
+ */
+export function isRequiredTerm(rawWord: string): boolean {
+  if (isSymbolWord(rawWord)) return true;
+  return /^[A-Za-z][A-Za-z0-9]*$/.test(rawWord) && /[A-Z]/.test(rawWord) && /[a-z]/.test(rawWord);
+}
+
+/**
+ * Drop stopwords, unless that would empty the query. A symbol or otherwise
+ * required-shaped word is never dropped (`CI` is two characters but it is the
+ * whole query), and a query made only of stopwords keeps its original words
+ * instead of degenerating into "match everything".
+ */
+export function dropStopwords(rawWords: string[]): string[] {
+  const kept = rawWords.filter((w) => !QUERY_STOPWORDS.has(w.toLowerCase()) || isRequiredTerm(w));
+  return kept.length > 0 ? kept : rawWords;
+}
+
+/**
+ * What a text has to carry to count as a match. `required` groups are ANDed,
+ * `optional` groups contribute a quota (`minOptional`), and `anyMode` is the
+ * explicit `--any` OR that overrides both. One plan is compiled per search and
+ * used by every engine, so the index path, the JSONL scan path and the memory
+ * store cannot drift apart.
+ */
+export type MatchPlan = {
+  required: QueryGroup[];
+  optional: QueryGroup[];
+  minOptional: number;
+  anyMode: boolean;
+};
+
+/**
+ * Build the plan. `relax` is the caller's decision (chat and memory both derive
+ * it from the ORIGINAL token count against MAX_WORDS, before stopword removal)
+ * so a 9-word query that drops one stopword still relaxes; without that, the
+ * threshold would move under the query.
+ *
+ * `rawWords` is index-aligned with `groups`: the shape judgment needs the word
+ * the user typed, not the lowercased, stemmed, synonym-expanded group.
+ */
+export function compileMatchPlan(
+  groups: QueryGroup[],
+  rawWords: string[],
+  anyMode: boolean,
+  relax: boolean,
+): MatchPlan {
+  if (anyMode || !relax) return { required: groups, optional: [], minOptional: 0, anyMode };
+  const required: QueryGroup[] = [];
+  const optional: QueryGroup[] = [];
+  for (let i = 0; i < groups.length; i++) {
+    const raw = rawWords[i] ?? groups[i][0]?.text ?? "";
+    if (isRequiredTerm(raw)) required.push(groups[i]);
+    else optional.push(groups[i]);
+  }
+  return { required, optional, minOptional: Math.ceil(optional.length / 2), anyMode: false };
+}
+
+/** Every group in the plan, for scoring and diagnostics (order: required first). */
+export function allGroups(plan: MatchPlan): QueryGroup[] {
+  return plan.optional.length === 0 ? plan.required : [...plan.required, ...plan.optional];
+}
+
+/** A plan with no groups at all — an empty query, which must match nothing. */
+export function planIsEmpty(plan: MatchPlan): boolean {
+  return plan.required.length === 0 && plan.optional.length === 0;
+}
+
+/**
+ * The single match predicate. Every engine ends here, which is what keeps the
+ * index/scan equivalence oracle meaningful once SQL stops carrying the whole
+ * requirement.
+ */
+export function planMatches(lowerText: string, plan: MatchPlan): boolean {
+  const hit = (group: QueryGroup) => group.some((term) => termIncludes(lowerText, term));
+  if (plan.anyMode) return plan.required.some(hit) || plan.optional.some(hit);
+  if (planIsEmpty(plan)) return false;
+  if (!plan.required.every(hit)) return false;
+  if (plan.optional.length === 0) return true;
+  // Early exit matters: this runs per message over a multi-GB corpus.
+  let seen = 0;
+  for (const group of plan.optional) {
+    if (hit(group) && ++seen >= plan.minOptional) return true;
+  }
+  return seen >= plan.minOptional;
 }

--- a/plugins/codexclaw/components/recall/src/rollout.ts
+++ b/plugins/codexclaw/components/recall/src/rollout.ts
@@ -15,6 +15,7 @@ import { readdirSync, existsSync, openSync, readSync, closeSync } from "node:fs"
 import { join, basename } from "node:path";
 import { splitLines } from "./text-lines.ts";
 import { normalizeRepoKey } from "./repo-key.ts";
+import { planMatches, planIsEmpty, type MatchPlan } from "./query-words.ts";
 
 export type RolloutSource = "main" | "subagent";
 
@@ -233,14 +234,16 @@ function readFirstLine(path: string): string {
 }
 
 /**
- * File-level prefilter: one lowercase pass, no line split / JSON.parse.
- * AND mode requires every word; OR mode any word.
+ * File-level prefilter: one lowercase pass, no line split / JSON.parse. Runs
+ * the SAME plan predicate the per-message test uses, so a file can never be
+ * skipped for a requirement the messages inside it would have satisfied.
+ *
+ * Sound as a prefilter because the plan is monotone in the text: whatever a
+ * single message satisfies, the whole-file concatenation satisfies too.
  */
-export function matchesFilePrefilter(lowerContent: string, words: string[], anyMode: boolean): boolean {
-  if (words.length === 0) return false;
-  return anyMode
-    ? words.some((w) => lowerContent.includes(w))
-    : words.every((w) => lowerContent.includes(w));
+export function matchesFilePrefilter(lowerContent: string, plan: MatchPlan): boolean {
+  if (planIsEmpty(plan)) return false;
+  return planMatches(lowerContent, plan);
 }
 
 /** function_call_output.output: string, {content|text} object, or content array. */

--- a/plugins/codexclaw/components/recall/src/synonyms.ts
+++ b/plugins/codexclaw/components/recall/src/synonyms.ts
@@ -55,6 +55,14 @@ export const SYNONYM_GROUPS: string[][] = [
   ["commit", "commits", "커밋"],
   ["review", "reviews", "리뷰", "검토"],
   ["branch", "branches", "브랜치"],
+  // 260910 wp5 seeds: the ko/en pairs the evaluation sentences turned on.
+  // `도그 푸딩` (two tokens) is deliberately absent — it already survives as an
+  // ordinary two-word AND, and a seed cannot span a space.
+  ["dogfooding", "도그푸딩"],
+  ["codex", "코덱스"],
+  ["restart", "재시작"],
+  ["verify", "verification", "verified", "검증", "provenance"],
+  ["source", "소스"],
 ];
 
 /** Max members per expanded group (original word + synonyms). */
@@ -89,6 +97,9 @@ const KOREAN_ENDINGS: string[] = [
   "해서",
   "하는",
   "한테",
+  // `소스인지`, `무엇인지` — the interrogative nominalizer. `한` stays out: it
+  // would trim `검증한` to `검증` but also every noun ending in 한.
+  "인지",
   "들을",
   "들이",
   "에게",

--- a/plugins/codexclaw/components/recall/test/fixtures.ts
+++ b/plugins/codexclaw/components/recall/test/fixtures.ts
@@ -13,6 +13,11 @@ export const THREAD_SUB = "019f0000-0000-7000-8000-00000000bbbb";
 export const THREAD_OLD = "019f0000-0000-7000-8000-00000000cccc";
 export const THREAD_ARCHIVED = "019f0000-0000-7000-8000-00000000eeee";
 
+/** Natural-language golden corpus threads (wp5): D3 dogfooding, P2 plugin wipe, R2 release. */
+export const THREAD_NL_D3 = "019f0000-0000-7000-8000-00000000d333";
+export const THREAD_NL_P2 = "019f0000-0000-7000-8000-00000000d222";
+export const THREAD_NL_R2 = "019f0000-0000-7000-8000-00000000d111";
+
 /** Origin shared by the /proj/alpha sessions; /proj/beta deliberately differs. */
 export const ORIGIN_ALPHA = "https://github.com/example/alpha.git";
 export const ORIGIN_BETA = "git@github.com:example/beta.git";
@@ -171,4 +176,83 @@ export function buildCodexHome(root: string): void {
   mins.run(THREAD_MAIN, Math.floor(Date.now() / 1000), "raw memory about trigram deployment", "summary duplicate");
   mins.run(THREAD_SUB, Math.floor(Date.now() / 1000), "db-only memory row about quagga migrations", "quagga summary");
   memDb.close();
+}
+
+/**
+ * Add the wp5 natural-language golden corpus to an existing synthetic home.
+ *
+ * These are the three evaluation sentences that returned zero hits on every
+ * engine, reproduced as synthetic sessions and memory files so the relaxation
+ * can be pinned WITHOUT reading the operator's real 12GB index or memory store.
+ * Callers must pass `--home`/`--index-path` into this root for that isolation
+ * to hold.
+ *
+ * Each document is deliberately partial. It carries enough of the sentence to
+ * clear the optional quota and NOT all of it, so a test that passes here could
+ * not have passed under the old all-words AND:
+ *
+ *   D3 `지난번 로컬 소스를 실제 서비스에 연결하고 정상 동작까지 확인한 방법`
+ *      → the transcript never says 지난번, 확인한 or 방법.
+ *   P2 `코덱스를 재시작하면 플러그인이 사라지는 문제`
+ *      → the transcript says Codex, not 코덱스, so it needs `--synonyms` on chat.
+ *   R2 `2.49.0 배포하고 npm 패키지가 진짜 그 소스인지 검증한 기록`
+ *      → the transcript never says 배포하고 or 진짜, and carries four of the six
+ *        optional words, one more than the quota.
+ */
+export function addNlGoldenCorpus(root: string): void {
+  const today = dateParts(0);
+  const dir = join(root, "sessions", today.y, today.m, today.d);
+  mkdirSync(dir, { recursive: true });
+
+  writeFileSync(
+    join(dir, `rollout-${today.y}-${today.m}-${today.d}T11-00-00-${THREAD_NL_D3}.jsonl`),
+    sessionMeta(THREAD_NL_D3, "/proj/alpha", false, today.iso, ORIGIN_ALPHA) +
+      message("user", "로컬 소스를 실제 서비스에 연결했다", today.iso) +
+      message(
+        "assistant",
+        "로컬 소스를 실제 서비스에 연결하고 정상 동작까지 확인. bun link 로 두 CLI 를 묶고 healthz 10100 응답.",
+        today.iso,
+      ),
+  );
+  writeFileSync(
+    join(dir, `rollout-${today.y}-${today.m}-${today.d}T12-00-00-${THREAD_NL_P2}.jsonl`),
+    sessionMeta(THREAD_NL_P2, "/proj/alpha", false, today.iso, ORIGIN_ALPHA) +
+      message("user", "코덱스 재시작하니 플러그인이 사라짐", today.iso) +
+      message(
+        "assistant",
+        "Codex를 재시작하면 BundledPluginsMarketplace 플러그인이 사라지는 문제가 재현된다. plugin wipe.",
+        today.iso,
+      ),
+  );
+  writeFileSync(
+    join(dir, `rollout-${today.y}-${today.m}-${today.d}T13-00-00-${THREAD_NL_R2}.jsonl`),
+    sessionMeta(THREAD_NL_R2, "/proj/alpha", false, today.iso, ORIGIN_ALPHA) +
+      message("user", "2.49.0 provenance 확인해", today.iso) +
+      message(
+        "assistant",
+        "2.49.0 npm latest gitHead가 그 소스인지 검증한 기록이다. 패키지가 provenance SLSA 로 확인됐다.",
+        today.iso,
+      ),
+  );
+
+  const mem = join(root, "memories");
+  mkdirSync(mem, { recursive: true });
+  writeFileSync(
+    join(mem, "nl-d3.md"),
+    "# dogfooding\n\n로컬 소스를 실제 서비스에 연결하고 정상 동작까지 확인. bun link healthz 10100.\n",
+  );
+  writeFileSync(
+    join(mem, "nl-p2.md"),
+    "# plugin wipe\n\nCodex restart 후 BundledPluginsMarketplace 플러그인이 사라지는 문제.\n",
+  );
+  writeFileSync(
+    join(mem, "nl-r2.md"),
+    "# 2.49.0 provenance\n\n2.49.0 npm 패키지가 그 소스인지 검증한 기록. gitHead SLSA.\n",
+  );
+  // c-4: a boundary-gated symbol must not match inside a longer word, even when
+  // another group in the same query missed.
+  writeFileSync(join(mem, "nl-c4-mismatch.md"), "# Notes\n\nTouched NaiControlsPanel and negativePrompt.\n");
+  writeFileSync(join(mem, "nl-c4-real.md"), "# Real\n\nThe LSP server crashed.\n");
+  // c-5: an inflected Korean query reaching the uninflected document.
+  writeFileSync(join(mem, "nl-c5.md"), "# 운영 노트\n\n첫 배포 이후 인덱스 재생성이 필요했다.\n");
 }

--- a/plugins/codexclaw/components/recall/test/index.test.ts
+++ b/plugins/codexclaw/components/recall/test/index.test.ts
@@ -92,6 +92,33 @@ test("index context windows match scan context windows", () => {
   );
 });
 
+test("oracle: a relaxed 9-word query agrees across engines in both orderings (wp5)", () => {
+  // Past MAX_WORDS the WHERE clause stops carrying the whole requirement, so
+  // the JS predicate has to hold three separate places together. The first
+  // query still has required words ("the" and "for" are short-ASCII symbols);
+  // the second has none at all, which is the case where SQL filters nothing and
+  // the lane candidates, the top-up sweep and the recent page are each free to
+  // drift on their own.
+  const key = (h: { ts: string; text: string; source: string }) => `${h.ts}|${h.source}|${h.text}`;
+  const cases: Array<[string, ChatSearchOptions]> = [
+    ["please deploy the trigram index for korean search extra", { source: "all" }],
+    ["please deploy trigram index korean search 확인 완료 없는단어", { source: "all" }],
+  ];
+  for (const [q, o] of cases) {
+    const scan = viaScan(q, o);
+    assert.ok(scan.hits.length > 0, `the relaxed query must match something: ${q}`);
+    for (const order of ["recent", "relevance"] as const) {
+      const a = viaIndex(q, { ...o, noRefresh: true, order });
+      assert.equal(a.mode, "index", `index mode expected for ${q}`);
+      assert.deepEqual(
+        a.hits.map(key).sort(),
+        scan.hits.map(key).sort(),
+        `relaxed oracle mismatch (${order}) for ${JSON.stringify(q)}`,
+      );
+    }
+  }
+});
+
 test("short (<3 char) words fall back to LIKE and still match", () => {
   // "한글" is 2 chars — trigram cannot serve it (verified in the WP2 spike).
   const a = viaIndex("한글", { noRefresh: true });

--- a/plugins/codexclaw/components/recall/test/nl-query.test.ts
+++ b/plugins/codexclaw/components/recall/test/nl-query.test.ts
@@ -1,0 +1,194 @@
+/**
+ * nl-query.test.ts — the wp5 natural-language golden set.
+ *
+ * Three sentences from the 2026-09-10 recall evaluation returned zero hits on
+ * all six paths (chat and memory, index and scan). They failed for one reason:
+ * a space-split query was truncated at eight words and then required every
+ * surviving word. This file pins the recovery on a SYNTHETIC Codex home, so it
+ * measures the matching rules rather than the state of the operator's corpus —
+ * every chat query passes both `home` and `indexPath`, because a missing
+ * `indexPath` silently answers from ~/.codexclaw/recall/index.sqlite.
+ *
+ * Each golden document is partial on purpose (see addNlGoldenCorpus): none of
+ * them contains the whole sentence, so none of these assertions could pass
+ * under the old all-words AND.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildCodexHome, addNlGoldenCorpus } from "./fixtures.ts";
+import { searchChat, chatMatchPlan, type ChatHit, type ChatSearchOptions } from "../src/chat-search.ts";
+import { searchMemory, type MemorySearchOptions } from "../src/memory-search.ts";
+import { main as cliMain } from "../src/cli.ts";
+
+/** The three evaluation sentences, verbatim. */
+const D3 = "지난번 로컬 소스를 실제 서비스에 연결하고 정상 동작까지 확인한 방법";
+const P2 = "코덱스를 재시작하면 플러그인이 사라지는 문제";
+const R2 = "2.49.0 배포하고 npm 패키지가 진짜 그 소스인지 검증한 기록";
+
+let home: string;
+let idx: string;
+
+const chat = (q: string, o: ChatSearchOptions = {}) =>
+  searchChat(q, { home, indexPath: idx, days: 0, noRefresh: true, ...o });
+const chatScan = (q: string, o: ChatSearchOptions = {}) =>
+  searchChat(q, { home, scan: true, days: 0, ...o });
+const mem = (q: string, o: MemorySearchOptions = {}) => searchMemory(q, { home, ...o });
+
+const key = (h: ChatHit) => `${h.ts}|${h.source}|${h.text}`;
+const relpaths = (r: { hits: Array<{ relpath: string }> }) => r.hits.map((h) => h.relpath);
+
+/**
+ * Both index orderings must return exactly the scan path's hit set. This is the
+ * wp5 extension of the index.test.ts oracle: once the optional groups leave the
+ * SQL WHERE clause, the JS predicate is the only thing keeping the relevance
+ * candidates, the top-up sweep and the recent page in agreement with the scan.
+ */
+function assertEnginesAgree(q: string, o: ChatSearchOptions = {}): ChatHit[] {
+  const scan = chatScan(q, o);
+  for (const order of ["relevance", "recent"] as const) {
+    const viaIndex = chat(q, { ...o, order });
+    assert.equal(viaIndex.mode, "index", `index mode expected for ${q}`);
+    assert.deepEqual(
+      viaIndex.hits.map(key).sort(),
+      scan.hits.map(key).sort(),
+      `index/scan mismatch (${order}) for ${JSON.stringify(q)}`,
+    );
+  }
+  return scan.hits;
+}
+
+test.before(() => {
+  home = mkdtempSync(join(tmpdir(), "recall-nl-"));
+  idx = join(home, "sidecar", "index.sqlite");
+  buildCodexHome(home);
+  addNlGoldenCorpus(home);
+  // Build the sidecar once; every query afterwards runs --no-refresh.
+  searchChat("trigram", { home, indexPath: idx, days: 0 });
+});
+
+test.after(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+test("G-D3: the 10-word dogfooding sentence recovers on chat, index and scan alike", () => {
+  const plan = chatMatchPlan(D3, false, false);
+  assert.equal(plan.optional.length, 9, "방법 is dropped; the 9th and 10th words are no longer truncated");
+  assert.equal(plan.required.length, 0, "korean prose carries no required term");
+  assert.equal(plan.minOptional, 5);
+
+  const hits = assertEnginesAgree(D3);
+  assert.ok(hits.length >= 1, "the sentence must reach the transcript");
+  assert.ok(
+    hits.every((h) => /bun link|healthz/.test(h.text)),
+    "the relaxed sweep must return the matching message, not merely the newest one",
+  );
+  // What makes this a relaxation and not a lucky AND: the hit does not contain
+  // three of the words the user typed.
+  assert.ok(hits.every((h) => !/지난번|확인한|방법/.test(h.text)));
+});
+
+test("G-D3: the same sentence reaches the memory store", () => {
+  const r = mem(D3);
+  assert.ok(relpaths(r).includes("nl-d3.md"), `expected nl-d3.md, got ${relpaths(r).join(", ")}`);
+  assert.ok(!r.warnings.some((w) => w.includes("lower confidence")));
+});
+
+test("G-P2: a 5-word sentence stays strict AND — chat needs --synonyms to cross languages", () => {
+  const plan = chatMatchPlan(P2, false, false);
+  assert.equal(plan.optional.length, 0, "5 words is under the threshold: every group stays required");
+  assert.equal(plan.required.length, 4, "문제 is dropped, the other four are required");
+
+  // Default chat: the transcript says Codex, the query says 코덱스를. No hit,
+  // and that is the contract — chat does not expand unless asked.
+  assert.equal(assertEnginesAgree(P2).length, 0);
+
+  const hits = assertEnginesAgree(P2, { synonyms: true });
+  assert.ok(hits.length >= 1, "--synonyms must reach the english transcript");
+  assert.ok(hits.every((h) => /BundledPluginsMarketplace|plugin wipe/.test(h.text)));
+});
+
+test("G-P2: memory expands by default, so the sentence needs no flag there", () => {
+  const r = mem(P2);
+  assert.ok(relpaths(r).includes("nl-p2.md"), `expected nl-p2.md, got ${relpaths(r).join(", ")}`);
+  // Opting out of expansion loses the ko→en bridge: the file says Codex/restart.
+  assert.equal(mem(P2, { synonyms: false }).hits.length, 0);
+});
+
+test("G-R2: symbols stay required while the korean padding becomes a quota", () => {
+  const plan = chatMatchPlan(R2, false, false);
+  assert.deepEqual(
+    plan.required.map((g) => g[0].text),
+    ["2.49.0", "npm"],
+    "the version and the package manager are what make this query specific",
+  );
+  assert.equal(plan.optional.length, 6, "그 is dropped from the remaining seven");
+  assert.equal(plan.minOptional, 3);
+
+  const hits = assertEnginesAgree(R2);
+  assert.ok(hits.length >= 1);
+  assert.ok(hits.every((h) => /gitHead|provenance/.test(h.text)));
+  // The required symbols really are required: dropping one of them from the
+  // corpus side (the user message has no npm) leaves that message out.
+  assert.ok(hits.every((h) => h.text.includes("npm")));
+});
+
+test("G-R2: memory recovers the release record with and without synonyms", () => {
+  for (const synonyms of [true, false]) {
+    const r = mem(R2, { synonyms });
+    assert.ok(
+      relpaths(r).includes("nl-r2.md"),
+      `synonyms=${synonyms}: expected nl-r2.md, got ${relpaths(r).join(", ")}`,
+    );
+  }
+});
+
+test("G-c4: relaxation does not loosen a boundary-gated symbol", () => {
+  const r = mem("LSP");
+  assert.ok(r.hits.length >= 1);
+  assert.ok(
+    relpaths(r).every((p) => p === "nl-c4-real.md"),
+    `LSP must not match inside NaiControlsPanel, got ${relpaths(r).join(", ")}`,
+  );
+  assert.ok(!r.warnings.some((w) => w.includes("lower confidence")));
+});
+
+test("G-c5: an inflected korean query still reaches the uninflected document", () => {
+  const r = mem("배포까지");
+  assert.ok(relpaths(r).includes("nl-c5.md"), `expected nl-c5.md, got ${relpaths(r).join(", ")}`);
+  assert.equal(mem("배포까지", { synonyms: false }).hits.length, 0, "opt-out drops the stem");
+});
+
+test("N-empty: an absent term still answers nothing on every path", () => {
+  const absent = "zxqv84721무지개잠수함";
+  assert.equal(assertEnginesAgree(absent).length, 0);
+  assert.equal(mem(absent).hits.length, 0);
+  // A sentence made of nothing but stopwords keeps its words rather than
+  // relaxing into "match everything".
+  assert.equal(mem("그 이 저 것 문제 방법").hits.length, 0);
+});
+
+test("cli: chat --synonyms reaches the engine, and stays off without it", () => {
+  const captured: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  (process.stdout as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+    captured.push(s);
+    return true;
+  };
+  try {
+    // --home AND --index-path: without the second one this reads the operator's
+    // real sidecar index instead of the fixture.
+    const argv = ["chat", "search", P2, "--home", home, "--index-path", idx, "--days", "0", "--no-refresh", "--json"];
+    assert.equal(cliMain([...argv]), 0);
+    const off = JSON.parse(captured.join("")) as { hits: unknown[] };
+    captured.length = 0;
+    assert.equal(cliMain([...argv, "--synonyms"]), 0);
+    const on = JSON.parse(captured.join("")) as { hits: unknown[] };
+    assert.equal(off.hits.length, 0, "chat does not expand unless asked");
+    assert.ok(on.hits.length >= 1, "--synonyms must reach the english transcript");
+  } finally {
+    (process.stdout as unknown as { write: typeof orig }).write = orig;
+  }
+});

--- a/plugins/codexclaw/components/recall/test/query-words.test.ts
+++ b/plugins/codexclaw/components/recall/test/query-words.test.ts
@@ -21,6 +21,11 @@ import {
   relaxQueryGroups,
   groupTexts,
   MAX_WORDS,
+  MAX_QUERY_TERMS,
+  dropStopwords,
+  isRequiredTerm,
+  compileMatchPlan,
+  planMatches,
 } from "../src/query-words.ts";
 import { expandQueryWords } from "../src/synonyms.ts";
 import { searchMemory, scoreChunk } from "../src/memory-search.ts";
@@ -31,7 +36,74 @@ const loose = (text: string) => ({ text, boundary: false });
 test("splitQueryWords: raw keeps case, lowercase variant matches the historical tokenizer", () => {
   assert.deepEqual(splitQueryWordsRaw("  CI  PR3956 "), ["CI", "PR3956"]);
   assert.deepEqual(splitQueryWords("  CI  PR3956 "), ["ci", "pr3956"]);
-  assert.equal(splitQueryWordsRaw("a b c d e f g h i j").length, MAX_WORDS);
+  // MAX_WORDS is a relaxation threshold now, not a truncation cap (wp5): a
+  // 10-word query keeps all ten tokens and relaxes its AND instead of losing
+  // the tail, which is where a sentence query's symbols usually sit.
+  assert.equal(splitQueryWordsRaw("a b c d e f g h i j").length, 10);
+  assert.ok(10 > MAX_WORDS, "and ten is past the threshold");
+  // MAX_QUERY_TERMS is the real cap: per-word SQL conditions grow with it.
+  const many = Array.from({ length: MAX_QUERY_TERMS + 5 }, (_, i) => `w${i}`).join(" ");
+  assert.equal(splitQueryWordsRaw(many).length, MAX_QUERY_TERMS);
+});
+
+test("dropStopwords: symbols survive, and an all-stopword query keeps its words", () => {
+  assert.deepEqual(dropStopwords(["CI", "문제"]), ["CI"], "CI is two characters but it is the query");
+  assert.deepEqual(dropStopwords(["재시작", "문제", "방법"]), ["재시작"]);
+  assert.deepEqual(dropStopwords(["그", "문제"]), ["그", "문제"], "removing everything would match everything");
+  assert.deepEqual(dropStopwords(["이해", "문제"]), ["이해"], "only the exact word is a stopword, not a prefix");
+});
+
+test("isRequiredTerm: symbols and mixed-case proper nouns, nothing else", () => {
+  const required = [
+    "2.49.0", "v2.49.0", "npm", "CI", "3956", "#3956",
+    "hook.ts", "src/hook.ts", "6e97e73d", "Codex", "BundledPluginsMarketplace", "NaiControlsPanel",
+  ];
+  for (const w of required) assert.ok(isRequiredTerm(w), `${w} must be required`);
+  for (const w of ["배포하고", "코덱스를", "deploy", "release", "korean", "지난번", "확인한"]) {
+    assert.ok(!isRequiredTerm(w), `${w} must be optional`);
+  }
+});
+
+test("compileMatchPlan: past the threshold, symbols are required and prose is a quota", () => {
+  const raw = splitQueryWordsRaw("2.49.0 배포하고 npm 패키지가 진짜 그 소스인지 검증한 기록");
+  assert.equal(raw.length, 9, "the 9th word is no longer truncated");
+  const kept = dropStopwords(raw);
+  assert.deepEqual(kept, ["2.49.0", "배포하고", "npm", "패키지가", "진짜", "소스인지", "검증한", "기록"]);
+  // Relaxation follows the ORIGINAL count: kept is back down to 8, so judging
+  // the threshold after stopword removal would silently re-impose the full AND.
+  assert.equal(kept.length, MAX_WORDS);
+  const plan = compileMatchPlan(expandQueryWords(kept), kept, false, raw.length > MAX_WORDS);
+  assert.deepEqual(plan.required.map((g) => g[0].text), ["2.49.0", "npm"]);
+  assert.equal(plan.optional.length, 6);
+  assert.equal(plan.minOptional, 3);
+});
+
+test("compileMatchPlan: a short query keeps whole-query AND, and --any outranks the quota", () => {
+  const short = ["trigram", "korean"];
+  const strict = compileMatchPlan(expandQueryWords(short), short, false, false);
+  assert.equal(strict.required.length, 2, "under the threshold every group stays required");
+  assert.deepEqual(strict.optional, []);
+  assert.equal(strict.minOptional, 0);
+
+  const long = splitQueryWordsRaw("지난번 로컬 소스를 실제 서비스에 연결하고 정상 동작까지 확인한 방법");
+  const anyPlan = compileMatchPlan(expandQueryWords(long), long, true, true);
+  assert.ok(anyPlan.anyMode, "--any is explicit and wins");
+  assert.equal(anyPlan.required.length, 10);
+  assert.deepEqual(anyPlan.optional, [], "OR over everything leaves no quota to meet");
+});
+
+test("planMatches: required groups are absolute, optional groups are a half quota", () => {
+  const raw = ["2.49.0", "npm", "패키지가", "검증한", "기록"];
+  const plan = compileMatchPlan(expandQueryWords(raw), raw, false, true);
+  assert.equal(plan.minOptional, 2, "ceil(3/2)");
+  assert.ok(planMatches("2.49.0 npm 패키지가 검증한 기록", plan));
+  assert.ok(planMatches("2.49.0 npm 패키지가 검증한 내용", plan), "two of three optional groups is enough");
+  assert.ok(!planMatches("2.49.0 npm 패키지가 다른 내용", plan), "one of three is not");
+  assert.ok(!planMatches("배포 npm 패키지가 검증한 기록", plan), "a missing required group ends it");
+  assert.ok(
+    !planMatches("anything at all", { required: [], optional: [], minOptional: 0, anyMode: false }),
+    "an empty plan matches nothing, never everything",
+  );
 });
 
 test("isSymbolWord: covers every shape in the roadmap table and excludes prose", () => {

--- a/plugins/codexclaw/components/recall/test/synonyms.test.ts
+++ b/plugins/codexclaw/components/recall/test/synonyms.test.ts
@@ -58,6 +58,40 @@ test("koreanStem: trims measured endings, refuses everything that would over-tri
   assert.equal(koreanStem("배포2"), null, "mixed tokens are out of scope");
 });
 
+test("koreanStem: 인지 trims (wp5), 한 deliberately does not", () => {
+  assert.equal(koreanStem("소스인지"), "소스");
+  assert.equal(koreanStem("무엇인지"), "무엇");
+  // The ending alone leaves no stem, so the two-syllable guard still rejects it.
+  assert.equal(koreanStem("인지"), null);
+  // 한 is not in the ending list on purpose: it would trim 검증한 → 검증 but
+  // also every noun that merely ends in 한.
+  assert.equal(koreanStem("검증한"), null);
+});
+
+test("wp5 seeds: the evaluation sentences' nouns reach their english family", () => {
+  const texts = (w: string) => groupTexts(expandQueryWords([w])[0]);
+  assert.ok(texts("도그푸딩").includes("dogfooding"));
+  assert.ok(texts("코덱스를").includes("codex"), "코덱스를 → 코덱스 → codex");
+  assert.ok(texts("재시작하면").includes("restart"), "하-verbalizer tail, then the seed");
+  assert.ok(texts("소스인지").includes("source"), "소스인지 → 소스 → source");
+  assert.ok(texts("검증").includes("verify"));
+  assert.ok(texts("검증").includes("provenance"));
+  assert.deepEqual(texts("검증한"), ["검증한"], "no 한 trimming means no seed lookup either");
+});
+
+test("memory search: 기억 recalls an english-only memory (c-5 durable-memory leg)", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-ko-recall-"));
+  try {
+    const mem = join(home, "memories");
+    mkdirSync(mem, { recursive: true });
+    writeFileSync(join(mem, "MEMORY.md"), "# Notes\n\nThe memory store keeps every decision.\n");
+    assert.ok(searchMemory("기억", { home }).hits.length >= 1, "기억 → memory");
+    assert.equal(searchMemory("기억", { home, synonyms: false }).hits.length, 0, "opt-out drops the bridge");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test("expandQueryWords: guard 3 keeps the original word leading, stem is additive", () => {
   const [group] = expandQueryWords(["배포를"]);
   const texts = groupTexts(group);

--- a/plugins/codexclaw/skills/recall/SKILL.md
+++ b/plugins/codexclaw/skills/recall/SKILL.md
@@ -36,7 +36,7 @@ and `cxc chat index --rebuild` deletes and re-ingests that index. Pass
 ```
 cxc chat search "<query>" [--days N] [--cwd PATH] [--role r] [--source main|subagent|all]
                           [--limit N] [--context N] [--any] [--all] [--no-tools]
-                          [--recent] [--rank] [--scan] [--no-refresh] [--json] [--full]
+                          [--recent] [--rank] [--scan] [--no-refresh] [--synonyms] [--json] [--full]
                           [--home PATH]
 cxc chat index [--rebuild] [--status] [--json]
 cxc memory search "<query>" [--days N] [--limit N] [--any] [--no-synonyms]
@@ -55,8 +55,13 @@ Flags that live in the CLI USAGE and are easy to miss:
 Defaults that matter:
 
 - Words AND together; pass `--any` for OR. Quote the whole query.
-- After a space split, at most 8 words are kept (`MAX_WORDS`). There is no
-  stopword list, so 그 / 진짜 / 지난번 / 문제 / 방법 stay required AND terms.
+- A space split keeps up to 16 words. Through 8 every word is required. Past 8
+  the AND relaxes: symbols, versions and mixed-case names (`2.49.0`, `npm`,
+  `CI`, `BundledPluginsMarketplace`) stay required, and the rest become a quota
+  — half of them, rounded up. Six fillers (그 / 이 / 저 / 것 / 문제 / 방법) are
+  dropped at any length; 진짜 and 지난번 are not.
+- A relaxed query can therefore answer a whole sentence, but it ranks by word
+  overlap, not by what you meant. The rewrite ladder below still wins.
 - Do not paste a Korean or English sentence as-is. Do not use `--any` on a long
   sentence — it fills the page with common-word noise and is not a relevance rewrite.
 - `--days` defaults to **7 for chat** and **0 (full history) for memory**. They
@@ -75,10 +80,15 @@ Defaults that matter:
 
 Chat (`cxc chat search`, sidecar FTS index):
 
-- Lowercase substring AND (OR with `--any`). No Korean stemming. No synonym table.
-- Drop particles yourself (`코덱스를` → `코덱스` or `codex`).
+- Lowercase substring AND (OR with `--any`). No Korean stemming and no synonym
+  table by default.
+- Drop particles yourself (`코덱스를` → `코덱스` or `codex`), or pass
+  `--synonyms` to borrow memory's ko/en table and Korean stemmer for one query
+  (`코덱스를 재시작하면` then reaches a transcript that says `Codex restart`). It
+  is off by default because expanding every word widens a multi-GB scan.
 - Trigram FTS for words of length >= 3; LIKE fallback below that. This is chat index only.
-- Empty results are possible. There is no substring fallback for a failed AND.
+- Empty results are possible. There is no substring fallback for a failed AND,
+  and past 8 words the required symbols must still all be present.
 
 Memory (`cxc memory search`):
 
@@ -120,12 +130,14 @@ own query (`--days 0`, chat then memory unless the noun is known to live in note
    answer from the excerpt.
 7. Only if the rewritten queries miss, ask the user and list what you searched.
 
-Worked recoveries (eval 2026-09-10): the sentences
-`지난번 로컬 소스를 실제 서비스에 연결하고 정상 동작까지 확인한 방법`,
-`코덱스를 재시작하면 플러그인이 사라지는 문제`,
-`2.49.0 배포하고 npm 패키지가 진짜 그 소스인지 검증한 기록`
-are 0 hits as-is. They recover as `source dogfooding` / `plugin restart` /
-`2.49.0 배포 npm`.
+Worked recoveries (eval 2026-09-10, re-measured after the long-query
+relaxation). `지난번 로컬 소스를 실제 서비스에 연결하고 정상 동작까지 확인한 방법`
+now returns hits as-is, on word overlap alone, so read them before trusting
+them. `코덱스를 재시작하면 플러그인이 사라지는 문제` and
+`2.49.0 배포하고 npm 패키지가 진짜 그 소스인지 검증한 기록` are still 0 as-is on
+this corpus: five words is a strict AND, and the release sentence's required
+`2.49.0` and `npm` never share a message with three of its remaining words.
+All three recover as `source dogfooding` / `plugin restart` / `2.49.0 배포 npm`.
 
 ## Result checks (before treating a hit as the answer)
 


### PR DESCRIPTION
A query longer than eight words was silently truncated to eight and every remaining word had to match with AND, so the sentences people actually type returned nothing while their keywords hit (the 2026-09-10 evaluation: 3 natural-language queries, 0 hits on both engines).

**After.** Every query compiles into one `MatchPlan` shared by the chat index, the chat JSONL scan and memory search. Nine words or more: symbols, versions and proper nouns are required (AND), the rest match by a ceil(n/2) quota. Eight or fewer: the previous all-AND behaviour, unchanged. A minimal stopword list (그/이/저/것/문제/방법) applies at any length. The plan is the final predicate at all three index sites (relevance recheck, top-up sweep, recent row filter) so index and scan stay equivalent; recent fetches a larger pool before the predicate and cuts at limit+1. Memory recompiles the plan inside `collect()` so the per-group relaxed retry from #125 still runs; the cwd/repo_key scope tail from #127 is untouched. `chat search --synonyms` (default off) applies the Korean stem/synonym expansion memory already uses.

| live index (read-only) | before | after |
|---|---|---|
| D3 chat "지난번 로컬 소스를 … 확인한 방법" | 0 hits / 7.3 s | 2 hits / 0.75 s |
| D3 memory | 0 | 3 |
| P2 chat "코덱스를 재시작하면 플러그인이 사라지는 문제" `--synonyms` | 0 | 3 |
| `LSP`, `2.49.0 SLSA` (c-4, wp2 goldens) | — | unchanged |

**Validation.** Synthetic golden set (`nl-query.test.ts` + `addNlGoldenCorpus`): D3/P2/R2 n≥1 on chat and memory, LSP and Korean-stem regressions retained, index/scan parity for required=0 and required≥1 nine-word oracles in relevance and recent modes. recall 177 pass (+19); dist-freshness, packaging, recall-skill-synopsis 7 pass. Tests badge 2974→2993. SKILL.md Commands fence and Two-engines section updated.

**Stack** (merge order; all PRs target `dev`): #123 → #124 → #125 → #126 → #127 → **this PR** → wp6.

Plan: `devlog/_plan/260910_memory-followup-roadmap/050_wp5_natural-language-query.md`.

