### PR TITLE
fix(provider-bridge): reuse win-exec for PATHEXT resolution and ComSpec routing (L1, #131)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C032_passing-brightgreen" alt="3,032 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C032_passing-brightgreen" alt="3,032 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C032_passing-brightgreen" alt="3,032 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_windows_issue_sweep/000_plan.md
+++ b/devlog/_plan/260911_windows_issue_sweep/000_plan.md
@@ -1,0 +1,244 @@
+# 260911 Windows issue sweep — roadmap
+
+Revision 2. Revision 1 was audited by an independent `xai/grok-4.6` reviewer and
+returned VERDICT: FAIL. Every blocker and concern below is folded, not rebutted;
+the audit trail is summarised in `Audit fold (revision 1 to 2)`.
+
+## Objective
+
+Close every open codexclaw issue that reproduces on Windows, deliver them as a
+manual stacked branch chain based on `dev`, and finish with green CI on every
+layer, a bottom-up merge, a release deploy, and a reinstall of the registered
+plugin from this local checkout.
+
+Host goal: `close-every-open-codexclaw-issue-that-reproduces` (session
+`01a08fba-94d6-7811-8ba6-097379c8a7ad`). This unit is the Phase-0 docs-only pass
+required by LOOP-DOCS-FIRST-01; its D locks the work-phase map below.
+
+The open set is exactly five issues: #109, #131, #132, #133, #134. Verified with
+`gh issue list --state open` at `9cd52769`.
+
+## Constraints
+
+- **Detect-only stays detect-only.** The provider bridge never runs `ocx ensure`
+  or `ocx sync` and never writes codex config (Q-P2-2). L1 changes execution
+  path resolution only.
+- **The evidence chain does not bend.** An `unavailable` source identity must not
+  certify a cycle. CHECK-BINDING-01 stays fail-closed for bound sessions
+  (`devlog/_plan/260815_pabcd_phase_collapse/075_receipt_binding.md:66`). L5 makes
+  a real git identity reachable in the split-cwd case; it never makes
+  `unavailable` acceptable.
+- **The root-session guard stays.** `ROOT_SOURCES` at `session-binding.ts:12`
+  rejecting subagent bindings is intended behavior and is not part of #134.
+- **Reuse `win-exec.ts`, do not invent a third ComSpec wrapper.** That module
+  already exists in `pabcd-state`, `cxc-ops`, `messenger-bridge`,
+  `skill-search` and `subagent-config` and already routes `.cmd` through
+  ComSpec. `provider-bridge` is the only component without it. `build.mjs`
+  permits only `node:*` and relative imports inside a component, so the correct
+  move is a faithful per-component copy of that existing pattern, not a new design
+  and not a cross-component import.
+- **Committed `dist` is per component, and new files are ignored.** `git ls-files dist`
+  returns nothing at the root; what is tracked is
+  `plugins/codexclaw/components/*/dist/`. `.gitignore:2` ignores `dist/`, so a
+  layer that adds a NEW `.ts` file cannot stage its build output with a plain
+  `git add` — it needs `git add -f` for that path. `npm run build` is
+  deterministic, so untouched components do not go dirty.
+- **No GitHub native stack.** The user asked for stacked PRs generically, which is
+  not a DEV-STACK-OPT-IN-01 opt-in. Manual branch chain only.
+- Windows is the target platform for every reproduction. Shell work follows the
+  `powershell-landmines` skill; `--attest-file` is mandatory for every attest.
+
+## Out of scope
+
+Changing the provider contract; letting an `unavailable` identity certify a cycle;
+relaxing the root-session guard; publishing outside `lidge-jun/codexclaw`; touching
+user credentials or opencodex configuration; PR #118 (a cross-repo fork PR from
+`thisisjun786` that is already CONFLICTING and belongs to its author).
+
+## Stack topology
+
+Bottom to top. Each layer PR bases on the layer below; merge bottom-up.
+
+| Layer | Branch | Base | Work-phase | Issue |
+|---|---|---|---|---|
+| L0 | `codex/win-sweep-roadmap` | `dev` | wp1 | — (this unit) |
+| L1 | `codex/fix-ocx-windows-detect` | L0 | wp2 | #131 |
+| L2 | `codex/fix-session-binding-extended-path` | L1 | wp3 | #134 |
+| L3 | `codex/fix-config-guard-help` | L2 | wp4 | #132 |
+| L4 | `codex/fix-nongit-early-refusal` | L3 | wp5 | #133 |
+| L5 | `codex/fix-split-cwd-source` | L4 | wp8 | #109 |
+| L6 | `codex/windows-landmine-sweep` | L5 | wp6 | — (corpus sweep) |
+
+wp7 is integration only: it adds no layer, it turns the chain green and ships it.
+Execution order is wp1, wp2, wp3, wp4, wp5, wp8, wp6, wp7.
+
+### Goalplan drift notice (read before following the bound plan)
+
+The bound goalplan's `workPhases[]` were registered against revision 1 and its
+titles and dependency edges are append-only — they cannot be rewritten. Three
+entries therefore disagree with this document, and **this document governs**:
+
+- `wp5` is titled `issues 133 and 109`. It covers **#133 only**.
+- `wp6` is titled `Stack L5` and does not depend on `wp8`. It is **L6** and
+  must run after `wp8`.
+- `wp7` does not depend on `wp8`. It must not start until `wp8` is done.
+
+Following the raw goalplan edges would let the loop reach integration without ever
+closing #109. A `loop steer` annotation records this correction in the ledger.
+
+### Why a chain, and where it is genuinely required
+
+Revision 1 claimed committed `dist` forces total ordering. That was overstated and
+the audit was right to reject it. The honest statement:
+
+- The user asked for a stacked delivery, which is sufficient reason on its own.
+- Two couplings are real: **L2 and L4/L5 all write `pabcd-state`**, and **L6 revisits
+  spawn code that L1 and L3 touched**. Those cannot be parallel without conflict.
+- L1, L2 and L3 are otherwise independent and could have been parallel PRs. They
+  are chained anyway to honour the requested delivery shape, at the cost of
+  cascade work, not because the tooling forces it.
+
+### Ordering rationale
+
+L1 first because it is already verified end-to-end on this host and it unblocks the
+provider status line every later session reads. L2 next because `cxc session current`
+is the SESSION-IDENTITY-01 corroboration step this very loop is currently missing.
+L3 is independent and cheap. L4 is the cheap half of the non-git problem. L5 is the
+only C4 layer and sits above everything it must not block. L6 is last because its
+findings touch files the lower layers moved.
+
+### Rebase exposure
+
+PR #130 (`codex/explorer-routing-fix`) is open against `dev`, MERGEABLE and CLEAN
+with 13/13 green checks. If it merges before this chain, **every layer needs a
+rebase**. Check `dev` head before each layer push and cascade from L0 upward.
+
+## Dependency-ordered work-phase map
+
+- **wp1 — docs-first roadmap (this unit).** Deliver `000_plan.md` plus decade docs
+  at diff-level precision. Docs only; no production patch.
+- **wp2 — L1 / #131.** `provider-bridge` selects the PATHEXT launcher AND routes
+  `.cmd` through ComSpec, mirroring `win-exec.ts`. Both halves need their own
+  test. Doc: `010_wp2_provider_bridge_windows_detect.md`.
+- **wp3 — L2 / #134.** `session-binding.ts` canonicalises with `realpathSync.native`
+  at both call sites (`:38` and `:78`). Doc:
+  `020_wp3_session_binding_extended_path.md`.
+- **wp4 — L3 / #132.** `enable`/`disable`/`uninstall`/`status` forward full
+  argv on BOTH entrypoints, `config-guard` main answers help before the action,
+  and the `uninstall` alias still reaches `disable`. Doc:
+  `030_wp4_config_guard_help_passthrough.md`.
+- **wp5 — L4 / #133 only.** Swallow git stderr in `source-identity.ts:69` and refuse
+  at entry instead of stalling at C. **The refusal predicate is "the SOURCE identity
+  cannot be resolved", never "the FSM cwd has no `.git`".** Written the second way,
+  L4 would reject the #109 case at the door and L5 would have to undo L4; written
+  the first way they compose, because L5's job is precisely to make that source
+  identity resolvable. This closes #133 and **explicitly does not close #109**.
+  Doc: `040_wp5_nongit_early_refusal.md`.
+- **wp8 — L5 / #109.** Split-cwd source separation: a bound session whose FSM
+  directory is not a repository but whose source tree is must complete a cycle with
+  a receipt carrying a real commit sha. Doc: `045_wp8_split_cwd_source.md`.
+- **wp6 — L6 / corpus sweep.** Doc: `050_wp6_windows_landmine_sweep.md`.
+- **wp7 — integration.** Doc: `060_wp7_integration_merge_deploy.md`.
+
+## Corpus sweep scope (fixed by preflight, not by guesswork)
+
+The preflight found that **#131 has two more live copies**. Fixing only
+`provider-bridge` leaves the GUI and `cxc serve` provider endpoints reporting
+error on this host.
+
+| path:line | corpus case | what breaks |
+|---|---|---|
+| `gui/src/server/middleware.ts:75` | `get-command-where-disagree` | `where` first line is the extensionless shim |
+| `gui/src/server/middleware.ts:79` | `spawn-npm-enoent-einval` | `.cmd` spawned without ComSpec |
+| `messenger-bridge/src/api-compat.ts:40` | `get-command-where-disagree` | same first-line bug in the serve path |
+| `messenger-bridge/src/api-compat.ts:45` | `spawn-npm-enoent-einval` | same shell-less `.cmd` spawn |
+| `config-guard/src/cli.ts:131` | `spawn-npm-enoent-einval` | bare `codex` spawn. The existing resolver lives in `cxc-ops/src/codex-bin.ts:106`, a different component, so the same import ban applies: copy the pattern, do not import it |
+| `gui/src/server/middleware.ts:88` | `windowsapps-alias-eperm` | same bare `codex` spawn |
+
+Deferred with reason (risk=medium, outside this issue set): the BOM-less `.cmd`
+written by `messenger-bridge/src/service.ts:245` (only bites on a non-ASCII home
+path) and the colon-PATH test fixtures in `payload-bin.test.mjs:72` and
+`live-catalog.test.ts:79` (test-only, currently green, product paths already
+use `commandInvocation`).
+
+## Triage provenance
+
+Root causes were established by independent read-only `xai/grok-4.6` dispatches
+against this checkout, each quoting `path:line`. Three findings correct the issue
+bodies and are load-bearing:
+
+- **#134 is not a database lookup failure.** The thread row exists and is readable.
+  On this host **77 of 77 thread rows** store `cwd` with the extended-length
+  prefix, including the #134 session (`source=vscode`). JS `realpathSync` throws
+  `EISDIR lstat 'C:'` on that shape; `realpathSync.native` resolves it. The
+  reproduction must use the extended-length prefix — **not** 8.3 short names, which
+  are a different alias class that happens to share the fix.
+- **#109's stated cause is inverted.** `--cwd` reaches git through
+  `captureSessionSourceIdentity(args.cwd)` and then `captureSourceIdentity(sourceCwd)`.
+  With no source binding, `sourceCwd === cwd`, so `--cwd` IS the git cwd. That
+  is why git fails. #109 needs source separation, not `--cwd` propagation.
+- **`cxc session source` cannot rescue #109 today.** `bindSessionSource` calls
+  `gitIdentity(cwd)` on the native cwd and accepts only a linked worktree of the
+  same repository (`session-source.ts:102`). A non-git parent with a nested git
+  child is not expressible. L5 must extend that surface.
+
+## Acceptance criteria
+
+The bound goalplan carries `c-1`..`c-12`. `c-8`..`c-12` were added in
+revision 2 to close gaming holes the audit found; where they overlap an earlier
+criterion, **the tighter one governs**.
+
+| id | criterion | proving layer |
+|---|---|---|
+| c-1 | numbered diff-level roadmap exists before any implementation cycle | wp1 |
+| c-9 | #131 fixed in both halves and in every copy; separate tests for launcher selection and ComSpec spawn; provider/GUI/serve endpoints all report provider, never error | wp2 + wp6 |
+| c-3 | `cxc session current` succeeds against an extended-length stored cwd | wp3 |
+| c-10 | both entrypoints, all four verbs, both help flags, config byte-identical and no bak; `cxc uninstall` without help still disables | wp4 |
+| c-5 | bound non-git cycle refused at entry; no git fatal reaches user output | wp5 |
+| c-8 | #109 positive path: non-git FSM dir with a git source completes P through D and the receipt carries a real commit sha | wp8 |
+| c-11 | every risk=high corpus finding fixed in this stack; deferral only for risk=medium with a reason | wp6 |
+| c-12 | after reinstall, the INSTALLED payload hook emits provider mode and the INSTALLED `cxc enable --help` is side-effect free | wp7 |
+| c-7 | green CI per layer, merged bottom-up, release deployed | wp7 |
+
+`c-2`, `c-4` and `c-6` remain open and are superseded by `c-9`, `c-10`
+and `c-11` respectively. They are satisfied as a side effect of the tighter ones;
+they are never satisfied on their own.
+
+## Verification contract
+
+Every implementation layer must produce, with pasted output and exit codes:
+
+1. `npm run build`, then stage the component dist. A layer that adds a NEW `.ts`
+   file must use `git add -f <that dist path>` because `.gitignore:2` ignores
+   `dist/` and only already-tracked outputs restage normally.
+2. `npm run gate`.
+3. the affected component suite via `node plugins/codexclaw/scripts/test.mjs <glob>`.
+4. a reproduction that fails on the parent commit and passes on the layer head.
+5. `cxc receipt test --session <id> -- <command>` backing the C to D edge.
+
+Known pre-existing failures on this host, not caused by this unit and not treated
+as regressions: `repo-map-packaging.test.mjs` (no Python installed),
+`gui/test/router.test.ts`, and the `hook-bench --json` schema test.
+
+## Audit fold (revision 1 to 2)
+
+| audit finding | disposition |
+|---|---|
+| BLOCKER: #109 listed in L4 but neither scoped nor gated | folded — #109 is its own layer L5/wp8 with positive criterion c-8 |
+| `dist` total-ordering rationale overstated | folded — rationale corrected; the real couplings are named |
+| new dist files are gitignored, contract said only restage | folded — `git add -f` is now step 1 |
+| c-2 passes on path change alone | folded — superseded by c-9 |
+| c-4 passes via the already-working top-level help | folded — superseded by c-10, which names the verbs and both entrypoints |
+| c-6 passes if everything is deferred | folded — superseded by c-11 |
+| c-7 passes on a version string | folded — superseded by c-12, which requires the installed binary |
+| L1 would be a third ComSpec implementation | folded — `win-exec.ts` reuse is now a constraint |
+| PR #130 can force a full rebase | folded — recorded as rebase exposure |
+| NIT: `--cwd` path is via `captureSessionSourceIdentity` | folded — chain corrected |
+| NIT: `session-source.ts:17` native reason is 8.3, not the prefix | folded — reproduction now pinned to the prefix |
+
+## Unattended resource bounds
+
+Tool scope: local repo, `gh` against `lidge-jun/codexclaw`, `xai/grok-4.6`
+subagents (user-declared unlimited). Write scope: this repository plus the locally
+installed plugin payload during wp7 reinstall. Wall-clock: CI waits are async and
+polled, never blocking sleeps. Hitting a bound is BUDGET_EXHAUSTED, not DONE.

--- a/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
+++ b/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
@@ -355,6 +355,19 @@ The behaviour difference from `where` is that a launcher reachable only through 
 `where`-visible alias but not through PATH+PATHEXT would no longer be found; no such
 case exists for npm global installs, which is the shape #131 reports.
 
+**Measured second behaviour difference: the reported extension carries PATHEXT casing.**
+`resolveWindowsCommand` builds candidates as `command + ext` using PATHEXT's own
+spelling, and Windows `existsSync` is case-insensitive, so a file named `ocx.cmd` on
+disk resolves to a path ending `.CMD` when PATHEXT says `.CMD`. The old `where`-parsing
+path reported the on-disk casing instead. Caught by the §5 tests on first run.
+
+Impact is cosmetic: Windows paths are case-insensitive, so spawning is unaffected, and
+the only consumer of `ocxPath` is the status line that the catalog and GUI read as a
+path. **Do not "fix" it by normalising inside `win-exec.ts`** — that file is byte-shared
+with four other components and the byte-identity test would fail. The §5 assertions
+compare case-insensitively and additionally assert the extension matches `/\.cmd$/i`, so
+the thing being pinned is that the extensionless shim lost, not a particular spelling.
+
 The real hazard is copy drift: `win-exec.ts` now lives in six components. The
 byte-identity test in §5 is the guard, and it fails loudly if the original is edited
 without propagating.

--- a/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
+++ b/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
@@ -16,15 +16,15 @@ criterion: **c-9** (wp2 half: launcher selection + ComSpec spawn, separate tests
 
 | file | NEW/MODIFY/DELETE | change |
 |---|---|---|
-| `plugins/codexclaw/components/provider-bridge/src/win-exec.ts` | NEW | Byte-identical copy of `cxc-ops/src/win-exec.ts`. SHA256 `B7B07DE668F622EA1AC0CD1A82FE04B61C85A41E9390233D22AEBAA4AF175E3D` (same bytes as `pabcd-state` / `cxc-ops` / `skill-search` / `subagent-config`). `build.mjs` allows only `node:*` + relative imports inside a component, so a cross-component import is illegal. |
+| `plugins/codexclaw/components/provider-bridge/src/win-exec.ts` | NEW | Byte-identical copy of `cxc-ops/src/win-exec.ts` (3657 bytes, SHA256 `B7B07DE6…`). Four components already carry these exact bytes: `cxc-ops`, `pabcd-state`, `skill-search`, `subagent-config`. See §4.1 for why a copy rather than the re-export `messenger-bridge` uses. |
 | `plugins/codexclaw/components/provider-bridge/dist/win-exec.js` | NEW | `npm run build` output. `.gitignore:2` ignores `dist/`, so `git add -f plugins/codexclaw/components/provider-bridge/dist/win-exec.js`. |
-| `plugins/codexclaw/components/provider-bridge/src/cli.ts` | MODIFY | Add `selectExecutableFromWhereOutput` for the `where` first-line bug. `runOcxStatus` must call the copied `commandInvocation`, not an inlined ComSpec wrapper. Direct-exec guard so tests can import `cli.ts`. |
+| `plugins/codexclaw/components/provider-bridge/src/cli.ts` | MODIFY | `whichOcx` resolves through `resolveWindowsCommand` on win32, **deleting** the `where`-stdout parsing rather than patching it. `runOcxStatus` routes through `commandInvocation` instead of an inlined ComSpec wrapper. Direct-exec guard so tests can import `cli.ts`. No `selectExecutableFromWhereOutput` helper survives. |
 | `plugins/codexclaw/components/provider-bridge/dist/cli.js` | MODIFY | compileSource of the same commit. Already tracked. |
-| `plugins/codexclaw/components/provider-bridge/test/detect.test.ts` | MODIFY | Launcher-selection test + ComSpec spawn test + SHARED-HELPER-01 byte-identity check. |
+| `plugins/codexclaw/components/provider-bridge/test/detect.test.ts` | MODIFY | Launcher-selection test + ComSpec spawn test + SHARED-HELPER-01 byte-identity check + the §5.1 end-to-end wiring test. |
 
 No DELETE. Do not modify `detect.ts`.
 
-## 3. Current code (L0 `9cd52769`)
+## 3. Current code (L0 `14aa3f21`, based on dev `a267b398`)
 
 `plugins/codexclaw/components/provider-bridge/src/cli.ts:15-36`:
 
@@ -36,7 +36,7 @@ function whichOcx(cmd: string): string | null {
   try {
     const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
     if (res.status === 0 && typeof res.stdout === "string") {
-      const path = res.stdout.split("\\n")[0]?.trim();
+      const path = res.stdout.split("\n")[0]?.trim();
       return path && path.length > 0 ? path : null;
     }
     return null;
@@ -69,7 +69,7 @@ process.exit(0);
 
 `where` prints the extensionless npm sh shim first (`get-command-where-disagree`). Spawning that path or a `.cmd` without a shell is EINVAL (`spawn-npm-enoent-einval`, CVE-2024-27980).
 
-Note: the live source at `:22` is `res.stdout.split("\n")[0]?.trim();` — a JS `"\\n"` split, not a CRLF-aware split. `where.exe` emits CRLF; `.trim()` currently strips the leftover CR by accident.
+Note: `:22` splits on `"\n"`, not on `/\r?\n/`. `where.exe` emits CRLF, so the first element keeps a trailing CR and `.trim()` removes it by accident rather than by design. §4.2 drops this code path on win32 entirely.
 
 ## 4. The committed implementation is correct but is a third ComSpec wrapper
 
@@ -100,10 +100,29 @@ first-line bug stops being something to work around.
 
 ### 4.1 NEW `provider-bridge/src/win-exec.ts`
 
-Byte-identical copy of `cxc-ops/src/win-exec.ts`. `build.mjs` permits only `node:*` and
-relative imports inside a component, so a cross-component import is illegal and a copy
-is the sanctioned form — the same copy already exists in `pabcd-state`, `cxc-ops`,
-`messenger-bridge`, `skill-search` and `subagent-config`.
+Byte-identical copy of `cxc-ops/src/win-exec.ts` — 3657 bytes, SHA256 `B7B07DE6…`.
+
+**Correction to an earlier claim in this document.** A cross-component import is not
+illegal. `build.mjs` lines 6-8 describe the `node:*`-plus-relative convention in a
+**comment**; there is no check enforcing it, and `messenger-bridge` already crosses the
+boundary:
+
+```ts
+// plugins/codexclaw/components/messenger-bridge/src/win-exec.ts — 142 bytes
+/** Compatibility export; subprocess escaping is shared with live model discovery. */
+export * from "../../subagent-config/dist/win-exec.js";
+```
+
+So the repository has both shapes: four byte-identical copies (`cxc-ops`, `pabcd-state`,
+`skill-search`, `subagent-config`) and one re-export.
+
+**Choose the copy here anyway, for a reason specific to this component.** The re-export
+targets another component's `dist/`, which makes the importer's runtime depend on that
+component having been built. `provider-bridge` is invoked by a **SessionStart hook** on
+every session start; a resolution failure there degrades the provider status line for
+reasons that have nothing to do with providers, and the hook is required to always exit
+0, so the failure would be silent. A self-contained copy removes that coupling. The
+cost is drift, which §5's byte-identity test converts into a loud test failure.
 
 ```powershell
 Copy-Item plugins/codexclaw/components/cxc-ops/src/win-exec.ts `
@@ -161,7 +180,7 @@ Keep the direct-exec guard from `f280394b` (`process.argv[1]` realpath compared 
 `import.meta.url`): without it, importing `cli.ts` from a test calls `process.exit(0)`.
 Do not touch `detect.ts`.
 
-## 5. MODIFY `test/detect.test.ts` — two halves, two tests
+## 5. MODIFY `test/detect.test.ts` — two halves, then the wiring
 
 c-9 requires launcher selection and ComSpec spawn to be proven **separately**. A single
 end-to-end test passes when only one half works.
@@ -211,6 +230,80 @@ test("provider-bridge win-exec.ts is byte-identical to the cxc-ops original", ()
 
 Keep the `status: null` → `error` test from `f280394b`: it pins that a failed spawn is
 never silently downgraded to `native`.
+
+### 5.1 The wiring test — NEW, and the one that actually gates c-9
+
+The three tests above exercise `win-exec.ts` directly. That is a real hole: copying
+`win-exec.ts` and **never touching `cli.ts`** would pass all three. The existing AC2 case
+(`detect.test.ts:12-16`) does not close it either, because it injects `which: () => null`
+and so never exercises the new win32 resolution at all.
+
+Close it with an end-to-end test that runs the real `cli.ts` as a subprocess against a
+crafted PATH. This is the only test here that proves launcher selection, ComSpec spawn,
+**and** the `whichOcx`/`runOcxStatus` wiring together.
+
+```ts
+// win32 only: proves the real cli.ts wiring, not just the helpers.
+test("detect resolves the .cmd launcher and reads status through ComSpec end to end", { skip: process.platform !== "win32" }, t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-e2e-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  // The npm global-install shape: an extensionless sh shim that `where` lists FIRST
+  // and that Windows cannot execute, beside the .cmd launcher that it can.
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\nexit 1\n");
+  writeFileSync(
+    join(dir, "ocx.cmd"),
+    // A .cmd that only answers `status --json`. Single-line echo: cmd has no here-doc.
+    "@echo off\r\n" +
+      'echo {"proxy":{"running":true},"defaultProvider":"openai","listen":{"port":10100}}\r\n',
+  );
+
+  const cli = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+  const res = spawnSync(process.execPath, ["--experimental-strip-types", cli, "detect"], {
+    encoding: "utf8",
+    // dir FIRST so the crafted launcher wins over any real ocx on this machine.
+    env: { ...process.env, PATH: `${dir};${process.env.PATH ?? ""}`, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+  });
+
+  assert.equal(res.status, 0);
+  const line = JSON.parse(res.stdout.trim().split(/\r?\n/).pop());
+  assert.equal(line.mode, "provider");                 // not "error", not "native"
+  assert.equal(line.ocxPath, join(dir, "ocx.cmd"));    // the launcher, not the shim
+  assert.equal(line.running, true);                    // the payload really came back
+  assert.equal(line.port, 10100);
+});
+```
+
+Why each assertion earns its place:
+
+- `mode === "provider"` fails if either half regresses. Picking the shim gives ENOENT →
+  `status: null` → `error`; spawning the `.cmd` shell-lessly gives EINVAL → the same
+  `error`. This is the assertion the roadmap's original c-2 was missing.
+- `ocxPath` ending in `.cmd` isolates launcher selection.
+- `running` and `port` prove the payload was actually read, so the test cannot pass on
+  a resolved path alone.
+
+Also **fix the AC2 gap** while here: keep the injected-`null` case, and add a real-PATH
+case asserting `mode === "native"` when `PATH` contains no `ocx` at all. Without it,
+`whichOcx` returning something truthy on a miss would silently reclassify absent-ocx as
+`error`.
+
+```ts
+test("no ocx on PATH resolves to native through the real resolver", { skip: process.platform !== "win32" }, t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-empty-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const cli = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+  const res = spawnSync(process.execPath, ["--experimental-strip-types", cli, "detect"], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+  });
+  assert.equal(res.status, 0);
+  assert.equal(JSON.parse(res.stdout.trim().split(/\r?\n/).pop()).mode, "native");
+});
+```
+
+Both tests need `mkdtempSync`, `writeFileSync`, `rmSync`, `tmpdir`, `join`,
+`spawnSync` and `fileURLToPath` imported at the top of the file.
 
 ## 6. Reproduction (parent fails, L1 head passes)
 

--- a/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
+++ b/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
@@ -1,0 +1,264 @@
+# 010 — wp2 / L1 / #131 provider-bridge Windows detect
+
+Date: 2026-09-11 (KST). Worktree `C:\\Users\\super\\Developers\\codexclaw`, branch `codex/win-sweep-roadmap`, HEAD `9cd52769`. This file is the plan. No production code was changed in this cycle.
+
+Sources: `000_plan.md` wp2, constraint "Reuse win-exec.ts", criterion **c-9**. Implementation commit `f280394b` (`codex/fix-ocx-windows-detect`, parent `9cd52769`) was read with `git show f280394b`. Before blocks are quoted from L0 HEAD.
+
+Detect-only: never `ocx ensure`, never `ocx sync`, never write Codex config (Q-P2-2).
+
+## 1. Goal
+
+`provider-bridge` on Windows must (1) pick a PATHEXT launcher from `where` stdout instead of the extensionless npm shim, and (2) run `.cmd`/`.bat` through ComSpec. Each half has its own test. GUI/serve copies are wp6 (`050`). This document owns provider-bridge only.
+
+criterion: **c-9** (wp2 half: launcher selection + ComSpec spawn, separate tests).
+
+## 2. File map
+
+| file | NEW/MODIFY/DELETE | change |
+|---|---|---|
+| `plugins/codexclaw/components/provider-bridge/src/win-exec.ts` | NEW | Byte-identical copy of `cxc-ops/src/win-exec.ts`. SHA256 `B7B07DE668F622EA1AC0CD1A82FE04B61C85A41E9390233D22AEBAA4AF175E3D` (same bytes as `pabcd-state` / `cxc-ops` / `skill-search` / `subagent-config`). `build.mjs` allows only `node:*` + relative imports inside a component, so a cross-component import is illegal. |
+| `plugins/codexclaw/components/provider-bridge/dist/win-exec.js` | NEW | `npm run build` output. `.gitignore:2` ignores `dist/`, so `git add -f plugins/codexclaw/components/provider-bridge/dist/win-exec.js`. |
+| `plugins/codexclaw/components/provider-bridge/src/cli.ts` | MODIFY | Add `selectExecutableFromWhereOutput` for the `where` first-line bug. `runOcxStatus` must call the copied `commandInvocation`, not an inlined ComSpec wrapper. Direct-exec guard so tests can import `cli.ts`. |
+| `plugins/codexclaw/components/provider-bridge/dist/cli.js` | MODIFY | compileSource of the same commit. Already tracked. |
+| `plugins/codexclaw/components/provider-bridge/test/detect.test.ts` | MODIFY | Launcher-selection test + ComSpec spawn test + SHARED-HELPER-01 byte-identity check. |
+
+No DELETE. Do not modify `detect.ts`.
+
+## 3. Current code (L0 `9cd52769`)
+
+`plugins/codexclaw/components/provider-bridge/src/cli.ts:15-36`:
+
+```ts
+/** Real PATH resolver via the platform `command -v` / `where`. */
+function whichOcx(cmd: string): string | null {
+  const finder = process.platform === "win32" ? "where" : "command";
+  const args = process.platform === "win32" ? [cmd] : ["-v", cmd];
+  try {
+    const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
+    if (res.status === 0 && typeof res.stdout === "string") {
+      const path = res.stdout.split("\\n")[0]?.trim();
+      return path && path.length > 0 ? path : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Real ocx status reader (detect-only — `status --json` is read-only; never
+ *  `ensure`/`sync`, which would mutate codex config). */
+function runOcxStatus(ocxPath: string): { status: number | null; stdout: string } {
+  const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
+}
+```
+
+`cli.ts:57-65` (importing the module exits immediately, so a test cannot import launcher helpers):
+
+```ts
+const [, , kind, event] = process.argv;
+if (kind === "hook" && event === "session-start") {
+  process.exit(runSessionStartHook());
+}
+// Allow `provider-bridge detect` for cxc doctor / manual probes.
+if (kind === "detect") {
+  process.exit(runBridge());
+}
+process.exit(0);
+```
+
+`where` prints the extensionless npm sh shim first (`get-command-where-disagree`). Spawning that path or a `.cmd` without a shell is EINVAL (`spawn-npm-enoent-einval`, CVE-2024-27980).
+
+Note: the live source at `:22` is `res.stdout.split("\n")[0]?.trim();` — a JS `"\\n"` split, not a CRLF-aware split. `where.exe` emits CRLF; `.trim()` currently strips the leftover CR by accident.
+
+## 4. The committed implementation is correct but is a third ComSpec wrapper
+
+Commit `f280394b` fixes both halves and is verified on this host (provider-bridge
+tests 9/9; the session-start hook emits `"mode":"provider"` with `C:\nvm4w\nodejs\ocx.cmd`).
+It does so with a bespoke helper pair: `selectExecutableFromWhereOutput()` parsing
+`where` stdout, and an inline `spawnSync(ComSpec, ["/d","/s","/c", `"${ocxPath}" status --json`])`.
+
+The 000_plan constraint says reuse `win-exec.ts`, and comparing the two makes the
+reason concrete rather than stylistic. `commandInvocation()` in
+`cxc-ops/src/win-exec.ts` already handles four things the bespoke version does not:
+
+| `win-exec.ts` behaviour | bespoke version |
+|---|---|
+| `envValue()` reads `PATH`/`PATHEXT` **case-insensitively** — a spawned child can arrive with `Path`, `PATH`, or both | reads `process.env.PATHEXT` only |
+| `resolveWindowsCommand()` walks PATH+PATHEXT itself and retries the **lowercased** extension for case-sensitive filesystems (WSL, Linux CI) | depends on `where.exe` stdout, which does not exist off win32 |
+| splits PATH on a literal `;` with an explicit comment that `node:path`'s `delimiter` follows the HOST and would collapse a Windows PATH on a Linux runner | not applicable, but the same trap sits in this repo's test fixtures (corpus `path-colon-not-delimiter`) |
+| `escapeCmdArg()`/`escapeCmdCommand()` escape `()%!^"<>&|;,` and space, cross-spawn style | wraps the path in plain double quotes. A launcher path containing `&` or `^` is a cmd injection (corpus `cmd-start-ampersand-splits`, `backslash-quote-ends-span`) |
+
+The last row is the one that matters: `windowsVerbatimArguments: true` with a naively
+quoted path hands cmd.exe an unescaped metacharacter. `C:\nvm4w\nodejs` is benign, so the
+host verification cannot distinguish the two implementations — which is exactly why
+this must be fixed by construction rather than by observation.
+
+**Decision: keep the shape of `f280394b` but replace both helpers with the existing
+module.** `resolveWindowsCommand()` also removes the `where` parsing entirely, so the
+first-line bug stops being something to work around.
+
+### 4.1 NEW `provider-bridge/src/win-exec.ts`
+
+Byte-identical copy of `cxc-ops/src/win-exec.ts`. `build.mjs` permits only `node:*` and
+relative imports inside a component, so a cross-component import is illegal and a copy
+is the sanctioned form — the same copy already exists in `pabcd-state`, `cxc-ops`,
+`messenger-bridge`, `skill-search` and `subagent-config`.
+
+```powershell
+Copy-Item plugins/codexclaw/components/cxc-ops/src/win-exec.ts `
+  plugins/codexclaw/components/provider-bridge/src/win-exec.ts
+```
+
+### 4.2 MODIFY `provider-bridge/src/cli.ts`
+
+after (replaces both helpers quoted in §3):
+
+```ts
+import { spawnSync } from "node:child_process";
+import { commandInvocation, resolveWindowsCommand } from "./win-exec.ts";
+import { detectOcx, renderStatusLine, type DetectDeps } from "./detect.ts";
+
+/**
+ * Resolve `ocx` to a spawnable path.
+ *
+ * #131: on win32 `where ocx` lists the extensionless npm sh shim FIRST, and that
+ * file is not an executable image, so spawnSync ENOENTs. Rather than pick a line
+ * out of `where` stdout, resolve PATH+PATHEXT directly — resolveWindowsCommand()
+ * reads PATH/PATHEXT case-insensitively and retries lowercased extensions, which a
+ * `where` parse cannot do. POSIX keeps `command -v`.
+ */
+function whichOcx(cmd: string): string | null {
+  if (process.platform === "win32") {
+    const resolved = resolveWindowsCommand(cmd, process.env);
+    // resolveWindowsCommand returns its input when nothing matched.
+    return resolved === cmd ? null : resolved;
+  }
+  try {
+    const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
+    if (res.status === 0 && typeof res.stdout === "string") {
+      const path = res.stdout.split(/\r?\n/)[0]?.trim();
+      return path && path.length > 0 ? path : null;
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+/** Real ocx status reader (detect-only — `status --json` is read-only; never
+ *  `ensure`/`sync`, which would mutate codex config).
+ *
+ *  #131 second half: after CVE-2024-27980 Node refuses a shell-less `.cmd` spawn
+ *  (EINVAL). commandInvocation routes only `.cmd`/`.bat` through ComSpec and escapes
+ *  cmd metacharacters; `shell: true` would not escape them. */
+function runOcxStatus(ocxPath: string): { status: number | null; stdout: string } {
+  const inv = commandInvocation(ocxPath, ["status", "--json"]);
+  const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 8000, ...inv.options });
+  return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
+}
+```
+
+Keep the direct-exec guard from `f280394b` (`process.argv[1]` realpath compared against
+`import.meta.url`): without it, importing `cli.ts` from a test calls `process.exit(0)`.
+Do not touch `detect.ts`.
+
+## 5. MODIFY `test/detect.test.ts` — two halves, two tests
+
+c-9 requires launcher selection and ComSpec spawn to be proven **separately**. A single
+end-to-end test passes when only one half works.
+
+```ts
+import { commandInvocation, resolveWindowsCommand } from "../src/win-exec.ts";
+
+// Half 1 — launcher selection. A directory holding BOTH the extensionless npm shim
+// and the .cmd launcher must resolve to the .cmd. This is #131's first cause.
+test("win32 launcher selection prefers the PATHEXT launcher over the extensionless shim", t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-which-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\n");      // npm sh shim, not an image
+  writeFileSync(join(dir, "ocx.cmd"), "@echo off\n");  // the real launcher
+  const resolved = resolveWindowsCommand("ocx", { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" });
+  assert.equal(resolved, join(dir, "ocx.cmd"));
+  // Case-insensitive env: a child may arrive with `Path` instead of `PATH`.
+  assert.equal(resolveWindowsCommand("ocx", { Path: dir }), join(dir, "ocx.cmd"));
+});
+
+// Half 2 — ComSpec routing. A .cmd must go through cmd.exe with verbatim args; an
+// .exe must not. Asserted on the invocation shape so it runs on every platform.
+test("win32 .cmd routes through ComSpec with verbatim args; .exe does not", () => {
+  const cmd = commandInvocation("C:\\nvm4w\\nodejs\\ocx.cmd", ["status", "--json"], "win32", { ComSpec: "C:\\Windows\\system32\\cmd.exe" });
+  assert.equal(cmd.file, "C:\\Windows\\system32\\cmd.exe");
+  assert.deepEqual(cmd.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.equal(cmd.options.windowsVerbatimArguments, true);
+  assert.match(cmd.args[3], /status/);
+
+  const exe = commandInvocation("C:\\tools\\ocx.exe", ["status", "--json"], "win32", {});
+  assert.equal(exe.file, "C:\\tools\\ocx.exe");
+  assert.deepEqual(exe.args, ["status", "--json"]);
+  assert.notEqual(exe.options.windowsVerbatimArguments, true);
+
+  // A metacharacter in the launcher path must be escaped, not passed through.
+  const amp = commandInvocation("C:\\a&b\\ocx.cmd", ["status"], "win32", {});
+  assert.match(amp.args[3], /\^&/);
+});
+
+// SHARED-HELPER-01: the copy must not drift from its source.
+test("provider-bridge win-exec.ts is byte-identical to the cxc-ops original", () => {
+  const here = readFileSync(new URL("../src/win-exec.ts", import.meta.url));
+  const origin = readFileSync(new URL("../../cxc-ops/src/win-exec.ts", import.meta.url));
+  assert.deepEqual(here, origin);
+});
+```
+
+Keep the `status: null` → `error` test from `f280394b`: it pins that a failed spawn is
+never silently downgraded to `native`.
+
+## 6. Reproduction (parent fails, L1 head passes)
+
+```powershell
+node plugins/codexclaw/components/provider-bridge/dist/cli.js detect
+```
+
+Parent (`a267b398`): `{"provider":"ocx","mode":"error","ocxPath":"C:\nvm4w\nodejs\ocx","reason":"ocx status exited null"}`.
+L1 head: `{"provider":"ocx","mode":"provider","ocxPath":"C:\nvm4w\nodejs\ocx.cmd","running":true,"defaultProvider":"openai","port":10100}`.
+
+The two spawn failures behind `exited null`, measured on this host:
+
+```text
+C:\nvm4w\nodejs\ocx                  status=null  err=ENOENT
+C:\nvm4w\nodejs\ocx.cmd              status=null  err=EINVAL
+C:\nvm4w\nodejs\ocx.cmd via ComSpec  status=0     stdout=3931 bytes
+```
+
+Then the suite and the build:
+
+```powershell
+node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/components/provider-bridge/test/*.test.ts"
+npm run build
+git add -f plugins/codexclaw/components/provider-bridge/dist/win-exec.js
+npm run gate
+cxc receipt test --session <id> -- node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/components/provider-bridge/test/*.test.ts"
+```
+
+`dist/win-exec.js` is a NEW file and `.gitignore:2` ignores `dist/`, so it needs `-f`.
+`dist/cli.js` is already tracked and restages normally.
+
+## 7. Regression risk
+
+Low, and narrower than `f280394b`. `detect.ts` and the detect-only contract are
+untouched: no `ocx ensure`, no `ocx sync`, no config write.
+
+`whichOcx` now returns `null` when `resolveWindowsCommand` finds nothing, which keeps the
+absent-ocx path on `mode:"native"` rather than `error` — the existing AC2 test pins that.
+The behaviour difference from `where` is that a launcher reachable only through a
+`where`-visible alias but not through PATH+PATHEXT would no longer be found; no such
+case exists for npm global installs, which is the shape #131 reports.
+
+The real hazard is copy drift: `win-exec.ts` now lives in six components. The
+byte-identity test in §5 is the guard, and it fails loudly if the original is edited
+without propagating.
+
+## 8. Criterion
+
+**c-9**, wp2 half: launcher selection and ComSpec spawn each proved by their own test
+(§5 halves 1 and 2), and `mode` is `provider` rather than `error` on this host (§6). The
+"every copy" half of c-9 — the GUI and `cxc serve` duplicates — belongs to wp6 (`050`).

--- a/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
+++ b/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
@@ -8,7 +8,7 @@ Detect-only: never `ocx ensure`, never `ocx sync`, never write Codex config (Q-P
 
 ## 1. Goal
 
-`provider-bridge` on Windows must (1) pick a PATHEXT launcher from `where` stdout instead of the extensionless npm shim, and (2) run `.cmd`/`.bat` through ComSpec. Each half has its own test. GUI/serve copies are wp6 (`050`). This document owns provider-bridge only.
+`provider-bridge` on Windows must (1) resolve `ocx` to a PATHEXT launcher rather than the extensionless npm shim, and (2) run `.cmd`/`.bat` through ComSpec. Half (1) is achieved by resolving PATH+PATHEXT directly and **deleting** the `where`-stdout parsing, not by picking a better line out of it (§4.2). Each half has its own test, plus §5.1 for the wiring. GUI/serve copies are wp6 (`050`). This document owns provider-bridge only.
 
 criterion: **c-9** (wp2 half: launcher selection + ComSpec spawn, separate tests).
 
@@ -340,8 +340,17 @@ cxc receipt test --session <id> -- node plugins/codexclaw/scripts/test.mjs "plug
 Low, and narrower than `f280394b`. `detect.ts` and the detect-only contract are
 untouched: no `ocx ensure`, no `ocx sync`, no config write.
 
+**Known coverage limit.** §5.1's two wiring tests are `win32`-only. The bug is a Windows
+process-spawn bug and the fixture needs a real `.cmd`, so there is no honest
+cross-platform form of that test. Consequence: **Linux and macOS CI do not gate the
+wiring** — only the Windows matrix jobs do. Do not read a green ubuntu run as proof that
+`cli.ts` is wired. The three helper tests in §5 are platform-neutral and still run
+everywhere, but they are exactly the ones that pass when `cli.ts` is untouched.
+
 `whichOcx` now returns `null` when `resolveWindowsCommand` finds nothing, which keeps the
-absent-ocx path on `mode:"native"` rather than `error` — the existing AC2 test pins that.
+absent-ocx path on `mode:"native"` rather than `error`. The **existing** AC2 test does not
+pin this: it injects `which: () => null` and never reaches the resolver. What pins it is
+the empty-PATH case added in §5.1, which drives the real resolver.
 The behaviour difference from `where` is that a launcher reachable only through a
 `where`-visible alias but not through PATH+PATHEXT would no longer be found; no such
 case exists for npm global installs, which is the shape #131 reports.

--- a/devlog/_plan/260911_windows_issue_sweep/020_wp3_session_binding_extended_path.md
+++ b/devlog/_plan/260911_windows_issue_sweep/020_wp3_session_binding_extended_path.md
@@ -1,0 +1,345 @@
+# 020 — wp3 / L2: session-binding extended-length cwd (#134)
+
+Layer: L2. Branch: `codex/fix-session-binding-extended-path`. Base: L1 (`codex/fix-ocx-windows-detect`).
+Issue: #134. Criterion: **c-3** (`cxc session current` succeeds against an extended-length stored cwd).
+This document is the copy-paste PRD for the implementation cycle. Docs-only now; no production patch in wp1.
+
+Source truth (this checkout, HEAD `9cd52769`): `realpathSync` call sites in `session-binding.ts` are **`:31` and `:74`**, not the `:38`/`:78` pair in `000_plan.md` wp3. Dist matches src. Implement against the file.
+
+## 1. Scope
+
+IN
+
+- `plugins/codexclaw/components/pabcd-state/src/session-binding.ts`: private `canonical()` copied from `session-source.ts`, used at both live `realpathSync` call sites.
+- `plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts`: fixture canonicalizes with `.native`; one new win32 test stores an extended-length cwd and drives both call sites plus `cxc session current`.
+- `plugins/codexclaw/components/pabcd-state/dist/session-binding.js`: rebuild in the same commit (already tracked; plain `git add` restages).
+
+OUT
+
+- Exporting or sharing `canonical` with `session-source.ts`. Copy the private helper; do not create a third module.
+- `worktree-guard.ts` `canonicalize()`. It walks missing paths up to an existing ancestor and returns a lexical join, which would convert the missing-cwd throw into a mismatch.
+- 8.3 short-name fixtures (`RUNNER~1`). `session-source.ts` uses `.native` for 8.3; #134's observed form is the extended-length prefix. Native fixes both; the regression test covers the observed form only.
+- `ROOT_SOURCES` at `session-binding.ts:10`. Rejecting subagent bindings stays.
+- Any other file.
+
+## 2. Change map
+
+| file | NEW/MODIFY/DELETE | what | lines (approx) |
+|---|---|---|---|
+| `plugins/codexclaw/components/pabcd-state/src/session-binding.ts` | MODIFY | add private `canonical()`; replace `:31` and `:74` | +18 / -2 |
+| `plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts` | MODIFY | fixture `.native`; import `toNamespacedPath`; new extended-prefix test after the parent/sibling test | +40 / -1 |
+| `plugins/codexclaw/components/pabcd-state/dist/session-binding.js` | MODIFY | `npm run build` output; do not hand-edit | compileSource of src |
+
+No new `.ts` file, so no `git add -f`. Dist is already tracked (`git ls-files plugins/codexclaw/components/pabcd-state/dist/session-binding.js`).
+
+## 3. Why these two sites, and why `.native`
+
+Host fact: every native thread row on this machine stores `cwd` with the extended-length prefix (`\\?\\C:\\...`). JS `realpathSync` on that shape throws `EISDIR: illegal operation on a directory, lstat 'C:'`. `realpathSync.native` returns the ordinary absolute path. Confirmed on this host against `C:\\Users\\super\\Developers\\codexclaw`:
+
+```
+js(prefixed)     ERR EISDIR lstat 'C:'
+native(prefixed) OK  C:\\Users\\super\\Developers\\codexclaw
+```
+
+`resolveNativeSession` canonicalises two strings and compares them. If either call uses JS `realpathSync`, a prefixed stored cwd (the live desktop case) or a prefixed live cwd dies in the `catch` and surfaces `Cannot resolve the native session's working directory.` — the #134 symptom. Both sites move together.
+
+Do not reuse `worktree-guard.ts:54-77` `canonicalize()`. On a missing path it does not throw:
+
+```ts
+/** realpath when possible; otherwise realpath the nearest existing ancestor and
+ *  append the remainder (symlink + macOS case-insensitive safety). */
+export function canonicalize(p: string): string {
+  const abs = resolve(p);
+  try {
+    return realpathSync.native(abs);
+  } catch {
+    // walk up to the nearest existing ancestor
+    let cur = abs;
+    const missing: string[] = [];
+    while (true) {
+      const parent = resolve(cur, "..");
+      if (parent === cur) return abs; // filesystem root: give up, return lexical
+      cur = parent;
+      missing.unshift(abs.slice(cur.length + 1).split(sep)[0] ?? "");
+      try {
+        const real = realpathSync.native(cur);
+        const rest = abs.slice(cur.length + 1);
+        return rest ? join(real, rest) : real;
+      } catch {
+        // keep walking
+      }
+      if (missing.length > 64) return abs; // pathological depth guard
+    }
+  }
+}
+```
+
+Copied from `plugins/codexclaw/components/pabcd-state/src/worktree-guard.ts:52-77`. That success-on-missing path would skip the `catch` at `session-binding.ts:77-78` and turn a missing row cwd into a mismatch string. The helper below throws, matching today's contract.
+
+## 4. MODIFY `session-binding.ts`
+
+### 4.1 Private `canonical()`, copied from `session-source.ts` (do not export)
+
+Pattern to copy, not import. `session-source.ts:17-25`:
+
+```ts
+/**
+ * Canonical absolute path. `realpathSync.native` expands Windows 8.3 short names
+ * (`RUNNER~1`) that the JS implementation leaves intact; Git always reports the long
+ * form, so comparing a short-name cwd against `rev-parse` output would refuse a
+ * valid worktree (observed on windows-latest CI where TEMP is a short path).
+ */
+function canonical(path: string): string {
+  return realpathSync.native(path);
+}
+```
+
+Insert the sibling helper in `session-binding.ts` immediately before `export function resolveNativeSession` (after `NativeSessionResult`, currently line 19). The comment names the #134 prefix, not 8.3. `realpathSync` stays imported from `node:fs` (`:1`); `.native` is a property of that function.
+
+after (insert at `session-binding.ts:19`, before the `resolveNativeSession` JSDoc):
+
+```ts
+/**
+ * Canonical absolute path. JS `realpathSync` throws `EISDIR: illegal operation
+ * on a directory, lstat 'C:'` on Windows extended-length prefixes stored in the
+ * native thread DB. `realpathSync.native` resolves that shape. Native also expands
+ * 8.3 short names the JS implementation leaves intact (same reason `session-source.ts`
+ * has a private copy). Do not export or share this helper. Do not call
+ * `worktree-guard` `canonicalize()`: that walks missing paths up to an ancestor and
+ * would break the missing-cwd throw.
+ */
+function canonical(path: string): string {
+  return realpathSync.native(path);
+}
+```
+
+### 4.2 Call site 1 — live cwd (`:31`)
+
+before (`plugins/codexclaw/components/pabcd-state/src/session-binding.ts:29-35`):
+
+```ts
+  let canonicalCwd: string;
+  try {
+    canonicalCwd = realpathSync(cwd);
+    if (!lstatSync(canonicalCwd).isDirectory()) throw new Error();
+  } catch {
+    return { ok: false, error: "Cannot resolve the working directory. Run from the native session's directory." };
+  }
+```
+
+after:
+
+```ts
+  let canonicalCwd: string;
+  try {
+    canonicalCwd = canonical(cwd);
+    if (!lstatSync(canonicalCwd).isDirectory()) throw new Error();
+  } catch {
+    return { ok: false, error: "Cannot resolve the working directory. Run from the native session's directory." };
+  }
+```
+
+### 4.3 Call site 2 — stored thread cwd (`:74`)
+
+before (`plugins/codexclaw/components/pabcd-state/src/session-binding.ts:70-79`):
+
+```ts
+      if (typeof row.cwd !== "string" || !isAbsolute(row.cwd)) {
+        return { ok: false, error: "Native session has an invalid working directory." };
+      }
+      try {
+        if (realpathSync(row.cwd) !== canonicalCwd) {
+          return { ok: false, error: "Working directory does not match the native session. Run from its exact directory." };
+        }
+      } catch {
+        return { ok: false, error: "Cannot resolve the native session's working directory." };
+      }
+```
+
+after:
+
+```ts
+      if (typeof row.cwd !== "string" || !isAbsolute(row.cwd)) {
+        return { ok: false, error: "Native session has an invalid working directory." };
+      }
+      try {
+        if (canonical(row.cwd) !== canonicalCwd) {
+          return { ok: false, error: "Working directory does not match the native session. Run from its exact directory." };
+        }
+      } catch {
+        return { ok: false, error: "Cannot resolve the native session's working directory." };
+      }
+```
+
+`isAbsolute(row.cwd)` stays in front. `path.win32.isAbsolute` is true for an extended-length prefix, so the prefix is not rejected as a relative cwd. Do not move or weaken that check.
+
+No other `realpathSync(` call exists in this file. Dist currently mirrors src:
+
+- `plugins/codexclaw/components/pabcd-state/dist/session-binding.js:31` — `canonicalCwd = realpathSync(cwd);`
+- `plugins/codexclaw/components/pabcd-state/dist/session-binding.js:74` — `if (realpathSync(row.cwd) !== canonicalCwd)`
+
+After `npm run build`, those two become `canonical(...)` plus the new helper. Restage the tracked dist file in the same commit as src.
+
+## 5. MODIFY `session-binding.test.ts`
+
+### 5.1 Fixture must canonicalise with `.native`
+
+Happy-path tests assert `cwd: f.cwd`. `session-source.ts:18-21` records that windows-latest TEMP is often an 8.3 short path: JS `realpathSync` leaves `RUNNER~1`, native expands it. If the fixture keeps JS `realpathSync` while production switches to native, `assert.deepEqual(..., { cwd: f.cwd })` flakes on that runner. Same helper as production.
+
+before (`plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts:5`):
+
+```ts
+import { join } from "node:path";
+```
+
+after:
+
+```ts
+import { join, toNamespacedPath } from "node:path";
+```
+
+before (`plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts:15-17`):
+
+```ts
+function fixture(t: TestContext) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "cxc-session-binding-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+```
+
+after:
+
+```ts
+function fixture(t: TestContext) {
+  const root = realpathSync.native(mkdtempSync(join(tmpdir(), "cxc-session-binding-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+```
+
+`realpathSync` stays in the `node:fs` import; the new test calls the JS implementation to pin the EISDIR.
+
+### 5.2 New test — observed form, both call sites, `session current`
+
+Insert **after** the parent/sibling test, currently `session-binding.test.ts:163-167`. Do not replace that test.
+
+Existing test that stays (anchor):
+
+```ts
+test("cwd must match exactly after realpath, not a parent or sibling", t => {
+  const f = fixture(t);
+  nativeDb(f.home, f.root);
+  assert.equal(resolveNativeSession(f.cwd, f.env).ok, false);
+});
+```
+
+Insert immediately after it:
+
+```ts
+test("extended-length stored cwd matches the live cwd", { skip: process.platform !== "win32" }, t => {
+  const f = fixture(t);
+  const prefixed = toNamespacedPath(f.cwd);
+  assert.ok(prefixed.startsWith("\\\\?\\"));
+  assert.notEqual(prefixed, f.cwd);
+  // Pin the JS implementation bug this layer fixes. 8.3 short names are a
+  // different alias class; do not substitute them here.
+  assert.throws(
+    () => realpathSync(prefixed),
+    (err: NodeJS.ErrnoException) => err.code === "EISDIR",
+  );
+  assert.equal(realpathSync.native(prefixed), f.cwd);
+
+  nativeDb(f.home, prefixed);
+
+  // Call site 2: stored row.cwd is prefixed, live cwd is not (desktop case).
+  const fromLive = resolveNativeSession(f.cwd, f.env);
+  assert.equal(fromLive.ok, true);
+  if (fromLive.ok) assert.equal(fromLive.cwd, f.cwd);
+
+  // Call site 1: live cwd is also prefixed.
+  const fromPrefixed = resolveNativeSession(prefixed, f.env);
+  assert.equal(fromPrefixed.ok, true);
+  if (fromPrefixed.ok) assert.equal(fromPrefixed.cwd, f.cwd);
+
+  // c-3: the CLI corroboration path, not only the helper.
+  const current = jsonResult(["current"], f);
+  assert.equal(current.code, 0);
+  assert.equal(current.body.sessionId, CHILD);
+  assert.equal(current.body.cwd, f.cwd);
+
+  const prefixedCurrent = runSessionCli(["current", "--json"], prefixed, f.env);
+  assert.equal(prefixedCurrent.code, 0);
+  assert.equal(JSON.parse(prefixedCurrent.output).cwd, f.cwd);
+});
+```
+
+Skip on non-win32: `toNamespacedPath` is a no-op on POSIX and the extended-length prefix is not an EISDIR there. Windows is the reproduction platform (`000_plan.md` Constraints).
+
+### 5.3 Why existing fail-closed tests still pass
+
+- **missing cwd** (`session-binding.test.ts:141`, `{ cwd: "/does-not-exist-cxc" }`): `realpathSync.native` throws `ENOENT` on a missing path, same as JS `realpathSync`. The `catch` at `:77-78` still returns `{ ok: false }`. The test asserts only `.ok === false`, not the error string.
+- **relative cwd** (`:142`, `{ cwd: "." }`): rejected at `:70` by `!isAbsolute(row.cwd)` before either realpath runs. `canonical()` is unreachable.
+- **parent/sibling mismatch** (`:163-167`): stores `f.root`, resolves `f.cwd` (a child directory). Native realpath of two existing distinct directories stays distinct, so `:74` still reports mismatch.
+- **symlink alias** (`:109-117`): `realpathSync.native` resolves the directory symlink to the same target JS `realpathSync` does, so `result.cwd === f.cwd` still holds. The fixture `.native` change keeps that equality on 8.3 TEMP.
+
+## 6. Reproduction (parent fails, L2 head passes)
+
+Parent = L1 head (today: this checkout at `9cd52769` still has JS `realpathSync` at both sites). Layer head = L2 after the patch + rebuild.
+
+PowerShell. Check native status with `$LASTEXITCODE`, never `$?`.
+
+### 6.1 The EISDIR shape (does not need the patch; documents the bug)
+
+```powershell
+node -e "const { realpathSync } = require('node:fs'); const p = require('node:path').toNamespacedPath(process.cwd()); try { realpathSync(p); console.log('js-ok'); } catch (e) { console.log('js', e.code, e.message); } console.log('native', realpathSync.native(p));"
+```
+
+Expected on this host: `js EISDIR EISDIR: illegal operation on a directory, lstat 'C:'` then `native C:\\Users\\super\\Developers\\codexclaw`.
+
+### 6.2 Unit test red/green
+
+On the parent commit, apply **only** the test file changes from §5, then:
+
+```powershell
+node plugins/codexclaw/scripts/test.mjs plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts
+```
+
+Expected: `extended-length stored cwd matches the live cwd` fails (`fromLive.ok` is `false`; error is `Cannot resolve the native session's working directory.`). Other tests in the file stay green.
+
+On the L2 head (src + dist from §4, tests from §5):
+
+```powershell
+npm run build
+git add plugins/codexclaw/components/pabcd-state/src/session-binding.ts plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts plugins/codexclaw/components/pabcd-state/dist/session-binding.js
+node plugins/codexclaw/scripts/test.mjs plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts
+```
+
+Expected: exit 0, including the new test. Then:
+
+```powershell
+npm run gate
+```
+
+Known pre-existing failures on this host, not this layer: `repo-map-packaging.test.mjs`, `gui/test/router.test.ts`, `hook-bench --json` schema. Do not treat them as L2 regressions.
+
+### 6.3 Live desktop corroboration (c-3)
+
+Inside a native Codex session on this host (thread row cwd already prefixed; `CODEX_THREAD_ID` set):
+
+```powershell
+node plugins/codexclaw/bin/cxc.mjs session current --json
+```
+
+Parent: `{"ok":false,"error":"Cannot resolve the native session's working directory.","hooksVerified":false}` and `$LASTEXITCODE` is 1.
+L2: `ok: true`, `sessionId` equals `$env:CODEX_THREAD_ID`, `cwd` is the ordinary absolute path (no extended-length prefix).
+
+C>D receipt for the implementation cycle:
+
+```powershell
+cxc receipt test --session <id> -- node plugins/codexclaw/scripts/test.mjs plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts
+```
+
+## 7. Regression risk
+
+The fail-closed matrix (missing/relative/mismatch/symlink/subagent/archived) is unchanged because native realpath still throws on missing paths, still resolves symlinks, and still distinguishes parent vs child. The real risk is an 8.3 TEMP fixture mismatch, which §5.1 removes, and a later "reuse `canonicalize()`" refactor, which would silently reclassify missing cwd as a mismatch. `ROOT_SOURCES` is untouched. POSIX CI skips the new test; the rest of the file is the cross-platform net.
+
+## 8. Criterion
+
+**c-3**: `cxc session current` succeeds against an extended-length stored cwd. Proved by the new test's `jsonResult(["current"], f)` on a `toNamespacedPath` row plus the live command in §6.3.

--- a/devlog/_plan/260911_windows_issue_sweep/030_wp4_config_guard_help_passthrough.md
+++ b/devlog/_plan/260911_windows_issue_sweep/030_wp4_config_guard_help_passthrough.md
@@ -1,0 +1,444 @@
+# 030 — wp4 / L3: config-guard help passthrough (#132)
+
+Layer: L3. Branch: `codex/fix-config-guard-help`. Base: L2 (`codex/fix-session-binding-extended-path`).
+Issue: #132. Criterion: **c-10** (both entrypoints, all four verbs, both help flags, config byte-identical and no bak; `cxc uninstall` without help still disables).
+This document is the copy-paste PRD for the implementation cycle. Docs-only now; no production patch in wp1.
+
+Source truth (this checkout, HEAD `9cd52769`): help never reaches config-guard because both dispatchers drop argv after the verb. `uninstall` is already rewritten to `disable` at both dispatchers — that rewrite must survive the passthrough. Dist of `config-guard` is already tracked.
+
+## 1. Scope
+
+IN
+
+- `bin/codexclaw.mjs`: `enable` / `disable` / `uninstall` / `status` forward remaining argv after rewriting `uninstall` → `disable`.
+- `plugins/codexclaw/bin/cxc.mjs`: same contract, same rewrite. Update the comment that currently says config-guard gets `[subcommand] only`.
+- `plugins/codexclaw/components/config-guard/src/cli.ts`: `main()` answers help before the action, any argument position, freeze-cli pattern.
+- `plugins/codexclaw/test/cli-usage.test.mjs`: both entrypoints × four verbs × both flags under a temp `CODEX_HOME`; uninstall-without-help still reaches disable.
+- `plugins/codexclaw/components/config-guard/dist/cli.js`: rebuild in the same commit (already tracked; plain `git add` restages).
+
+OUT
+
+- Adding `case "uninstall"` to config-guard `main()`. The dispatcher rewrite is the contract. If a caller forwards the raw token, `switch` default must still fire so the trap stays visible.
+- Changing `cxc config --help` (`runConfig` already owns `CONFIG_USAGE`; existing `cli-usage.test.mjs:44-53` pins it). `main()` must not steal `config` or `hook`.
+- Treating empty config-guard argv as help. freeze-cli does that because a bare `cxc freeze` used to write files. Empty config-guard argv is already a usage error (stderr, exit 2) and is not this bug.
+- Touching `activate.ts` / `deactivate.ts` / managed keys. Help must not call them.
+- Any other file.
+
+## 2. Change map
+
+| file | NEW/MODIFY/DELETE | what | lines (approx) |
+|---|---|---|---|
+| `bin/codexclaw.mjs` | MODIFY | four verbs forward rest argv; `uninstall` rewritten to `disable` | ~8 |
+| `plugins/codexclaw/bin/cxc.mjs` | MODIFY | same forwarding; comment at `:154-158` updated | ~6 |
+| `plugins/codexclaw/components/config-guard/src/cli.ts` | MODIFY | `FEATURE_USAGE`; help-before-action in `main()` | ~25 |
+| `plugins/codexclaw/components/config-guard/dist/cli.js` | MODIFY | `npm run build` output; do not hand-edit | compileSource of src |
+| `plugins/codexclaw/test/cli-usage.test.mjs` | MODIFY | imports + two tests at EOF | ~90 |
+
+No NEW. No DELETE. No new `.ts` file, so no `git add -f`.
+
+## 3. The trap (load-bearing — do not follow issue #132's suggested `slice(2)`)
+
+Issue #132 proposes forwarding `process.argv.slice(2)` for all four verbs. That is correct for `enable` / `disable` / `status` and **wrong for `uninstall`**.
+
+config-guard `main()` has no `uninstall` case. `plugins/codexclaw/components/config-guard/src/cli.ts:236-238`:
+
+```ts
+    default:
+      process.stderr.write("usage: config-guard <enable|disable|status|config>\n");
+      return 2;
+```
+
+Today both dispatchers already rewrite the verb and drop the rest:
+
+- `bin/codexclaw.mjs:465-467` — `runConfigGuard(["disable"])`
+- `plugins/codexclaw/bin/cxc.mjs:165` — `delegate(component, [cmd === "uninstall" ? "disable" : cmd])`
+
+So `cxc uninstall` without help **already disables**. A naive passthrough of `["uninstall", ...rest]` would hit `default`, print usage, exit 2, and leave flags on. That is the gaming hole c-10 exists to close.
+
+Required shape at **both** entrypoints:
+
+```js
+[cmd === "uninstall" ? "disable" : cmd, ...process.argv.slice(3)]
+```
+
+Verb rewritten, remaining argv appended. Never forward the raw `uninstall` token. Do not add `uninstall` as a `switch` alias to hide a missed rewrite.
+
+## 4. Help-before-action (freeze-cli pattern)
+
+Same class of bug, already fixed in freeze. `plugins/codexclaw/components/pabcd-state/src/freeze-cli.ts:61-65`:
+
+```ts
+    // 260825 wp1: `cxc freeze --help` used to fall straight through to runFreeze,
+    // which WROTE .codexclaw/interview/freeze.json and exited 0 — a workspace
+    // mutation behind a read-only-looking flag, with nothing in the output to
+    // signal it. Help is now parsed, and runFreeze returns before any IO.
+    help: argv.length === 0 || argv.some((a) => a === "help" || a === "--help" || a === "-h"),
+```
+
+Copy the `.some(...)` position-independent test. Do **not** copy `argv.length === 0`: freeze's bare invocation was mutating; config-guard's empty argv is already exit 2 on `default` and must stay that.
+
+Help must run **before** the action `switch`. `runConfig` already checks only `argv[0]` (`cli.ts:41`). That is the config subcommand. Feature verbs never enter `runConfig`. If the dispatcher starts forwarding `["enable", "--help"]`, `cmd === "enable"` and enable still runs unless `main()` scans every token first.
+
+Exclude `config` (keeps `CONFIG_USAGE`, existing test) and `hook` (SessionStart must not turn `--help` into a usage print).
+
+## 5. MODIFY `bin/codexclaw.mjs`
+
+### 5.1 Four verbs currently drop argv
+
+before (`bin/codexclaw.mjs:462-471`):
+
+```js
+  case "enable":
+    process.exit(runConfigGuard(["enable"]));
+    break;
+  case "uninstall":
+  case "disable":
+    process.exit(runConfigGuard(["disable"]));
+    break;
+  case "status":
+    process.exit(runConfigGuard(["status"]));
+    break;
+```
+
+after:
+
+```js
+  case "enable":
+  case "uninstall":
+  case "disable":
+  case "status":
+    // Rewrite uninstall → disable, then append remaining argv. Forwarding
+    // process.argv.slice(2) would send the raw "uninstall" token into
+    // config-guard main(), which has no such case and would hit default
+    // (usage, exit 2) instead of disable. Help flags ride in the rest.
+    process.exit(runConfigGuard([
+      cmd === "uninstall" ? "disable" : cmd,
+      ...process.argv.slice(3),
+    ]));
+    break;
+```
+
+`runConfigGuard` already spreads `args` onto the compiled CLI (`:202-204`). No change there. `config` already forwards `process.argv.slice(2)` (`:472-479`); leave it.
+
+## 6. MODIFY `plugins/codexclaw/bin/cxc.mjs`
+
+### 6.1 Comment + single-token delegate
+
+before (`plugins/codexclaw/bin/cxc.mjs:154-165`):
+
+```js
+  // Component CLI argv contracts (mirror root bin):
+  //   config-guard: [subcommand] only, EXCEPT `config`, which forwards its full argv so
+  //     `config set <key> <value>` keeps its arguments; skill-search: [search|show, ...]
+  //     (drop the "skill" verb);
+  //   provider-bridge: ["detect"]; everything else: [cmd, ...rest] verbatim.
+  if (component === "config-guard") {
+    if (cmd === "config") {
+      // `config interview` is owned by pabcd-state; the rest by config-guard.
+      const target = process.argv[3] === "interview" ? "pabcd-state" : "config-guard";
+      process.exit(delegate(target, process.argv.slice(2)));
+    }
+    process.exit(delegate(component, [cmd === "uninstall" ? "disable" : cmd]));
+  }
+```
+
+after:
+
+```js
+  // Component CLI argv contracts (mirror root bin):
+  //   config-guard feature verbs: [disable-rewritten-verb, ...rest]. `uninstall`
+  //     is rewritten to `disable` because config-guard main() has no uninstall
+  //     case (raw token hits switch default and does not disable). `config`
+  //     still forwards its full argv so `config set <key> <value>` keeps its
+  //     arguments; skill-search: [search|show, ...] (drop the "skill" verb);
+  //   provider-bridge: ["detect"]; everything else: [cmd, ...rest] verbatim.
+  if (component === "config-guard") {
+    if (cmd === "config") {
+      // `config interview` is owned by pabcd-state; the rest by config-guard.
+      const target = process.argv[3] === "interview" ? "pabcd-state" : "config-guard";
+      process.exit(delegate(target, process.argv.slice(2)));
+    }
+    process.exit(delegate(component, [
+      cmd === "uninstall" ? "disable" : cmd,
+      ...process.argv.slice(3),
+    ]));
+  }
+```
+
+The `config` branch is unchanged. `COMMAND_TABLE` already maps `uninstall` to `"config-guard"` (`:37`); do not remove that row — the rewrite happens at the delegate call, not at the table.
+
+## 7. MODIFY `plugins/codexclaw/components/config-guard/src/cli.ts`
+
+### 7.1 Usage string, next to `CONFIG_USAGE`
+
+Insert immediately after `CONFIG_USAGE` (`cli.ts:35`), before `function runConfig`:
+
+```ts
+const FEATURE_USAGE = [
+  "Usage:",
+  "  cxc enable                         activate declared Codex feature flags",
+  "  cxc disable | uninstall            revert flags codexclaw enabled when safe",
+  "  cxc status                         show declared feature-flag state",
+  "",
+  "  --help / -h / help in any argument position prints this text and writes nothing.",
+  "  enable writes $CODEX_HOME/config.toml and a timestamped .bak; disable/uninstall revert.",
+].join("\n");
+```
+
+`cxc enable`, `cxc disable`, `cxc uninstall` (via `disable | uninstall`), and `cxc status` all appear so a per-verb `/cxc ${verb}/` match works for enable/status and `/uninstall/` works for the alias.
+
+### 7.2 `main()` currently has no help path for feature verbs
+
+before (`plugins/codexclaw/components/config-guard/src/cli.ts:140-145`):
+
+```ts
+function main(argv: readonly string[]): number {
+  const cmd = argv[0];
+  const run = makeRealRunner();
+  const codexHome = resolveCodexHome();
+
+  switch (cmd) {
+```
+
+after:
+
+```ts
+function main(argv: readonly string[]): number {
+  const cmd = argv[0];
+  // Same class of bug as freeze-cli.ts:61-65 (`cxc freeze --help` used to write
+  // freeze.json). Help is position-independent and runs BEFORE the action:
+  // once the dispatcher forwards ["enable", "--help"], argv[0] is "enable" and
+  // runConfig's first-arg help at :41 never sees the flag.
+  // Do not steal `config --help` (CONFIG_USAGE) or the SessionStart `hook` path.
+  // Empty argv stays the default usage/exit 2 — unlike freeze, it is not a
+  // mutating bare invocation.
+  if (
+    cmd !== "config" &&
+    cmd !== "hook" &&
+    argv.some((a) => a === "help" || a === "--help" || a === "-h")
+  ) {
+    process.stdout.write(`${FEATURE_USAGE}\n`);
+    return 0;
+  }
+  const run = makeRealRunner();
+  const codexHome = resolveCodexHome();
+
+  switch (cmd) {
+```
+
+The rest of the `switch` (`hook` / `enable` / `disable` / `status` / `config` / `default`) is unchanged. Do not add `case "uninstall"`.
+
+Help returns before `makeRealRunner()` / `resolveCodexHome()`, so it cannot spawn `codex` or read the real home. `activate` (`:168`) and `deactivate` (`:206`) are unreachable on a help token.
+
+After `npm run build`, restage `plugins/codexclaw/components/config-guard/dist/cli.js`. Both entrypoints spawn that file, not `src/cli.ts`. Tests that drive `bin/codexclaw.mjs` / `plugins/codexclaw/bin/cxc.mjs` will keep failing until dist is rebuilt.
+
+## 8. MODIFY `plugins/codexclaw/test/cli-usage.test.mjs`
+
+### 8.1 Imports
+
+before (`plugins/codexclaw/test/cli-usage.test.mjs:1-9`):
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { dirname, resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..", "..");
+const cli = join(repoRoot, "bin", "codexclaw.mjs");
+```
+
+after:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, resolve, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..", "..");
+const cli = join(repoRoot, "bin", "codexclaw.mjs");
+const payloadCli = join(repoRoot, "plugins", "codexclaw", "bin", "cxc.mjs");
+```
+
+Existing tests are unchanged. They do not set `CODEX_HOME`; they only hit top-level / `config` / `orchestrate` help, which never enter `activate`/`deactivate`.
+
+### 8.2 New tests — insert at EOF (after `cli-usage.test.mjs:73`)
+
+Do not replace the existing `config --help` loop. These tests **must** set a temp `CODEX_HOME`. `resolveCodexHome` (`cli.ts:105-107`) falls through to `~/.codex` when the env is missing; without isolation, a leaked enable would write the operator's real config — the #132 symptom.
+
+```js
+const FEATURE_VERBS = ["enable", "disable", "uninstall", "status"];
+const HELP_FLAGS = ["--help", "-h"];
+const FEATURE_ENTRIES = [cli, payloadCli];
+const SEEDED_CONFIG = "[features]\nhooks = false\n";
+
+function isolatedCodexHome() {
+  const home = mkdtempSync(join(tmpdir(), "cxc-132-home-"));
+  writeFileSync(join(home, "config.toml"), SEEDED_CONFIG);
+  return home;
+}
+
+function spawnFeature(entry, args, home) {
+  return spawnSync("node", [entry, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, CODEX_HOME: home },
+  });
+}
+
+function assertNoMutation(home) {
+  assert.equal(readFileSync(join(home, "config.toml"), "utf8"), SEEDED_CONFIG);
+  assert.equal(readdirSync(home).some((name) => name.includes(".bak")), false);
+  assert.equal(existsSync(join(home, "codexclaw-self-heal.json")), false);
+  assert.deepEqual(readdirSync(home).sort(), ["config.toml"]);
+}
+
+// #132: `cxc enable --help` used to run enable (config.toml rewrite + timestamped
+// .bak). Fixing only the root bin, only --help, or only argv[0] help is the
+// same class of miss as the #47 --version dual-entrypoint test above.
+test("enable/disable/uninstall/status help is side-effect free on both entrypoints", () => {
+  for (const entry of FEATURE_ENTRIES) {
+    for (const verb of FEATURE_VERBS) {
+      for (const flag of HELP_FLAGS) {
+        const home = isolatedCodexHome();
+        try {
+          const res = spawnFeature(entry, [verb, flag], home);
+          const label = `${basename(entry)} ${verb} ${flag}`;
+          assert.equal(res.status, 0, `${label} exited ${res.status}: ${res.stderr}`);
+          assert.match(res.stdout, /Usage:/, `${label} stdout`);
+          assert.match(res.stdout, /enable/);
+          assert.match(res.stdout, /uninstall/);
+          assert.match(res.stdout, /status/);
+          assert.doesNotMatch(res.stdout, /codexclaw: enabled/);
+          assert.doesNotMatch(res.stdout, /codexclaw: disabled/);
+          assert.doesNotMatch(res.stdout, /no install manifest/);
+          assertNoMutation(home);
+        } finally {
+          rmSync(home, { recursive: true, force: true });
+        }
+      }
+    }
+  }
+});
+
+test("feature-verb help is position-independent", () => {
+  const home = isolatedCodexHome();
+  try {
+    const res = spawnFeature(cli, ["enable", "ignored", "--help"], home);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Usage:/);
+    assert.doesNotMatch(res.stdout, /codexclaw: enabled/);
+    assertNoMutation(home);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+// Guard the uninstall rewrite. Parent already maps uninstall → disable with
+// no rest args, so this test is green before the patch. A naive
+// process.argv.slice(2) passthrough (the #132 issue-body suggestion) turns
+// it red: config-guard main() default prints usage and exits 2.
+test("cxc uninstall without help still disables on both entrypoints", () => {
+  for (const entry of FEATURE_ENTRIES) {
+    const home = isolatedCodexHome();
+    try {
+      const res = spawnFeature(entry, ["uninstall"], home);
+      const label = `${basename(entry)} uninstall`;
+      assert.equal(res.status, 0, `${label} exited ${res.status}: ${res.stderr}`);
+      assert.match(res.stdout, /no install manifest|disabled/);
+      assert.doesNotMatch(res.stderr, /usage: config-guard/);
+      assert.equal(readFileSync(join(home, "config.toml"), "utf8"), SEEDED_CONFIG);
+      assert.equal(readdirSync(home).some((name) => name.includes(".bak")), false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+});
+```
+
+Empty isolated home has no install manifest. `deactivate` then prints `codexclaw: no install manifest; nothing to revert` and returns 0 **without spawning `codex`** (`deactivate.ts:114-115`). That string is unique to the disable case. `default` would be stderr `usage: config-guard ...` and exit 2.
+
+Help must not write `codexclaw-self-heal.json`. Disable always calls `markSelfHealOptedOut` even on no-manifest (`deactivate.ts:99-115`), so a leaked `uninstall --help` would create that file and fail `assertNoMutation`.
+
+Do not add an `enable`-without-help case: that path spawns the real `codex` binary via `makeRealRunner()`.
+
+## 9. Reproduction (parent fails, L3 head passes)
+
+Parent = L2 head (today: this checkout at `9cd52769` still drops argv at both dispatchers). Layer head = L3 after the patch + rebuild.
+
+PowerShell. Check native status with `$LASTEXITCODE`, never `$?`.
+
+### 9.1 Unit test red/green
+
+On the parent commit, apply **only** the test file changes from §8, then:
+
+```powershell
+node plugins/codexclaw/scripts/test.mjs plugins/codexclaw/test/cli-usage.test.mjs
+```
+
+Expected:
+
+- existing tests stay green (`config --help`, top-level help, `--version`)
+- `enable/disable/uninstall/status help is side-effect free on both entrypoints` fails: stdout is `codexclaw: enabled [...]` / disable-side-effect / status listing, not `Usage:`; `assertNoMutation` fails on `.bak` or `codexclaw-self-heal.json`
+- `feature-verb help is position-independent` fails the same way
+- `cxc uninstall without help still disables on both entrypoints` **passes on the parent** (rewrite already exists). It exists to fail a naive `slice(2)` implementation.
+
+On the L3 head (bins + src + dist from §5–7, tests from §8):
+
+```powershell
+npm run build
+git add bin/codexclaw.mjs plugins/codexclaw/bin/cxc.mjs plugins/codexclaw/components/config-guard/src/cli.ts plugins/codexclaw/components/config-guard/dist/cli.js plugins/codexclaw/test/cli-usage.test.mjs
+node plugins/codexclaw/scripts/test.mjs plugins/codexclaw/test/cli-usage.test.mjs
+```
+
+Expected: exit 0. Then:
+
+```powershell
+npm run gate
+```
+
+Known pre-existing failures on this host, not this layer: `repo-map-packaging.test.mjs`, `gui/test/router.test.ts`, `hook-bench --json` schema. Do not treat them as L3 regressions.
+
+### 9.2 Live command (c-10)
+
+Temp home. Never point `CODEX_HOME` at the real `~/.codex`.
+
+```powershell
+$home = Join-Path $env:TEMP ("cxc-132-" + [guid]::NewGuid().ToString("n"))
+New-Item -ItemType Directory -Path $home | Out-Null
+Set-Content -LiteralPath (Join-Path $home "config.toml") -Value "[features]`nhooks = false`n" -Encoding utf8
+$env:CODEX_HOME = $home
+node bin/codexclaw.mjs enable --help
+Write-Output "exit=$LASTEXITCODE"
+node plugins/codexclaw/bin/cxc.mjs uninstall --help
+Write-Output "exit=$LASTEXITCODE"
+Get-ChildItem -LiteralPath $home | Select-Object Name
+node bin/codexclaw.mjs uninstall
+Write-Output "exit=$LASTEXITCODE"
+Remove-Item -LiteralPath $home -Recurse -Force
+```
+
+Parent: first two commands print enable/disable output (not Usage), `$LASTEXITCODE` 0, `Get-ChildItem` shows a `.bak` and/or `codexclaw-self-heal.json`.
+L3: first two print `Usage:`, `$LASTEXITCODE` 0, directory still only `config.toml`. Bare `uninstall` prints `no install manifest` / `disabled`, not `usage: config-guard`.
+
+C>D receipt for the implementation cycle:
+
+```powershell
+cxc receipt test --session <id> -- node plugins/codexclaw/scripts/test.mjs plugins/codexclaw/test/cli-usage.test.mjs
+```
+
+## 10. Regression risk
+
+`cxc config --help` stays on `runConfig` because `main()` skips the new help path when `cmd === "config"`. Existing `cli-usage.test.mjs` coverage for `loop`/`scan`/`receipt`/`config` is untouched. `cxc uninstall` without help already disabled; the rewrite-then-append shape preserves that and is pinned by the new guard test. The real risk is a later "just forward `slice(2)`" cleanup that reintroduces the trap, or help that runs after `activate`/`deactivate`. Help returns before `makeRealRunner`, so it cannot spawn `codex` or write a bak. POSIX and Windows share this argv bug; the tests are not win32-skipped.
+
+## 11. Criterion
+
+**c-10**: both entrypoints, all four verbs, both help flags, config byte-identical and no bak; `cxc uninstall` without help still disables. Proved by the three tests in §8.2 plus the live commands in §9.2.
+

--- a/devlog/_plan/260911_windows_issue_sweep/040_wp5_nongit_early_refusal.md
+++ b/devlog/_plan/260911_windows_issue_sweep/040_wp5_nongit_early_refusal.md
@@ -1,0 +1,238 @@
+# 040 — wp5 / L4 / #133 non-git early refusal
+
+Branch `codex/fix-nongit-early-refusal`, base L3 (`codex/fix-config-guard-help`).
+Criterion **c-5**. This document closes **#133 only**. #109 is `045`.
+
+## 1. Scope
+
+Two changes, both small, both in `pabcd-state`:
+
+1. Stop leaking git `stderr` into user output.
+2. Refuse a bound cycle **at entry** when the source identity cannot be resolved,
+   instead of letting it reach C and stall there with no exit.
+
+### The refusal predicate is the load-bearing decision
+
+000_plan.md pins it: the predicate is **"the SOURCE identity cannot be resolved"**,
+never **"the FSM cwd has no `.git`"**.
+
+Written the second way this layer would reject #109's split-cwd case at the door, and
+`045` would have to undo `040`. Written the first way they compose: `045`'s entire job
+is to make that source identity resolvable for a split cwd, so once a source is bound
+the predicate stops firing on its own.
+
+Concretely: the gate calls the same `captureSessionSourceIdentity()` the C→D gate
+already uses, and refuses on `kind === "unavailable"`. It never calls `existsSync(join(cwd, ".git"))`.
+
+## 2. Change map
+
+| file | NEW/MODIFY/DELETE | change |
+|---|---|---|
+| `plugins/codexclaw/components/pabcd-state/src/source-identity.ts` | MODIFY | `git()` pipes stderr instead of inheriting it |
+| `plugins/codexclaw/components/pabcd-state/src/source-gate.ts` | NEW | one exported predicate both entry points call |
+| `plugins/codexclaw/components/pabcd-state/src/goalplan-cli.ts` | MODIFY | `loop init --session` refuses an unresolvable source |
+| `plugins/codexclaw/components/pabcd-state/src/orchestrate-cli.ts` | MODIFY | IDLE→P on a bound session refuses the same way |
+| `plugins/codexclaw/components/pabcd-state/dist/*.js` | MODIFY/NEW | `npm run build`. `dist/source-gate.js` is NEW, so `git add -f` it |
+| `plugins/codexclaw/components/pabcd-state/test/source-gate.test.ts` | NEW | predicate unit tests |
+| `plugins/codexclaw/components/pabcd-state/test/nongit-bound-cycle.test.ts` | NEW | integration: non-git bound session refused at entry, unbound still passes |
+
+## 3. MODIFY `source-identity.ts` — swallow git stderr
+
+The leak is one missing option. `session-source.ts:30` already got this right; this
+file is the only one that still inherits.
+
+before (`source-identity.ts:69-71`):
+
+```ts
+function git(cwd: string, args: string[]): Buffer {
+  return execFileSync("git", args, { cwd, env: gitEnv(), maxBuffer: 64 * 1024 * 1024 });
+}
+```
+
+after:
+
+```ts
+function git(cwd: string, args: string[]): Buffer {
+  // stdio: inherit (the default for stderr) is why `fatal: not a git repository`
+  // reaches the user on every transition in a non-git workspace (#133). The
+  // absence of git is a normal, handled outcome here — captureSourceIdentity
+  // turns the throw into kind:"unavailable" — so its diagnostics must not be
+  // narrated as if a command failed. session-source.ts:30 already pipes.
+  return execFileSync("git", args, {
+    cwd,
+    env: gitEnv(),
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+```
+
+`stdio[1]` must stay `pipe`: every caller reads the returned Buffer.
+
+## 4. NEW `source-gate.ts` — the single predicate
+
+One module so the two entry points cannot drift apart, and so the test can exercise
+the predicate without driving the CLI.
+
+```ts
+/**
+ * source-gate.ts — entry refusal for goalplan-bound cycles whose source identity
+ * cannot be resolved (#133).
+ *
+ * WHY AT ENTRY: the C->D gate (check-gate.ts:83) and `receipt test`
+ * (receipt-cli.ts:167) both refuse an `unavailable` identity, and that refusal is
+ * correct - CHECK-BINDING-01 is fail-closed and 075_receipt_binding.md forbids
+ * reading "I do not know" as "unchanged". But B->C is deliberately fail-open ("no
+ * git means no opinion"), so a bound session sails P->A->B->C and only discovers at
+ * C that it can never close. Plan, audit and implementation are already spent. This
+ * gate moves the same verdict to the cheapest possible point.
+ *
+ * WHAT IT DOES NOT DO: it never tests for `.git`. The predicate is "the SOURCE
+ * identity is unavailable", so binding a git source worktree (see 045 / #109)
+ * clears it without this file knowing anything about split cwds.
+ *
+ * Unbound sessions are untouched: they close D on checkOutput + exitCode and never
+ * enter the receipt path.
+ */
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
+
+export interface SourceGateResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export function checkBoundSourceIdentity(cwd: string, sessionId: string): SourceGateResult {
+  let kind: string;
+  try {
+    kind = captureSessionSourceIdentity(cwd, sessionId, { excludeCodexclawArtifacts: true }).kind;
+  } catch (err) {
+    // A thrown SOURCE-ROOT/binding error is also "cannot resolve".
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (kind === "unavailable") {
+    return {
+      ok: false,
+      reason: [
+        "this workspace has no resolvable git source identity, and a goalplan-bound",
+        "cycle cannot be closed without one: C -> D requires a testReceiptPath",
+        "(CHECK-BINDING-01) and `cxc receipt test` refuses to write a receipt it",
+        "cannot bind to a commit.",
+        "",
+        "Pick one:",
+        "  - bind a git source tree:  cxc session source <absolute-path> --json",
+        "  - or run this cycle unbound (no `cxc loop init --session`), which closes",
+        "    D on checkOutput + exitCode alone.",
+      ].join("\n"),
+    };
+  }
+  return { ok: true };
+}
+```
+
+## 5. MODIFY the two entry points
+
+Both refuse before writing anything. Read the current argument-parsing shape in each
+file and insert the guard immediately after the session id is known and the goalplan
+binding is established, before the first mutation.
+
+### 5.1 `goalplan-cli.ts` — `loop init --session <id>`
+
+This is the earliest honest point: `loop init` is what makes the session bound in the
+first place (it binds a slug and does not consult git at all today). Refusing here
+means the trap never gets built.
+
+Insert immediately before the goalplan artifact is written:
+
+```ts
+// #133: a bound plan promises a closable cycle. Do not create the binding when
+// the source identity cannot be resolved - the failure would otherwise surface at
+// C, after plan/audit/build are spent.
+const gate = checkBoundSourceIdentity(cwd, session);
+if (!gate.ok) {
+  return { output: `loop init: ${gate.reason}\nNothing was written.`, code: 1 };
+}
+```
+
+### 5.2 `orchestrate-cli.ts` — IDLE→P on an already-bound session
+
+`loop init` is not the only way to arrive bound: a plan can be bound by an earlier
+session, or created before this layer shipped. Guard P entry too, and **only** when a
+goalplan is bound (`state.slug`) — the same condition `orchestrate-cli.ts:701` already
+uses for the C→D receipt requirement. An unbound P entry must stay unaffected.
+
+```ts
+// #133: same predicate as loop init, for a session that arrived bound.
+// Guarded by state.slug so unbound HITL cycles are untouched.
+if (state.slug) {
+  const gate = checkBoundSourceIdentity(cwd, session);
+  if (!gate.ok) {
+    return { output: `orchestrate P: ${gate.reason}\nNothing was written.`, code: 1 };
+  }
+}
+```
+
+## 6. Tests
+
+### 6.1 NEW `test/source-gate.test.ts`
+
+Three cases, no CLI:
+
+1. A temp directory that is **not** a repository, with a bound session → `ok === false`
+   and the reason names both `cxc session source` and the unbound escape hatch.
+2. A temp `git init` directory with one commit → `ok === true`.
+3. A dirty temp repository → `ok === true`. Dirty is a *resolved* identity; this gate
+   must not confuse "dirty" with "unavailable".
+
+### 6.2 NEW `test/nongit-bound-cycle.test.ts`
+
+The integration test that would have caught #133. In a non-git temp cwd:
+
+1. `loop init --session <id> --objective ...` exits non-zero and writes **no**
+   `.codexclaw/goalplans/` directory.
+2. The **unbound** path still works end to end: `orchestrate P/A/B/C` then D closes
+   to IDLE on `checkOutput` + `exitCode`, exactly as it does today. This is the
+   regression guard that proves the layer did not tighten the unbound contract.
+3. No line matching `/^fatal:/m` appears on stdout or stderr of any transition.
+   This is the §3 assertion; before the fix, B→C and C emit two `fatal:` lines each.
+
+## 7. Reproduction (parent fails, L4 head passes)
+
+```powershell
+$probe = Join-Path $env:TEMP ("cxc-nongit-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $probe | Out-Null
+cd $probe
+cxc loop init --objective "bound probe" --session cli --criterion "probe closes a cycle"
+cxc orchestrate P --session cli
+```
+
+On the parent commit: `loop init` succeeds, P succeeds, and the cycle later dies at C
+with `no receipt written` — plus `fatal: not a git repository` on the B and C
+transitions. On the L4 head: `loop init` refuses immediately with the two-option
+message and writes nothing, and no `fatal:` line appears anywhere.
+
+## 8. Regression risk
+
+The behaviour change is intentional and is the point: a bound non-git session that
+used to reach C now stops at entry. Three things must NOT change, and each has a test:
+
+- **Unbound cycles.** Guarded by `state.slug`. §6.2 case 2 pins it.
+- **Dirty repositories.** `dirty` is resolved, not unavailable. §6.1 case 3 pins it.
+- **The C→D contract.** Nothing in `check-gate.ts` or `receipt-cli.ts` is touched. This
+  layer adds an earlier refusal; it never adds a way through.
+
+The real hazard is a later refactor rewriting the predicate as a `.git` existence
+check because it is cheaper. That would silently re-break #109. §4's doc comment and
+§6.1 case 2/3 are the defence.
+
+Piping git stderr loses diagnostics for genuinely broken repositories (corrupt index,
+permission failure). Accepted: those already surface as a thrown `execFileSync` error
+whose message the callers report, and the alternative is the #133 leak on every
+ordinary non-git transition.
+
+## 9. Criterion
+
+**c-5**: a goalplan-bound cycle in a non-git workspace is refused at entry with an
+actionable message instead of stalling at C, and no git `fatal` line reaches user
+output on any transition. Proved by §6.2 cases 1 and 3 plus the live §7 reproduction.
+
+Explicitly **not** claimed here: #109. See `045` and criterion **c-8**.

--- a/devlog/_plan/260911_windows_issue_sweep/045_wp8_split_cwd_source.md
+++ b/devlog/_plan/260911_windows_issue_sweep/045_wp8_split_cwd_source.md
@@ -1,0 +1,268 @@
+# 045 — wp8 / L5 / #109 split-cwd source separation
+
+Branch `codex/fix-split-cwd-source`, base L4 (`codex/fix-nongit-early-refusal`).
+Criterion **c-8**. Work class **C4**: this layer touches the evidence chain.
+
+## 1. The problem, stated correctly
+
+#109's own diagnosis is inverted, and building to it would produce the wrong fix.
+
+The issue says `--cwd` applies to the FSM but git reads the process cwd. The code is the
+opposite. `--cwd` reaches git through `captureSessionSourceIdentity(args.cwd)`, which
+calls `resolveSessionSource` and then `captureSourceIdentity(sourceCwd)`:
+
+```ts
+// session-source-identity.ts
+export function captureSessionSourceIdentity(cwd: string, sessionId: string, options: CaptureOptions = {}): SourceIdentity {
+  const sourceCwd = resolveSessionSource(cwd, sessionId);
+  const identity = captureSourceIdentity(sourceCwd, sourceCwd === cwd ? options : { excludeCodexclawArtifacts: true, ...options });
+  return sourceCwd === cwd ? identity : { ...identity, sourceRoot: sourceCwd };
+}
+```
+
+With no source binding `resolveSessionSource` returns `cwd` unchanged, so `sourceCwd === cwd`
+and `--cwd` **is** the git cwd. That is precisely why git fails: the FSM directory is
+not a repository. Propagating `--cwd` harder changes nothing.
+
+The real gap is that the one mechanism designed to separate them refuses this shape.
+
+## 2. Why `cxc session source` cannot express it today
+
+```ts
+// session-source.ts, bindSessionSource
+const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
+if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
+  throw new Error("Source must be a linked worktree root in the native session's repository.");
+}
+```
+
+Two independent blocks:
+
+1. `gitIdentity(cwd)` **throws** when the native cwd is not a repository. #109's FSM
+   directory is not one, so the call dies before any comparison runs.
+2. Even surviving that, `source.commonDir !== native.commonDir` demands the target be a
+   linked worktree of the **same** repository. A non-git parent holding an unrelated
+   git child has no shared `commonDir` and can never satisfy it.
+
+The same asymmetry exists in `verifyBinding` (`session-source.ts:91`), which re-derives
+`native.commonDir` on every resolve.
+
+## 3. Options considered
+
+### Option A — a per-command `--source-cwd` flag
+
+Add `--source-cwd <path>` to `receipt test` and `orchestrate`, used for git while
+`--cwd` stays the FSM.
+
+**Rejected.** It makes source identity a per-invocation argument. The B→C baseline and
+the C→D check would be free to pass different values, and `compareSource` would then
+be comparing two different trees while reporting `same`. That is a forgery surface
+aimed straight at CHECK-BINDING-01, and it is worse than the bug: today the cycle
+cannot close, which is safe; with Option A it can close on the wrong tree. It also
+duplicates a binding that is already supposed to be immutable and session-owned.
+
+### Option B — widen `bindSessionSource` to accept a non-git native cwd (**recommended**)
+
+Keep exactly one immutable, session-owned, on-disk binding. Relax only the premise
+that the native cwd must itself be a repository. When it is not, accept a target that
+is a git **root** in its own right.
+
+Everything downstream is already written for this: `resolveSessionSource` returns the
+bound root, `captureSessionSourceIdentity` captures against it with
+`excludeCodexclawArtifacts: true` and stamps `sourceRoot`, and the receipt then carries
+a real commit sha. No gate is loosened; a previously unreachable input becomes
+reachable.
+
+It also composes with L4 by construction: L4 refuses on an **unavailable source
+identity**, and after this binding the identity resolves, so L4 stops firing without
+knowing anything about split cwds.
+
+## 4. Change map
+
+| file | NEW/MODIFY/DELETE | change |
+|---|---|---|
+| `plugins/codexclaw/components/pabcd-state/src/session-source.ts` | MODIFY | `gitIdentity` gains a non-throwing probe; `bindSessionSource` and `verifyBinding` accept a non-git native cwd |
+| `plugins/codexclaw/components/pabcd-state/src/session-cli.ts` | MODIFY | `session source` error text names the new accepted shape |
+| `plugins/codexclaw/components/pabcd-state/dist/*.js` | MODIFY | `npm run build` |
+| `plugins/codexclaw/components/pabcd-state/test/session-source.test.ts` | MODIFY | binding acceptance/rejection matrix for a non-git native |
+| `plugins/codexclaw/components/pabcd-state/test/split-cwd-cycle.test.ts` | NEW | the c-8 positive path, end to end |
+
+## 5. Design detail
+
+### 5.1 A non-throwing native probe
+
+`gitIdentity` stays as-is for the source side, where a repository is mandatory. Add a
+probe for the native side:
+
+```ts
+/**
+ * Native-side git identity, or null when the native cwd is not a repository.
+ *
+ * #109: an FSM directory need not be a repository. When it is one, the existing
+ * linked-worktree rule applies unchanged. When it is not, there is no `commonDir`
+ * to compare against and the only meaningful requirement is that the target is a
+ * repository root. `gitIdentity` keeps throwing for the SOURCE, where a repository
+ * is mandatory.
+ */
+function nativeGitIdentity(cwd: string): { root: string; commonDir: string; gitDir: string } | null {
+  try { return gitIdentity(cwd); } catch { return null; }
+}
+```
+
+The `catch` is safe because `gitIdentity` already pipes stderr (`session-source.ts:30`),
+so a non-repository probe is silent.
+
+### 5.2 The widened guard
+
+before (`session-source.ts:100-104`):
+
+```ts
+  const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
+  if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
+    throw new Error("Source must be a linked worktree root in the native session's repository.");
+  }
+```
+
+after:
+
+```ts
+  const native = nativeGitIdentity(cwd), source = gitIdentity(sourceRoot);
+  if (source.root !== sourceRoot) {
+    throw new Error("Source must be the root of a Git repository or worktree.");
+  }
+  if (native) {
+    // Unchanged contract for a git native cwd: same repository, different worktree.
+    if (source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
+      throw new Error("Source must be a linked worktree root in the native session's repository.");
+    }
+  } else {
+    // #109: non-git native cwd. There is no repository to be a worktree OF, so the
+    // root check above is the whole requirement. Reject a source that would contain
+    // the FSM's own .codexclaw tree: the identity capture excludes those artifacts,
+    // but a source root ABOVE the FSM directory would also sweep in unrelated
+    // siblings and silently widen what the receipt certifies.
+    const fsmArtifacts = canonical(cwd);
+    if (fsmArtifacts === sourceRoot || fsmArtifacts.startsWith(sourceRoot + sep)) {
+      throw new Error("Source root must not contain the session's own working directory; bind the repository itself, not an ancestor of it.");
+    }
+  }
+```
+
+Import `sep` from `node:path`.
+
+`commonDir` and `gitDir` are still recorded in the binding from the **source** side, so
+`verifyBinding` keeps detecting a moved or re-pointed source worktree.
+
+### 5.3 `verifyBinding` symmetry
+
+`session-source.ts:91` compares `native.commonDir !== binding.commonDir`. With a non-git
+native that comparison is meaningless and must be skipped, using the same probe:
+
+```ts
+  const native = nativeGitIdentity(cwd);
+  if (source.root !== binding.sourceRoot
+      || source.gitDir !== binding.gitDir
+      || (native !== null && native.commonDir !== binding.commonDir)) {
+    throw new Error("Bound source worktree moved or its repository identity changed.");
+  }
+```
+
+Read the exact surrounding lines before patching; `:91` is the tail of a multi-line
+condition.
+
+## 6. What is deliberately NOT changed
+
+- `check-gate.ts` and `receipt-cli.ts`: untouched. `unavailable` still refuses.
+- `compareSource`: untouched. `unavailable` vs `unavailable` is still never `same`.
+- The binding remains **immutable** and session-owned, and still cannot be created
+  after B (`["IDLE","I","P","A"]` phase guard).
+- `GIT_ROUTING_VARS` sanitisation in `gitEnv()`: untouched, so a stray `GIT_DIR` cannot
+  redirect the capture.
+- `excludeCodexclawArtifacts: true` on the bound path: untouched, so FSM bookkeeping
+  never registers as a source change.
+
+This layer makes a real git identity **reachable**. It does not make an absent one
+acceptable.
+
+## 7. Tests
+
+### 7.1 MODIFY `test/session-source.test.ts` — acceptance matrix
+
+| native cwd | target | expected |
+|---|---|---|
+| not a repo | git root, sibling of the FSM dir | accepted |
+| not a repo | git root nested **under** the FSM dir | accepted |
+| not a repo | a **subdirectory** of a repo, not its root | rejected, "root of a Git repository" |
+| not a repo | an **ancestor** directory containing the FSM dir | rejected, "must not contain" |
+| repo | linked worktree, same repo | accepted (unchanged) |
+| repo | unrelated repo root | rejected (unchanged) |
+| any | relative path | rejected (unchanged) |
+| any | second, different target after binding | rejected, immutable (unchanged) |
+
+### 7.2 NEW `test/split-cwd-cycle.test.ts` — the c-8 positive path
+
+This is the test whose absence let #109 sit open. Fixture: a temp directory that is
+**not** a repository, containing a `src/` child that is `git init` with one commit.
+
+1. `loop init --session <id>` in the FSM dir. Under L4 this refuses, so the test binds
+   first: `cxc session source <fsm>/src --json`, then `loop init` succeeds. **This
+   ordering is the L4/L5 composition assertion** — it proves the two layers compose
+   rather than contradict.
+2. `orchestrate P → A → B → C` with real attests.
+3. `cxc receipt test --session <id> -- <trivially passing command>` writes a receipt,
+   exit 0.
+4. **Assert the receipt's `sourceIdentity.kind` is not `unavailable` and its
+   `commitSha` equals `git -C <fsm>/src rev-parse HEAD`.** This is the criterion. A
+   receipt that merely exists does not satisfy c-8.
+5. `orchestrate D` with `testReceiptPath` closes to IDLE.
+6. Negative control: mutate a tracked file in `src/` between the B baseline and the
+   check, and confirm `receipt test` still refuses with `changed the source while running`.
+   Separation must not cost staleness detection.
+
+## 8. Reproduction (parent fails, L5 head passes)
+
+```powershell
+$fsm = Join-Path $env:TEMP ("cxc-split-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $fsm | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $fsm "src") | Out-Null
+cd (Join-Path $fsm "src")
+git init -q; "x" | Set-Content -Encoding utf8 a.txt; git add a.txt
+git -c user.name=t -c user.email=t@t commit -q -m init
+cd $fsm
+cxc session source (Join-Path $fsm "src") --json
+```
+
+On the L4 head that last command fails with `Source must be a linked worktree root in`
+`the native session's repository.` (and on the pre-L4 parent, `gitIdentity(cwd)` throws
+first). On the L5 head it succeeds, `cxc session current --json` reports `sourceCwd`
+and `sourceIdentity`, and the full bound cycle closes with a receipt carrying the
+`src` HEAD sha.
+
+## 9. Regression risk
+
+Highest in this stack. The guard being widened is the one that decides which tree a
+receipt certifies.
+
+- **Widening too far.** The `source.root !== sourceRoot` check is retained and now runs
+  unconditionally, so a subdirectory can never be bound. §7.1 row 3 pins it.
+- **Binding an ancestor.** The FSM directory would then be inside the certified tree,
+  and its `.codexclaw` churn plus unrelated siblings would enter the identity. The
+  explicit ancestor rejection plus §7.1 row 4 pin it.
+- **Losing staleness detection.** §7.2 case 6 is the negative control.
+- **Weakening the `unavailable` refusal.** Nothing in the gate files is touched; §6
+  enumerates what stays.
+- **`verifyBinding` drift.** Skipping the `commonDir` comparison for a non-git native
+  must not skip the `gitDir`/`root` comparisons, which are what detect a re-pointed
+  source. §5.3 keeps both.
+
+A POSIX-only reviewer should note the ancestor test uses `canonical()` on both sides,
+so `realpathSync.native` handles the Windows extended-length and 8.3 aliases that L2
+addressed; a prefix comparison on raw strings would be unsound on this platform.
+
+## 10. Criterion
+
+**c-8**: a goalplan-bound session whose FSM directory is not a git repository but
+whose source tree is, completes P through D and the written receipt carries a real
+commit sha rather than an unavailable identity. Proved by §7.2 cases 4 and 5, with §7.2
+case 1 additionally proving L4/L5 composition and case 6 proving staleness detection
+survived.

--- a/devlog/_plan/260911_windows_issue_sweep/050_wp6_windows_landmine_sweep.md
+++ b/devlog/_plan/260911_windows_issue_sweep/050_wp6_windows_landmine_sweep.md
@@ -1,0 +1,469 @@
+# 050 — WP6 / L6: Windows landmine corpus sweep
+
+Layer: L6. Branch: `codex/windows-landmine-sweep`. Base: L5 `codex/fix-split-cwd-source` (after L1–L5). Work-phase: wp6. Criteria: **c-11** (every risk=high corpus finding in this stack) and the "every copy" clause of **c-9** (GUI + serve provider endpoints report provider, never error from the #131 spawn bugs).
+
+Scope is the six-row table in `000_plan.md` "Corpus sweep scope". Do not expand it. Deferred (risk=medium, out of this issue set — do not touch): `messenger-bridge/src/service.ts:245` BOM-less `.cmd`; `payload-bin.test.mjs:72` and `live-catalog.test.ts:79` colon-PATH fixtures.
+
+`build.mjs` allows only `node:*` and relative imports inside a component. Copy helpers; do not import `cxc-ops`. GUI is not a `build.mjs` component and already relative-imports other packages, but this layer still copies. messenger-bridge already has `src/win-exec.ts` (re-export of `subagent-config/dist/win-exec.js`); reuse that `commandInvocation`, do not add a second copy.
+
+L3 (`030`) also edits `config-guard/src/cli.ts`. If `makeRealRunner` has moved by L5, apply the same substitution in place. Do not create a second runner.
+
+The `where` selector is the L1 helper from `010` (`selectExecutableFromWhereOutput`). Copy the function into each spawn site; do not add it to `win-exec.ts` (that would fail SHARED-HELPER-01 byte identity).
+
+## Change list
+
+- NEW `plugins/codexclaw/gui/src/server/win-exec.ts`
+- NEW `plugins/codexclaw/gui/src/server/codex-bin.ts`
+- NEW `plugins/codexclaw/gui/test/codex-bin.test.ts`
+- NEW `plugins/codexclaw/components/config-guard/src/win-exec.ts`
+- NEW `plugins/codexclaw/components/config-guard/src/codex-bin.ts`
+- NEW `plugins/codexclaw/components/config-guard/test/codex-bin.test.ts`
+- NEW `plugins/codexclaw/components/config-guard/dist/win-exec.js` (build output; `git add -f`)
+- NEW `plugins/codexclaw/components/config-guard/dist/codex-bin.js` (build output; `git add -f`)
+- MODIFY `plugins/codexclaw/gui/src/server/middleware.ts`
+- MODIFY `plugins/codexclaw/gui/test/crlf-where.test.ts`
+- MODIFY `plugins/codexclaw/components/messenger-bridge/src/api-compat.ts`
+- MODIFY `plugins/codexclaw/components/messenger-bridge/test/crlf-where.test.ts`
+- MODIFY `plugins/codexclaw/components/messenger-bridge/dist/api-compat.js` (restage after build; already tracked)
+- MODIFY `plugins/codexclaw/components/config-guard/src/cli.ts`
+- MODIFY `plugins/codexclaw/components/config-guard/dist/cli.js` (restage after build; already tracked)
+- DELETE none (the `splitLines` import in the two detectDeps sites becomes unused and is removed as part of those MODIFY after-blocks)
+
+## NEW copies of win-exec.ts and codex-bin.ts
+
+Byte-identical copies. Do not retype.
+
+```
+
+## L1 helper (paste into both detectDeps files)
+
+Copy from 010's `cli.ts` after-block. Export it. Do not put it in `win-exec.ts`.
+
+```ts
+const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+function whereLines(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function pathExt(filePath: string): string {
+  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
+}
+
+function pathextList(pathext: string | undefined): string[] {
+  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
+  return raw
+    .split(";")
+    .map((ext) => ext.trim().toLowerCase())
+    .filter((ext) => ext.length > 0);
+}
+
+export function selectExecutableFromWhereOutput(
+  stdout: string,
+  options: { platform: NodeJS.Platform; pathext?: string },
+): string | null {
+  const lines = whereLines(stdout);
+  if (lines.length === 0) return null;
+  if (options.platform !== "win32") return lines[0] ?? null;
+  const allowed = pathextList(options.pathext);
+  const match = lines.find((line) => {
+    const ext = pathExt(line);
+    return ext.length > 0 && allowed.includes(ext);
+  });
+  return match ?? lines[0] ?? null;
+}
+```
+
+gui: add `extname` to `middleware.ts:23` (`import { dirname, join } from "node:path"` → `import { dirname, extname, join } from "node:path"`).
+messenger-bridge: add `import { extname } from "node:path";` next to the spawnSync import.
+
+## Row 1 — gui/src/server/middleware.ts:75 (get-command-where-disagree)
+
+Before `middleware.ts:20-21`:
+
+```ts
+import { spawnSync } from "node:child_process";
+import { splitLines } from "./text-lines.ts";
+```
+
+Before `middleware.ts:23`:
+
+```ts
+import { dirname, join } from "node:path";
+```
+
+Before `middleware.ts:66-77`:
+
+```ts
+// Real ocx detection deps for the dev server (detect-only).
+function detectDeps() {
+  return {
+    which: (cmd: string) => {
+      const res = spawnSync(process.platform === "win32" ? "where" : "command", process.platform === "win32" ? [cmd] : ["-v", cmd], {
+        encoding: "utf8",
+        shell: process.platform !== "win32",
+      });
+      // where.exe emits CRLF; the trailing .trim() saved this by accident.
+      const out = res.status === 0 && typeof res.stdout === "string" ? splitLines(res.stdout)[0]?.trim() ?? "" : null;
+      return out && out.length > 0 ? out : null;
+    },
+```
+
+After imports (delete splitLines; keep spawnSync; add win-exec + codex-bin + extname):
+
+```ts
+import { spawnSync } from "node:child_process";
+import { dirname, extname, join } from "node:path";
+import { commandInvocation, envValue } from "./win-exec.ts";
+import { resolveCodexInvocation } from "./codex-bin.ts";
+```
+
+After `which` (paste the L1 helper above `detectDeps`):
+
+```ts
+function detectDeps() {
+  return {
+    which: (cmd: string) => {
+      const res = spawnSync(process.platform === "win32" ? "where" : "command", process.platform === "win32" ? [cmd] : ["-v", cmd], {
+        encoding: "utf8",
+        shell: process.platform !== "win32",
+      });
+      if (res.status !== 0 || typeof res.stdout !== "string") return null;
+      return selectExecutableFromWhereOutput(res.stdout, {
+        platform: process.platform,
+        pathext: envValue(process.env, "PATHEXT"),
+      });
+    },
+```
+
+## Row 2 — gui/src/server/middleware.ts:79 (spawn-npm-enoent-einval)
+
+Before `middleware.ts:78-81`:
+
+```ts
+    runStatus: (ocxPath: string) => {
+      const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+      return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
+    },
+```
+
+After:
+
+```ts
+    runStatus: (ocxPath: string) => {
+      const inv = commandInvocation(ocxPath, ["status", "--json"]);
+      const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 8000, ...inv.options });
+      return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
+    },
+```
+
+## Row 3 — messenger-bridge/src/api-compat.ts:40 (get-command-where-disagree)
+
+Before `api-compat.ts:15-21`:
+
+```ts
+import { spawnSync } from "node:child_process";
+// Compiled component dists — runtime-typed, so minimal local shapes below.
+import { getSettings, updateSettings, settingsResponse } from "../../subagent-config/dist/settings-api.js";
+import { readCatalog } from "../../subagent-config/dist/live-catalog.js";
+import { detectOcx } from "../../provider-bridge/dist/detect.js";
+import type { ApiRoute, ApiResponse } from "./server.ts";
+import { splitLines } from "./text-lines.ts";
+```
+
+Before `api-compat.ts:28-43`:
+
+```ts
+/** Real ocx detection deps (detect-only) — mirrored from gui/src/server/middleware.ts. */
+function detectDeps(): Record<string, unknown> {
+  return {
+    which: (cmd: string) => {
+      const res = spawnSync(
+        process.platform === "win32" ? "where" : "command",
+        process.platform === "win32" ? [cmd] : ["-v", cmd],
+        { encoding: "utf8", shell: process.platform !== "win32" },
+      );
+      // where.exe emits CRLF; the trailing .trim() saved this by accident.
+      const out =
+        res.status === 0 && typeof res.stdout === "string"
+          ? splitLines(res.stdout)[0]?.trim() ?? ""
+          : null;
+      return out && out.length > 0 ? out : null;
+    },
+```
+
+After imports (delete splitLines; reuse existing win-exec re-export):
+
+```ts
+import { spawnSync } from "node:child_process";
+import { extname } from "node:path";
+// Compiled component dists — runtime-typed, so minimal local shapes below.
+import { getSettings, updateSettings, settingsResponse } from "../../subagent-config/dist/settings-api.js";
+import { readCatalog } from "../../subagent-config/dist/live-catalog.js";
+import { detectOcx } from "../../provider-bridge/dist/detect.js";
+import type { ApiRoute, ApiResponse } from "./server.ts";
+import { commandInvocation, envValue } from "./win-exec.ts";
+```
+
+After `which` (paste the L1 helper above `detectDeps`):
+
+```ts
+function detectDeps(): Record<string, unknown> {
+  return {
+    which: (cmd: string) => {
+      const res = spawnSync(
+        process.platform === "win32" ? "where" : "command",
+        process.platform === "win32" ? [cmd] : ["-v", cmd],
+        { encoding: "utf8", shell: process.platform !== "win32" },
+      );
+      if (res.status !== 0 || typeof res.stdout !== "string") return null;
+      return selectExecutableFromWhereOutput(res.stdout, {
+        platform: process.platform,
+        pathext: envValue(process.env, "PATHEXT"),
+      });
+    },
+```
+
+## Row 4 — messenger-bridge/src/api-compat.ts:45 (spawn-npm-enoent-einval)
+
+Before `api-compat.ts:44-50`:
+
+```ts
+    runStatus: (ocxPath: string) => {
+      const res = spawnSync(ocxPath, ["status", "--json"], {
+        encoding: "utf8",
+        timeout: 8000,
+      });
+      return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
+    },
+```
+
+After:
+
+```ts
+    runStatus: (ocxPath: string) => {
+      const inv = commandInvocation(ocxPath, ["status", "--json"]);
+      const res = spawnSync(inv.file, inv.args, {
+        encoding: "utf8",
+        timeout: 8000,
+        ...inv.options,
+      });
+      return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
+    },
+```
+
+## Row 5 — config-guard/src/cli.ts:131 (spawn-npm-enoent-einval, bare codex)
+
+Before `cli.ts:5`:
+
+```ts
+import { spawnSync } from "node:child_process";
+```
+
+After — keep that line and insert immediately under it:
+
+```ts
+import { resolveCodexInvocation } from "./codex-bin.ts";
+```
+
+Before `cli.ts:129-138`:
+
+```ts
+export function makeRealRunner(): CodexRunner {
+  return (args) => {
+    const res = spawnSync("codex", [...args], { encoding: "utf8" });
+    return {
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
+      exitCode: typeof res.status === "number" ? res.status : 1,
+    };
+  };
+}
+```
+
+After:
+
+```ts
+export function makeRealRunner(): CodexRunner {
+  return (args) => {
+    const inv = resolveCodexInvocation("codex", [...args]);
+    const res = spawnSync(inv.file, inv.args, { encoding: "utf8", ...inv.options });
+    return {
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
+      exitCode: typeof res.status === "number" ? res.status : 1,
+    };
+  };
+}
+```
+
+## Row 6 — gui/src/server/middleware.ts:88 (windowsapps-alias-eperm, same bare codex spawn)
+
+Before `middleware.ts:85-94`:
+
+```ts
+function codexFeatureDeps() {
+  const run: CodexRunner = (args) => {
+    const command = process.env.CODEX_CLI_PATH?.trim() || "codex";
+    const res = spawnSync(command, [...args], { encoding: "utf8", timeout: 15000 });
+    return {
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
+      exitCode: typeof res.status === "number" ? res.status : 1,
+    };
+  };
+```
+
+After (keep `CODEX_CLI_PATH` as the command argument so the existing GUI override still wins when `CODEX_BIN` is unset; `resolveCodexInvocation` still honors `CODEX_BIN` when set, matching cxc-ops):
+
+```ts
+function codexFeatureDeps() {
+  const run: CodexRunner = (args) => {
+    const command = process.env.CODEX_CLI_PATH?.trim() || "codex";
+    const inv = resolveCodexInvocation(command, [...args]);
+    const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 15000, ...inv.options });
+    return {
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
+      exitCode: typeof res.status === "number" ? res.status : 1,
+    };
+  };
+```
+
+
+## Row 7 — scripts/dev-install.sh reads the manifest with python3 (install)
+
+Not in the original preflight table. Found while writing `060`, and it **blocks c-12**:
+the reinstall this stack has to prove cannot run on this host at all.
+
+`scripts/dev-install.sh:44-50`:
+
+```bash
+installed_version() {
+  python3 - "$PLUGIN_SRC/.codex-plugin/plugin.json" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    print(json.load(fh)["version"])
+PY
+}
+```
+
+`VERSION="$(installed_version)"` runs on every path, not only `--status`. On this host
+`python`, `python3` and `py` all resolve to the Microsoft Store alias or nothing, so
+under `set -euo pipefail` the script aborts before it builds. A Node project whose
+dogfood install depends on Python is the landmine; the corpus case is
+`windowsapps-alias-eperm` (the Store alias that exits without running) compounded by
+`pathext-bare-name-enoent`.
+
+after:
+
+```bash
+installed_version() {
+  # node, not python3: the toolchain this repo already requires. A Windows host with
+  # no Python otherwise kills the whole dev-install under `set -e`, and the Microsoft
+  # Store `python3` alias can exit without running at all.
+  node -e 'process.stdout.write(require(process.argv[1]).version)' "$PLUGIN_SRC/.codex-plugin/plugin.json"
+}
+```
+
+`require()` of an absolute `.json` path is fine here: the script always passes an
+absolute `$PLUGIN_SRC`. `process.stdout.write` rather than `console.log` so no trailing
+newline enters `$VERSION` — a trailing newline would break the
+`[ "$(basename "$dir")" != "$VERSION" ]` prune comparison and delete the freshly
+installed cache root.
+
+That last point is why this is risk=high rather than a convenience fix: the prune loop
+`rm -rf`s every cache directory whose name differs from `$VERSION`.
+
+### Test
+
+Shell scripts have no suite here. Verify by execution, both ways:
+
+```powershell
+& "C:\Program Files\Git\usr\bin\bash.exe" scripts/dev-install.sh --status
+```
+
+Before: exits non-zero with `python3: command not found`. After: prints `source:`,
+`manifest: 0.2.24`, `marketplace:` and the cache roots. Confirm `manifest:` has no
+blank line after the version, which would indicate a trailing newline survived.
+
+## Regression risk (all rows)
+
+Rows 1-4 are the same edit applied to two more copies of the `#131` bug. The risk is
+**copy drift**: `win-exec.ts` now exists in eight places once `gui` and
+`messenger-bridge` get theirs. Each copy needs the byte-identity test from `010` §5,
+otherwise a later edit to the `cxc-ops` original silently diverges. `build.mjs` forbids
+cross-component imports, so deduplication is not available and the test is the only
+defence.
+
+Rows 5-6 replace a bare `codex` spawn with `resolveCodexInvocation`. Both call sites are
+fail-open today — `config-guard`'s SessionStart self-heal swallows the failure — so the
+observable change is that the self-heal starts working on hosts where `codex` is a
+`.cmd`. Nothing that currently succeeds can start failing: the resolver returns the
+input unchanged when nothing matches.
+
+Row 7 is the only row that touches a destructive path. See above.
+
+`gui/test/crlf-where.test.ts` pins the first-line behaviour being replaced; update its
+expectation in the same commit or the layer fails its own suite. Note that
+`gui/test/router.test.ts` is a **pre-existing** failure on this host (recorded in
+`000_plan.md`) and is not this layer's regression.
+
+## Criteria
+
+**c-11**: every risk=high corpus finding is fixed inside this stack; deferral with a
+recorded reason is permitted only for risk=medium. Rows 1-4 are risk=high and fixed
+here. Row 7 is risk=high and fixed here. Rows 5-6 are risk=medium and fixed here
+anyway because `wp4` already opens `config-guard/src/cli.ts`. The deferred set is
+recorded in `000_plan.md`: the BOM-less `.cmd` in `messenger-bridge/src/service.ts:245`
+(risk=medium, needs a non-ASCII home path to bite) and the colon-PATH test fixtures in
+`payload-bin.test.mjs:72` and `live-catalog.test.ts:79` (risk=medium, test-only,
+currently green).
+
+**c-9**, "every copy" half: rows 1-4 bring the GUI `/api/provider` and the `cxc serve`
+provider endpoint to `mode: provider` on this host. Prove by starting each surface and
+reading the endpoint, not by reading the diff.
+Copy-Item -LiteralPath plugins/codexclaw/components/cxc-ops/src/win-exec.ts -Destination plugins/codexclaw/gui/src/server/win-exec.ts
+Copy-Item -LiteralPath plugins/codexclaw/components/cxc-ops/src/win-exec.ts -Destination plugins/codexclaw/components/config-guard/src/win-exec.ts
+Copy-Item -LiteralPath plugins/codexclaw/components/cxc-ops/src/codex-bin.ts -Destination plugins/codexclaw/gui/src/server/codex-bin.ts
+Copy-Item -LiteralPath plugins/codexclaw/components/cxc-ops/src/codex-bin.ts -Destination plugins/codexclaw/components/config-guard/src/codex-bin.ts
+```
+
+`win-exec.ts`: LF, 89 lines, 3657 bytes, hash `B7B07DE668F622EA1AC0CD1A82FE04B61C85A41E9390233D22AEBAA4AF175E3D`. Full text is in `010_wp2_provider_bridge_windows_detect.md` NEW win-exec.ts (same bytes as cxc-ops).
+
+`codex-bin.ts`: LF, 125 lines, 5437 bytes. Full text is `plugins/codexclaw/components/cxc-ops/src/codex-bin.ts` as of L0 `9cd52769`. The load-bearing export is `resolveCodexInvocation` at `codex-bin.ts:106-125`. Quoted here so the copy cannot silently drift; if this block disagrees with the cxc-ops file, the cxc-ops file wins and the identity test will catch a bad retype.
+
+Before (cxc-ops, the function this layer copies), `codex-bin.ts:101-125`:
+
+```ts
+/**
+ * Build the spawn shape for the `codex` CLI.
+ *
+ * POSIX is a passthrough; `CODEX_BIN` wins on every platform when it is set.
+ */
+export function resolveCodexInvocation(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): Invocation {
+  const override = envValue(env, "CODEX_BIN")?.trim();
+  const target = override && override.length > 0 ? override : command;
+  if (platform !== "win32") return { file: target, args: [...args], options: {} };
+
+  // An explicit override is honored as written; only PATH discovery filters.
+  const resolved = override && override.length > 0
+    ? (spawnableWindowsCandidates(override, env)[0] ?? null)
+    : (spawnableWindowsCandidates(command, env)[0] ?? null);
+  if (resolved === null) return cmdShellInvocation(target, args, env);
+  // commandInvocation already routes .cmd/.bat through ComSpec and spawns a
+  // resolved .exe directly; the path it gets here is absolute, so it re-resolves
+  // nothing.
+  return commandInvocation(resolved, args, platform, env);
+}
+```
+
+After: the NEW files are that entire cxc-ops file, unmodified. Do not trim `isWindowsAppsAlias`, `spawnableWindowsCandidates`, or `cmdShellInvocation` — `resolveCodexInvocation` needs all three.

--- a/devlog/_plan/260911_windows_issue_sweep/060_wp7_integration_merge_deploy.md
+++ b/devlog/_plan/260911_windows_issue_sweep/060_wp7_integration_merge_deploy.md
@@ -156,6 +156,50 @@ gh pr merge <n> --repo lidge-jun/codexclaw --merge
 ```
 
 Do **not** pass `--delete-branch` on the promotion. `dev` is the permanent integration
+
+### 5.1 The promotion deletes `dev` anyway — measured, not theoretical
+
+Omitting `--delete-branch` is **not sufficient**. This repository has
+`delete_branch_on_merge: true`:
+
+```powershell
+gh api repos/lidge-jun/codexclaw --jq .delete_branch_on_merge   # -> true
+```
+
+GitHub applies that setting to the merged PR's **head** branch. On a `dev`→`main`
+promotion the head is `dev`, so merging the promotion PR deletes the permanent
+integration branch. Observed on PR #145: immediately after the merge,
+`git ls-remote --heads origin` listed only `main` and the feature branch, and
+`gh api repos/.../branches/dev` returned `404 Branch not found`.
+
+A local `git fetch origin dev` fails with `couldn't find remote ref dev` while a stale
+`origin/dev` ref still resolves, so `git rev-parse origin/dev` keeps answering the old
+sha and hides the deletion. Check `git ls-remote --heads origin`, not the local ref.
+
+Nothing is lost: the old tip survives as the second parent of the promotion merge
+commit on `main`.
+
+**Preventive (preferred).** Disable the setting for the duration of the promotion:
+
+```powershell
+gh api -X PATCH repos/lidge-jun/codexclaw -f delete_branch_on_merge=false
+gh pr merge <n> --repo lidge-jun/codexclaw --merge
+gh api -X PATCH repos/lidge-jun/codexclaw -f delete_branch_on_merge=true
+```
+
+**Remedial.** If the promotion already merged, restore `dev` at the pre-merge tip. Take
+it from the merge commit's second parent rather than trusting a stale local ref:
+
+```powershell
+git fetch origin main
+$tip = git rev-parse "origin/main^2"
+git push origin ($tip + ":refs/heads/dev")
+git ls-remote --heads origin        # confirm refs/heads/dev is back
+```
+
+Restore before opening any further PR: `enforce-pr-target.yml` requires `dev` as the
+target for every non-promotion PR, so while `dev` is missing the whole stack is
+unmergeable.
 branch.
 
 ## 6. Release deploy

--- a/devlog/_plan/260911_windows_issue_sweep/060_wp7_integration_merge_deploy.md
+++ b/devlog/_plan/260911_windows_issue_sweep/060_wp7_integration_merge_deploy.md
@@ -1,0 +1,320 @@
+# 060 — wp7 integration: CI, bottom-up merge, release, reinstall
+
+Not a stack layer. This is the execution procedure that turns the chain green and
+ships it. Criteria **c-7** and **c-12**.
+
+## 0. Entry gate — do not start wp7 early
+
+**c-8 must be `met` before this work-phase begins.** The bound goalplan's `wp7` has no
+`dependsOn` edge to `wp8` because `workPhases[]` is append-only and `wp8` was added
+in roadmap revision 2 (see `000_plan.md` "Goalplan drift notice"). Following the raw
+goalplan edges would reach integration without closing #109.
+
+```powershell
+cxc loop show --session <id> | Select-String -Pattern "c-8"
+```
+
+Proceed only when that line reads `[met]`.
+
+## 1. Stack facts as of this document
+
+| fact | value |
+|---|---|
+| `origin/main` | `6aae1c97` (promotion PR #145, merged 2026-09-11) |
+| `origin/dev` | `a267b398` (includes #130) |
+| L0 base | `a267b398` — already fast-forwarded |
+| open cross-repo PR | #118, CONFLICTING, fork `thisisjun786`, out of scope |
+
+PR #130 is **merged**, so the rebase exposure recorded in `000_plan.md` for that
+specific PR is discharged. The exposure itself is not: any new merge into `dev` while
+this chain is open forces a cascade. §4 keeps the check.
+
+## 2. Per-layer PR creation
+
+Each layer's PR bases on the layer **below**, never on `dev` (except L0).
+`enforce-pr-target.yml` requires `dev` as the target and exempts only `dev`→`main`, so a
+child PR targeting its parent branch will be flagged `[WRONG BRANCH]`. That is expected
+for a manual chain and is not a failure: the workflow prefixes the title and comments,
+it does not block the merge. Do not "fix" it by retargeting a layer at `dev` — that
+would collapse the chain into overlapping diffs.
+
+Write the body to a file. A multi-paragraph `--body` string does not survive PowerShell
+argument parsing (corpus: `oss-native-arg-quoting`, `dq-regex-interpolates`).
+
+```powershell
+# once per layer; $head and $base are branch names
+gh pr create --repo lidge-jun/codexclaw --base $base --head $head `
+  --title "<layer thesis>" --body-file .codexclaw/pr-body-$head.md
+```
+
+Every PR body carries the same stack map so a reviewer can see the position:
+
+```markdown
+Stack (bottom to top), merge bottom-up:
+
+| layer | branch | base | issue |
+|---|---|---|---|
+| L0 | codex/win-sweep-roadmap | dev | roadmap |
+| L1 | codex/fix-ocx-windows-detect | L0 | #131 |
+| L2 | codex/fix-session-binding-extended-path | L1 | #134 |
+| L3 | codex/fix-config-guard-help | L2 | #132 |
+| L4 | codex/fix-nongit-early-refusal | L3 | #133 |
+| L5 | codex/fix-split-cwd-source | L4 | #109 |
+| L6 | codex/windows-landmine-sweep | L5 | sweep |
+
+This is a manual branch chain, not a registered GitHub stack.
+```
+
+## 3. CI, observed asynchronously
+
+Never block a turn on CI. Poll, and do other work between polls.
+
+```powershell
+gh pr view <n> --repo lidge-jun/codexclaw --json mergeStateStatus --jq .mergeStateStatus
+gh pr checks <n> --repo lidge-jun/codexclaw 2>&1 | Select-String -Pattern "pending|fail"
+```
+
+Use `--jq` with a **bare path** (`.mergeStateStatus`). A `--jq` expression containing
+quotes, e.g. `[.a,.b]|join("/")`, is mangled before `gh` sees it and `gh` reports
+`accepts at most 1 arg(s)`. Observed on this host.
+
+`mergeStateStatus` vocabulary that matters here:
+
+| value | meaning | action |
+|---|---|---|
+| `CLEAN` | mergeable, nothing pending or failing | merge |
+| `UNSTABLE` | mergeable, a non-required check pending or failed | inspect the named check; do not merge on "mergeable" alone |
+| `BLOCKED` | required check or review missing | wait |
+| `DIRTY` | conflicts | cascade first |
+
+**`main` and `dev` have no branch protection** (`gh api .../branches/main/protection` →
+`404 Branch not protected`), so there are **no required checks** and `UNSTABLE` will not
+stop a merge. The wait is a deliberate discipline, not an enforced gate. Wait for
+`CLEAN`.
+
+### DEV-STACK-07 record, per layer
+
+Record these four separately; do not collapse them into "CI green":
+
+1. branch topology (head branch, base branch, parent head sha),
+2. native membership (none — manual chain; `gh api repos/.../stacks?pull_request=<n>` for the record),
+3. the layer's current head sha and the sha each check ran against,
+4. workflow event, ref and concurrency group.
+
+CI runs per layer. That is correct for a manual chain, not duplication — there is no
+native stack to deduplicate. The slowest job on this repository is `wsl (drvfs /mnt/c)`
+at roughly 12-15 minutes; it is the usual reason a PR sits at `UNSTABLE`.
+
+## 4. Bottom-up merge and cascade
+
+Invariant: **merge bottom-up, and re-verify every layer above after any merge.**
+
+Before pushing or merging any layer, confirm `dev` has not moved:
+
+```powershell
+git fetch origin dev
+git rev-parse origin/dev
+```
+
+If it differs from the sha L0 was built on, cascade from L0 upward before touching a PR.
+
+For each layer from the bottom:
+
+```powershell
+gh pr merge <n> --repo lidge-jun/codexclaw --squash --delete-branch
+git fetch origin dev
+# retarget and rebase the next layer onto the new dev
+git checkout <next-layer>
+git rebase --onto origin/dev <old-parent-branch>
+npm run build
+git add -A plugins/codexclaw/components
+# a NEW dist file needs -f; .gitignore:2 ignores dist/
+git add -f <new dist paths>
+git commit --amend --no-edit   # or a fresh build commit
+git push --force-with-lease
+gh pr edit <next-n> --repo lidge-jun/codexclaw --base dev
+```
+
+`--force-with-lease`, never `--force`. Use `--squash` for layer merges, matching how #130
+was merged into `dev`; `dev`→`main` promotion uses `--merge` to match the existing
+`Merge pull request #N from lidge-jun/dev` history on `main`.
+
+After each rebase, re-run the layer's own reproduction from `000_plan.md` §Verification.
+A rebase that compiles is not a rebase that still fixes the issue.
+
+## 5. Promote `dev` → `main`
+
+The promotion path is a PR from `dev` to `main`, merged with a merge commit.
+`enforce-pr-target.yml` exempts exactly this combination (`PROMOTION_BASE = "main"`,
+`PROMOTION_HEAD = "dev"`).
+
+```powershell
+gh pr create --repo lidge-jun/codexclaw --base main --head dev `
+  --title "release: <summary>" --body-file .codexclaw/pr-body-promote.md
+# wait for CLEAN, then
+gh pr merge <n> --repo lidge-jun/codexclaw --merge
+```
+
+Do **not** pass `--delete-branch` on the promotion. `dev` is the permanent integration
+branch.
+
+## 6. Release deploy
+
+`.github/workflows/release.yml` has two triggers: a `v*` tag push, and
+`workflow_dispatch` with `version`, `prerelease`, `dry_run` and `expected_sha`.
+
+The dispatch is fail-closed in three independent ways, all of which must be satisfied:
+
+1. it must run from `refs/heads/main`,
+2. `expected_sha` is required and must equal the run's `GITHUB_SHA` — this is the
+   "main moved after the release audit" guard,
+3. the version's tag and any zero-asset GitHub Release must not already exist
+   (a zero-asset release may be resumed).
+
+```powershell
+git fetch origin main
+$sha = git rev-parse origin/main
+gh workflow run release.yml --repo lidge-jun/codexclaw --ref main `
+  -f version=<x.y.z> -f expected_sha=$sha -f prerelease=true -f dry_run=true
+```
+
+Run `dry_run=true` first: it exercises the whole gate without publishing. Then repeat
+with `dry_run=false`.
+
+**The version number is a human decision.** The payload manifest currently declares
+`0.2.24`. This document does not pick the next version; obtain it from the user and
+pin `expected_sha` to the audited `main` commit.
+
+## 7. Reinstall from the local checkout
+
+### 7.1 Blocker found on this host — `dev-install.sh` requires Python
+
+`scripts/dev-install.sh` reads the manifest version with `python3`:
+
+```bash
+installed_version() {
+  python3 - "$PLUGIN_SRC/.codex-plugin/plugin.json" <<'PY'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    print(json.load(fh)["version"])
+PY
+}
+```
+
+`VERSION="$(installed_version)"` runs on **every** path, not only `--status`. This host
+has no Python (`python`, `python3` and `py` all resolve to the Microsoft Store alias or
+nothing), so the script dies under `set -euo pipefail` before it builds anything.
+
+This is a Windows landmine in the project's own dogfood path: a Node project whose dev
+install depends on Python. **Fix it in L6** (`050`) with the one-line Node equivalent:
+
+```bash
+installed_version() {
+  # node, not python3: the toolchain this repo already requires. A Windows host with
+  # no Python otherwise kills the whole dev-install under `set -e`.
+  node -e 'process.stdout.write(require(process.argv[1]).version)' "$PLUGIN_SRC/.codex-plugin/plugin.json"
+}
+```
+
+Until that lands, the reinstall cannot be performed with the shipped script, and c-12
+is unprovable. Treat the Node rewrite as a **prerequisite** of wp7, not an optional
+cleanup.
+
+### 7.2 Running it on Windows
+
+The script is bash. Git Bash is present at `C:\Program Files\Git\usr\bin\bash.exe`.
+
+```powershell
+& "C:\Program Files\Git\usr\bin\bash.exe" scripts/dev-install.sh --status
+& "C:\Program Files\Git\usr\bin\bash.exe" scripts/dev-install.sh
+```
+
+Run `--status` first and read the `marketplace:` line.
+
+### 7.3 The marketplace repoint is expected, and it is destructive
+
+The currently registered install does **not** come from this checkout:
+
+```text
+codexclaw@codexclaw  installed, enabled  0.2.24+codex.20260908031619
+marketplace root: C:\Users\super\.codex\.tmp\marketplaces\codexclaw
+```
+
+Because that root is not `$REPO_ROOT`, `dev-install.sh` will
+`codex plugin remove`, `codex plugin marketplace remove`, then
+`codex plugin marketplace add $REPO_ROOT`. It also `rm -rf`s any cache version
+directory that is not the manifest version.
+
+This is exactly what "reinstall from local dev" means, and it is what the user asked
+for — but it replaces a working installation. Before running it, back up the installed
+payload and note the current role configuration (`cxc subagents --global`), per the
+"Preserve a local integration track" guidance in `docs-site/src/content/docs/development/dogfood-dev-install.md`.
+
+### 7.4 After installing
+
+Hooks and skills are read at session start, so **open a new Codex thread** before
+trusting any live observation. Hook trust covers the hook *declaration*, not the files
+it runs, so rebuilding `dist/` keeps trust while editing a `hooks/*.json` matcher or
+command would require re-approval in Codex. This stack changes no hook declaration.
+
+## 8. c-12 proof — run the INSTALLED binary, not the checkout
+
+c-12 exists because c-7 could be satisfied by a version string. Both probes below must
+target `$CACHE\<version>`, never `plugins/codexclaw` in the repo.
+
+```powershell
+$cache = "C:\Users\super\.codex\plugins\cache\codexclaw\codexclaw"
+$ver = (Get-ChildItem $cache -Directory | Select-Object -First 1).Name
+$root = Join-Path $cache $ver
+```
+
+### 8.1 The installed session-start hook reports provider mode (#131)
+
+```powershell
+node (Join-Path $root "components\provider-bridge\dist\cli.js") hook session-start
+```
+
+Must contain `"mode":"provider"` and an `ocx.cmd` path. Before this stack the same
+command emits `"mode":"error"` with `"reason":"ocx status exited null"`.
+
+### 8.2 The installed `cxc enable --help` is side-effect free (#132)
+
+Compare the config by hash, not by eye, and check for new `.bak` files:
+
+```powershell
+$cfg = "C:\Users\super\.codex\config.toml"
+$before = (Get-FileHash $cfg -Algorithm SHA256).Hash
+$baksBefore = (Get-ChildItem "C:\Users\super\.codex" -Filter "config.toml.codexclaw-*.bak").Count
+node (Join-Path $root "bin\cxc.mjs") enable --help
+$after = (Get-FileHash $cfg -Algorithm SHA256).Hash
+$baksAfter = (Get-ChildItem "C:\Users\super\.codex" -Filter "config.toml.codexclaw-*.bak").Count
+"hash equal: $($before -eq $after); baks added: $($baksAfter - $baksBefore)"
+```
+
+Required: `hash equal: True` and `baks added: 0`, with usage text on stdout.
+
+Repeat for `disable --help`, `uninstall --help` and `status --help`. Run these against
+the installed payload with the **real** `CODEX_HOME` only after the L3 tests have passed
+against a temporary one — before the fix, `enable --help` mutates the real config.
+
+### 8.3 Session identity (#134), opportunistic
+
+```powershell
+node (Join-Path $root "bin\cxc.mjs") session current --json
+```
+
+From the native cwd of a root desktop thread this must stop returning
+`Cannot resolve the native session's working directory.`. It is not part of c-12, but it
+is the cheapest live confirmation of L2 and it unblocks SESSION-IDENTITY-01
+corroboration for later loops. A subagent thread will still be refused by
+`ROOT_SOURCES`, which is correct and unchanged.
+
+## 9. Criteria
+
+**c-7**: every stack layer has green hosted CI, the chain is merged bottom-up into
+`dev`, and the release is deployed. Proved by the per-layer §3 records, the §4 merge
+log, and the §6 release run URL.
+
+**c-12**: after the local reinstall, the installed payload's session-start hook emits
+provider mode and the installed `cxc enable --help` is side-effect free, proven by
+running the installed binary. Proved by §8.1 and §8.2, and blocked until §7.1 lands.

--- a/plugins/codexclaw/components/provider-bridge/dist/cli.js
+++ b/plugins/codexclaw/components/provider-bridge/dist/cli.js
@@ -10,7 +10,59 @@
  * line carries native/provider/error so consumers can react.
  */
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { detectOcx, renderStatusLine,                 } from "./detect.js";
+
+/** PATHEXT default when the env var is missing or empty (win-exec convention). */
+const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+function whereLines(stdout        )           {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function pathExt(filePath        )         {
+  // Normalize slashes so Linux CI can still read a Windows `where` listing.
+  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
+}
+
+function pathextList(pathext                    )           {
+  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
+  return raw
+    .split(";")
+    .map((ext) => ext.trim().toLowerCase())
+    .filter((ext) => ext.length > 0);
+}
+
+/**
+ * Pick a spawnable path from `where` / `command -v` stdout.
+ * On win32, PATHEXT-backed launchers beat the extensionless npm sh shim that
+ * `where` prints first. No executable candidate -> first line, matching the
+ * historical resolver.
+ */
+export function selectExecutableFromWhereOutput(
+  stdout        ,
+  options                                                 ,
+)                {
+  const lines = whereLines(stdout);
+  if (lines.length === 0) return null;
+  if (options.platform !== "win32") return lines[0] ?? null;
+  const allowed = pathextList(options.pathext);
+  const match = lines.find((line) => {
+    const ext = pathExt(line);
+    return ext.length > 0 && allowed.includes(ext);
+  });
+  return match ?? lines[0] ?? null;
+}
+
+function isWindowsBatchLauncher(ocxPath        )          {
+  const ext = pathExt(ocxPath);
+  return ext === ".cmd" || ext === ".bat";
+}
 
 /** Real PATH resolver via the platform `command -v` / `where`. */
 function whichOcx(cmd        )                {
@@ -19,8 +71,10 @@ function whichOcx(cmd        )                {
   try {
     const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
     if (res.status === 0 && typeof res.stdout === "string") {
-      const path = res.stdout.split("\n")[0]?.trim();
-      return path && path.length > 0 ? path : null;
+      return selectExecutableFromWhereOutput(res.stdout, {
+        platform: process.platform,
+        pathext: process.env.PATHEXT,
+      });
     }
     return null;
   } catch {
@@ -31,7 +85,14 @@ function whichOcx(cmd        )                {
 /** Real ocx status reader (detect-only — `status --json` is read-only; never
  *  `ensure`/`sync`, which would mutate codex config). */
 function runOcxStatus(ocxPath        )                                            {
-  const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  const res =
+    process.platform === "win32" && isWindowsBatchLauncher(ocxPath)
+      ? spawnSync(
+          process.env.ComSpec ?? "cmd.exe",
+          ["/d", "/s", "/c", `"${ocxPath}" status --json`],
+          { encoding: "utf8", timeout: 8000, windowsVerbatimArguments: true },
+        )
+      : spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
   return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
 }
 
@@ -54,12 +115,28 @@ export function runSessionStartHook(deps             = { which: whichOcx, runSta
   return 0; // always 0 — detect-only never fails the session.
 }
 
-const [, , kind, event] = process.argv;
-if (kind === "hook" && event === "session-start") {
-  process.exit(runSessionStartHook());
+function realOrSelf(p        )         {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
 }
-// Allow `provider-bridge detect` for cxc doctor / manual probes.
-if (kind === "detect") {
-  process.exit(runBridge());
+
+function main()         {
+  const [, , kind, event] = process.argv;
+  if (kind === "hook" && event === "session-start") {
+    return runSessionStartHook();
+  }
+  // Allow `provider-bridge detect` for cxc doctor / manual probes.
+  if (kind === "detect") {
+    return runBridge();
+  }
+  return 0;
 }
-process.exit(0);
+
+// Direct-exec guard: importing this module from a test must not exit.
+const invokedPath = process.argv[1] ? realOrSelf(resolve(process.argv[1])) : "";
+if (invokedPath === realOrSelf(fileURLToPath(import.meta.url))) {
+  process.exit(main());
+}

--- a/plugins/codexclaw/components/provider-bridge/dist/cli.js
+++ b/plugins/codexclaw/components/provider-bridge/dist/cli.js
@@ -11,70 +11,34 @@
  */
 import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { extname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { detectOcx, renderStatusLine,                 } from "./detect.js";
-
-/** PATHEXT default when the env var is missing or empty (win-exec convention). */
-const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
-
-function whereLines(stdout        )           {
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
-
-function pathExt(filePath        )         {
-  // Normalize slashes so Linux CI can still read a Windows `where` listing.
-  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
-}
-
-function pathextList(pathext                    )           {
-  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
-  return raw
-    .split(";")
-    .map((ext) => ext.trim().toLowerCase())
-    .filter((ext) => ext.length > 0);
-}
+import { commandInvocation, resolveWindowsCommand } from "./win-exec.js";
 
 /**
- * Pick a spawnable path from `where` / `command -v` stdout.
- * On win32, PATHEXT-backed launchers beat the extensionless npm sh shim that
- * `where` prints first. No executable candidate -> first line, matching the
- * historical resolver.
+ * Resolve `ocx` to a spawnable path.
+ *
+ * #131: on win32 an npm global install lays down BOTH an extensionless sh shim and
+ * a `.cmd` launcher, and `where ocx` lists the extensionless one FIRST. That file is
+ * not an executable image, so spawning it fails with ENOENT and detect reports
+ * `ocx status exited null`. Resolve PATH+PATHEXT directly instead of picking a line
+ * out of `where` stdout: resolveWindowsCommand reads PATH/PATHEXT case-insensitively
+ * (a child can arrive with `Path`, `PATH`, or both), splits PATH on a literal `;`
+ * rather than node:path's host-dependent delimiter, and retries the lowercased
+ * extension for case-sensitive filesystems. POSIX keeps `command -v`.
  */
-export function selectExecutableFromWhereOutput(
-  stdout        ,
-  options                                                 ,
-)                {
-  const lines = whereLines(stdout);
-  if (lines.length === 0) return null;
-  if (options.platform !== "win32") return lines[0] ?? null;
-  const allowed = pathextList(options.pathext);
-  const match = lines.find((line) => {
-    const ext = pathExt(line);
-    return ext.length > 0 && allowed.includes(ext);
-  });
-  return match ?? lines[0] ?? null;
-}
-
-function isWindowsBatchLauncher(ocxPath        )          {
-  const ext = pathExt(ocxPath);
-  return ext === ".cmd" || ext === ".bat";
-}
-
-/** Real PATH resolver via the platform `command -v` / `where`. */
 function whichOcx(cmd        )                {
-  const finder = process.platform === "win32" ? "where" : "command";
-  const args = process.platform === "win32" ? [cmd] : ["-v", cmd];
+  if (process.platform === "win32") {
+    const resolved = resolveWindowsCommand(cmd, process.env);
+    // resolveWindowsCommand returns its input unchanged when nothing matched.
+    return resolved === cmd ? null : resolved;
+  }
   try {
-    const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
+    const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
     if (res.status === 0 && typeof res.stdout === "string") {
-      return selectExecutableFromWhereOutput(res.stdout, {
-        platform: process.platform,
-        pathext: process.env.PATHEXT,
-      });
+      const path = res.stdout.split(/\r?\n/)[0]?.trim();
+      return path && path.length > 0 ? path : null;
     }
     return null;
   } catch {
@@ -82,17 +46,18 @@ function whichOcx(cmd        )                {
   }
 }
 
-/** Real ocx status reader (detect-only — `status --json` is read-only; never
- *  `ensure`/`sync`, which would mutate codex config). */
+/**
+ * Real ocx status reader (detect-only — `status --json` is read-only; never
+ * `ensure`/`sync`, which would mutate codex config).
+ *
+ * #131 second half: after the CVE-2024-27980 hardening (Node 18.20.2 / 20.12.2)
+ * a shell-less `.cmd` spawn fails with EINVAL. commandInvocation routes only
+ * `.cmd`/`.bat` through ComSpec and escapes cmd metacharacters; `shell: true` would
+ * not escape them, so a launcher path containing `&` or `^` would be an injection.
+ */
 function runOcxStatus(ocxPath        )                                            {
-  const res =
-    process.platform === "win32" && isWindowsBatchLauncher(ocxPath)
-      ? spawnSync(
-          process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", `"${ocxPath}" status --json`],
-          { encoding: "utf8", timeout: 8000, windowsVerbatimArguments: true },
-        )
-      : spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  const inv = commandInvocation(ocxPath, ["status", "--json"]);
+  const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 8000, ...inv.options });
   return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
 }
 

--- a/plugins/codexclaw/components/provider-bridge/dist/win-exec.js
+++ b/plugins/codexclaw/components/provider-bridge/dist/win-exec.js
@@ -1,0 +1,89 @@
+/**
+ * win-exec.ts - one entry point for spawning external commands.
+ *
+ * Three Windows facts drive this:
+ *  1. npm-installed CLIs are `.cmd` shims, and Node refuses shell-less `.cmd` spawns
+ *     after the CVE-2024-27980 hardening.
+ *  2. A bare command name skips PATHEXT resolution, so `spawn("npm")` ENOENTs even
+ *     with `npm.cmd` on PATH (measured, 002 B4).
+ *  3. `shell: true` is not a fix: Node does not escape cmd metacharacters there, so
+ *     a path containing `&` or `^` becomes a command injection.
+ *
+ * Env vars are read case-insensitively: a spawned child can arrive with `Path`,
+ * `PATH`, or both, and reading one fixed spelling resolves against the wrong list
+ * (001 3.2).
+ */
+import { existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+
+
+
+
+
+
+/** Case-insensitive env lookup with a key-scan fallback. */
+export function envValue(env                   , name        )                     {
+  const direct = env[name];
+  if (direct !== undefined) return direct;
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === lower) return env[key];
+  }
+  return undefined;
+}
+
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/** Resolve `command` against PATH + PATHEXT. Returns the input when nothing matches. */
+export function resolveWindowsCommand(command        , env                   )         {
+  if (command.includes("/") || command.includes("\\") || isAbsolute(command)) return command;
+  const exts = (envValue(env, "PATHEXT") ?? DEFAULT_PATHEXT).split(";").filter((e) => e.length > 0);
+  // A WINDOWS PATH is always ";"-separated. node:path's `delimiter` follows the
+  // HOST, so on a Linux runner exercising this win32-only walk it would be ":"
+  // and the whole PATH would collapse into one bogus directory entry.
+  const dirs = (envValue(env, "PATH") ?? "").split(";").filter((d) => d.length > 0);
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = join(dir, command + ext);
+      if (existsSync(candidate)) return candidate;
+      // Case-sensitive filesystems (WSL, Linux CI): PATHEXT spells ".EXE" but
+      // real shims are "npm.cmd" / "gh.exe". Retry the lowercased extension.
+      const lowered = join(dir, command + ext.toLowerCase());
+      if (existsSync(lowered)) return lowered;
+    }
+  }
+  return command;
+}
+
+/** cross-spawn's escaping: double backslashes before quotes, quote, then caret. */
+function escapeCmdArg(arg        )         {
+  let out = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1");
+  out = `"${out}"`;
+  return out.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+function escapeCmdCommand(command        )         {
+  return command.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+/**
+ * Build the spawn shape for `command`. POSIX is a passthrough; win32 resolves
+ * PATHEXT and routes only `.cmd`/`.bat` through cmd.exe.
+ */
+export function commandInvocation(
+  command        ,
+  args          ,
+  platform                  = process.platform,
+  env                    = process.env,
+)             {
+  if (platform !== "win32") return { file: command, args: [...args], options: {} };
+  const resolved = resolveWindowsCommand(command, env);
+  if (!/\.(cmd|bat)$/i.test(resolved)) return { file: resolved, args: [...args], options: {} };
+  const line = [escapeCmdCommand(resolved), ...args.map(escapeCmdArg)].join(" ");
+  return {
+    file: envValue(env, "ComSpec") ?? "cmd.exe",
+    args: ["/d", "/s", "/c", `"${line}"`],
+    options: { windowsVerbatimArguments: true },
+  };
+}

--- a/plugins/codexclaw/components/provider-bridge/src/cli.ts
+++ b/plugins/codexclaw/components/provider-bridge/src/cli.ts
@@ -11,70 +11,34 @@
  */
 import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { extname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { detectOcx, renderStatusLine, type DetectDeps } from "./detect.ts";
-
-/** PATHEXT default when the env var is missing or empty (win-exec convention). */
-const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
-
-function whereLines(stdout: string): string[] {
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
-
-function pathExt(filePath: string): string {
-  // Normalize slashes so Linux CI can still read a Windows `where` listing.
-  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
-}
-
-function pathextList(pathext: string | undefined): string[] {
-  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
-  return raw
-    .split(";")
-    .map((ext) => ext.trim().toLowerCase())
-    .filter((ext) => ext.length > 0);
-}
+import { commandInvocation, resolveWindowsCommand } from "./win-exec.ts";
 
 /**
- * Pick a spawnable path from `where` / `command -v` stdout.
- * On win32, PATHEXT-backed launchers beat the extensionless npm sh shim that
- * `where` prints first. No executable candidate -> first line, matching the
- * historical resolver.
+ * Resolve `ocx` to a spawnable path.
+ *
+ * #131: on win32 an npm global install lays down BOTH an extensionless sh shim and
+ * a `.cmd` launcher, and `where ocx` lists the extensionless one FIRST. That file is
+ * not an executable image, so spawning it fails with ENOENT and detect reports
+ * `ocx status exited null`. Resolve PATH+PATHEXT directly instead of picking a line
+ * out of `where` stdout: resolveWindowsCommand reads PATH/PATHEXT case-insensitively
+ * (a child can arrive with `Path`, `PATH`, or both), splits PATH on a literal `;`
+ * rather than node:path's host-dependent delimiter, and retries the lowercased
+ * extension for case-sensitive filesystems. POSIX keeps `command -v`.
  */
-export function selectExecutableFromWhereOutput(
-  stdout: string,
-  options: { platform: NodeJS.Platform; pathext?: string },
-): string | null {
-  const lines = whereLines(stdout);
-  if (lines.length === 0) return null;
-  if (options.platform !== "win32") return lines[0] ?? null;
-  const allowed = pathextList(options.pathext);
-  const match = lines.find((line) => {
-    const ext = pathExt(line);
-    return ext.length > 0 && allowed.includes(ext);
-  });
-  return match ?? lines[0] ?? null;
-}
-
-function isWindowsBatchLauncher(ocxPath: string): boolean {
-  const ext = pathExt(ocxPath);
-  return ext === ".cmd" || ext === ".bat";
-}
-
-/** Real PATH resolver via the platform `command -v` / `where`. */
 function whichOcx(cmd: string): string | null {
-  const finder = process.platform === "win32" ? "where" : "command";
-  const args = process.platform === "win32" ? [cmd] : ["-v", cmd];
+  if (process.platform === "win32") {
+    const resolved = resolveWindowsCommand(cmd, process.env);
+    // resolveWindowsCommand returns its input unchanged when nothing matched.
+    return resolved === cmd ? null : resolved;
+  }
   try {
-    const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
+    const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
     if (res.status === 0 && typeof res.stdout === "string") {
-      return selectExecutableFromWhereOutput(res.stdout, {
-        platform: process.platform,
-        pathext: process.env.PATHEXT,
-      });
+      const path = res.stdout.split(/\r?\n/)[0]?.trim();
+      return path && path.length > 0 ? path : null;
     }
     return null;
   } catch {
@@ -82,17 +46,18 @@ function whichOcx(cmd: string): string | null {
   }
 }
 
-/** Real ocx status reader (detect-only — `status --json` is read-only; never
- *  `ensure`/`sync`, which would mutate codex config). */
+/**
+ * Real ocx status reader (detect-only — `status --json` is read-only; never
+ * `ensure`/`sync`, which would mutate codex config).
+ *
+ * #131 second half: after the CVE-2024-27980 hardening (Node 18.20.2 / 20.12.2)
+ * a shell-less `.cmd` spawn fails with EINVAL. commandInvocation routes only
+ * `.cmd`/`.bat` through ComSpec and escapes cmd metacharacters; `shell: true` would
+ * not escape them, so a launcher path containing `&` or `^` would be an injection.
+ */
 function runOcxStatus(ocxPath: string): { status: number | null; stdout: string } {
-  const res =
-    process.platform === "win32" && isWindowsBatchLauncher(ocxPath)
-      ? spawnSync(
-          process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", `"${ocxPath}" status --json`],
-          { encoding: "utf8", timeout: 8000, windowsVerbatimArguments: true },
-        )
-      : spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  const inv = commandInvocation(ocxPath, ["status", "--json"]);
+  const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 8000, ...inv.options });
   return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
 }
 

--- a/plugins/codexclaw/components/provider-bridge/src/cli.ts
+++ b/plugins/codexclaw/components/provider-bridge/src/cli.ts
@@ -10,7 +10,59 @@
  * line carries native/provider/error so consumers can react.
  */
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { detectOcx, renderStatusLine, type DetectDeps } from "./detect.ts";
+
+/** PATHEXT default when the env var is missing or empty (win-exec convention). */
+const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+function whereLines(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function pathExt(filePath: string): string {
+  // Normalize slashes so Linux CI can still read a Windows `where` listing.
+  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
+}
+
+function pathextList(pathext: string | undefined): string[] {
+  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
+  return raw
+    .split(";")
+    .map((ext) => ext.trim().toLowerCase())
+    .filter((ext) => ext.length > 0);
+}
+
+/**
+ * Pick a spawnable path from `where` / `command -v` stdout.
+ * On win32, PATHEXT-backed launchers beat the extensionless npm sh shim that
+ * `where` prints first. No executable candidate -> first line, matching the
+ * historical resolver.
+ */
+export function selectExecutableFromWhereOutput(
+  stdout: string,
+  options: { platform: NodeJS.Platform; pathext?: string },
+): string | null {
+  const lines = whereLines(stdout);
+  if (lines.length === 0) return null;
+  if (options.platform !== "win32") return lines[0] ?? null;
+  const allowed = pathextList(options.pathext);
+  const match = lines.find((line) => {
+    const ext = pathExt(line);
+    return ext.length > 0 && allowed.includes(ext);
+  });
+  return match ?? lines[0] ?? null;
+}
+
+function isWindowsBatchLauncher(ocxPath: string): boolean {
+  const ext = pathExt(ocxPath);
+  return ext === ".cmd" || ext === ".bat";
+}
 
 /** Real PATH resolver via the platform `command -v` / `where`. */
 function whichOcx(cmd: string): string | null {
@@ -19,8 +71,10 @@ function whichOcx(cmd: string): string | null {
   try {
     const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
     if (res.status === 0 && typeof res.stdout === "string") {
-      const path = res.stdout.split("\n")[0]?.trim();
-      return path && path.length > 0 ? path : null;
+      return selectExecutableFromWhereOutput(res.stdout, {
+        platform: process.platform,
+        pathext: process.env.PATHEXT,
+      });
     }
     return null;
   } catch {
@@ -31,7 +85,14 @@ function whichOcx(cmd: string): string | null {
 /** Real ocx status reader (detect-only — `status --json` is read-only; never
  *  `ensure`/`sync`, which would mutate codex config). */
 function runOcxStatus(ocxPath: string): { status: number | null; stdout: string } {
-  const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  const res =
+    process.platform === "win32" && isWindowsBatchLauncher(ocxPath)
+      ? spawnSync(
+          process.env.ComSpec ?? "cmd.exe",
+          ["/d", "/s", "/c", `"${ocxPath}" status --json`],
+          { encoding: "utf8", timeout: 8000, windowsVerbatimArguments: true },
+        )
+      : spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
   return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
 }
 
@@ -54,12 +115,28 @@ export function runSessionStartHook(deps: DetectDeps = { which: whichOcx, runSta
   return 0; // always 0 — detect-only never fails the session.
 }
 
-const [, , kind, event] = process.argv;
-if (kind === "hook" && event === "session-start") {
-  process.exit(runSessionStartHook());
+function realOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
 }
-// Allow `provider-bridge detect` for cxc doctor / manual probes.
-if (kind === "detect") {
-  process.exit(runBridge());
+
+function main(): number {
+  const [, , kind, event] = process.argv;
+  if (kind === "hook" && event === "session-start") {
+    return runSessionStartHook();
+  }
+  // Allow `provider-bridge detect` for cxc doctor / manual probes.
+  if (kind === "detect") {
+    return runBridge();
+  }
+  return 0;
 }
-process.exit(0);
+
+// Direct-exec guard: importing this module from a test must not exit.
+const invokedPath = process.argv[1] ? realOrSelf(resolve(process.argv[1])) : "";
+if (invokedPath === realOrSelf(fileURLToPath(import.meta.url))) {
+  process.exit(main());
+}

--- a/plugins/codexclaw/components/provider-bridge/src/win-exec.ts
+++ b/plugins/codexclaw/components/provider-bridge/src/win-exec.ts
@@ -1,0 +1,89 @@
+/**
+ * win-exec.ts - one entry point for spawning external commands.
+ *
+ * Three Windows facts drive this:
+ *  1. npm-installed CLIs are `.cmd` shims, and Node refuses shell-less `.cmd` spawns
+ *     after the CVE-2024-27980 hardening.
+ *  2. A bare command name skips PATHEXT resolution, so `spawn("npm")` ENOENTs even
+ *     with `npm.cmd` on PATH (measured, 002 B4).
+ *  3. `shell: true` is not a fix: Node does not escape cmd metacharacters there, so
+ *     a path containing `&` or `^` becomes a command injection.
+ *
+ * Env vars are read case-insensitively: a spawned child can arrive with `Path`,
+ * `PATH`, or both, and reading one fixed spelling resolves against the wrong list
+ * (001 3.2).
+ */
+import { existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+export interface Invocation {
+  file: string;
+  args: string[];
+  options: { windowsVerbatimArguments?: boolean };
+}
+
+/** Case-insensitive env lookup with a key-scan fallback. */
+export function envValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const direct = env[name];
+  if (direct !== undefined) return direct;
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === lower) return env[key];
+  }
+  return undefined;
+}
+
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/** Resolve `command` against PATH + PATHEXT. Returns the input when nothing matches. */
+export function resolveWindowsCommand(command: string, env: NodeJS.ProcessEnv): string {
+  if (command.includes("/") || command.includes("\\") || isAbsolute(command)) return command;
+  const exts = (envValue(env, "PATHEXT") ?? DEFAULT_PATHEXT).split(";").filter((e) => e.length > 0);
+  // A WINDOWS PATH is always ";"-separated. node:path's `delimiter` follows the
+  // HOST, so on a Linux runner exercising this win32-only walk it would be ":"
+  // and the whole PATH would collapse into one bogus directory entry.
+  const dirs = (envValue(env, "PATH") ?? "").split(";").filter((d) => d.length > 0);
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = join(dir, command + ext);
+      if (existsSync(candidate)) return candidate;
+      // Case-sensitive filesystems (WSL, Linux CI): PATHEXT spells ".EXE" but
+      // real shims are "npm.cmd" / "gh.exe". Retry the lowercased extension.
+      const lowered = join(dir, command + ext.toLowerCase());
+      if (existsSync(lowered)) return lowered;
+    }
+  }
+  return command;
+}
+
+/** cross-spawn's escaping: double backslashes before quotes, quote, then caret. */
+function escapeCmdArg(arg: string): string {
+  let out = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1");
+  out = `"${out}"`;
+  return out.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+function escapeCmdCommand(command: string): string {
+  return command.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+/**
+ * Build the spawn shape for `command`. POSIX is a passthrough; win32 resolves
+ * PATHEXT and routes only `.cmd`/`.bat` through cmd.exe.
+ */
+export function commandInvocation(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): Invocation {
+  if (platform !== "win32") return { file: command, args: [...args], options: {} };
+  const resolved = resolveWindowsCommand(command, env);
+  if (!/\.(cmd|bat)$/i.test(resolved)) return { file: resolved, args: [...args], options: {} };
+  const line = [escapeCmdCommand(resolved), ...args.map(escapeCmdArg)].join(" ");
+  return {
+    file: envValue(env, "ComSpec") ?? "cmd.exe",
+    args: ["/d", "/s", "/c", `"${line}"`],
+    options: { windowsVerbatimArguments: true },
+  };
+}

--- a/plugins/codexclaw/components/provider-bridge/test/detect.test.ts
+++ b/plugins/codexclaw/components/provider-bridge/test/detect.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { detectOcx, parseOcxStatus, renderStatusLine } from "../src/detect.ts";
+import { selectExecutableFromWhereOutput } from "../src/cli.ts";
 
 const STATUS_JSON = JSON.stringify({
   schemaVersion: 1,
@@ -63,4 +64,37 @@ test("parseOcxStatus: valid payload, missing proxy.running, non-json", () => {
   assert.equal(parseOcxStatus('{"listen":{"port":1}}'), null); // no proxy.running
   assert.equal(parseOcxStatus("not json"), null);
   assert.equal(parseOcxStatus(""), null);
+});
+
+test("win32 where: extensionless shim first still selects .cmd", () => {
+  const stdout = "C:\\nvm4w\\nodejs\\ocx\r\nC:\\nvm4w\\nodejs\\ocx.cmd\r\n";
+  assert.equal(
+    selectExecutableFromWhereOutput(stdout, { platform: "win32", pathext: ".COM;.EXE;.BAT;.CMD" }),
+    "C:\\nvm4w\\nodejs\\ocx.cmd",
+  );
+  // PATHEXT unset uses the same default, so the .cmd still wins.
+  assert.equal(
+    selectExecutableFromWhereOutput(stdout, { platform: "win32" }),
+    "C:\\nvm4w\\nodejs\\ocx.cmd",
+  );
+  // No PATHEXT-backed candidate -> historical first-line fallback.
+  assert.equal(
+    selectExecutableFromWhereOutput("C:\\nvm4w\\nodejs\\ocx\n", { platform: "win32" }),
+    "C:\\nvm4w\\nodejs\\ocx",
+  );
+  // Non-win32 keeps the first line even when a .cmd follows.
+  assert.equal(
+    selectExecutableFromWhereOutput(stdout, { platform: "linux" }),
+    "C:\\nvm4w\\nodejs\\ocx",
+  );
+});
+
+test("AC3: .cmd EINVAL (status=null) -> error mode, not native", () => {
+  const s = detectOcx({
+    which: () => "C:\\nvm4w\\nodejs\\ocx.cmd",
+    runStatus: () => ({ status: null, stdout: "" }),
+  });
+  assert.equal(s.mode, "error");
+  assert.match((s as { reason: string }).reason, /exited null/);
+  assert.match(renderStatusLine(s), /"mode":"error"/);
 });

--- a/plugins/codexclaw/components/provider-bridge/test/detect.test.ts
+++ b/plugins/codexclaw/components/provider-bridge/test/detect.test.ts
@@ -1,7 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { detectOcx, parseOcxStatus, renderStatusLine } from "../src/detect.ts";
-import { selectExecutableFromWhereOutput } from "../src/cli.ts";
+import { commandInvocation, resolveWindowsCommand } from "../src/win-exec.ts";
 
 const STATUS_JSON = JSON.stringify({
   schemaVersion: 1,
@@ -66,29 +71,6 @@ test("parseOcxStatus: valid payload, missing proxy.running, non-json", () => {
   assert.equal(parseOcxStatus(""), null);
 });
 
-test("win32 where: extensionless shim first still selects .cmd", () => {
-  const stdout = "C:\\nvm4w\\nodejs\\ocx\r\nC:\\nvm4w\\nodejs\\ocx.cmd\r\n";
-  assert.equal(
-    selectExecutableFromWhereOutput(stdout, { platform: "win32", pathext: ".COM;.EXE;.BAT;.CMD" }),
-    "C:\\nvm4w\\nodejs\\ocx.cmd",
-  );
-  // PATHEXT unset uses the same default, so the .cmd still wins.
-  assert.equal(
-    selectExecutableFromWhereOutput(stdout, { platform: "win32" }),
-    "C:\\nvm4w\\nodejs\\ocx.cmd",
-  );
-  // No PATHEXT-backed candidate -> historical first-line fallback.
-  assert.equal(
-    selectExecutableFromWhereOutput("C:\\nvm4w\\nodejs\\ocx\n", { platform: "win32" }),
-    "C:\\nvm4w\\nodejs\\ocx",
-  );
-  // Non-win32 keeps the first line even when a .cmd follows.
-  assert.equal(
-    selectExecutableFromWhereOutput(stdout, { platform: "linux" }),
-    "C:\\nvm4w\\nodejs\\ocx",
-  );
-});
-
 test("AC3: .cmd EINVAL (status=null) -> error mode, not native", () => {
   const s = detectOcx({
     which: () => "C:\\nvm4w\\nodejs\\ocx.cmd",
@@ -97,4 +79,122 @@ test("AC3: .cmd EINVAL (status=null) -> error mode, not native", () => {
   assert.equal(s.mode, "error");
   assert.match((s as { reason: string }).reason, /exited null/);
   assert.match(renderStatusLine(s), /"mode":"error"/);
+});
+
+// ---------------------------------------------------------------------------
+// #131 half 1 — launcher selection.
+// An npm global install lays down BOTH an extensionless sh shim and a .cmd
+// launcher, and `where ocx` lists the extensionless one first. That file is not an
+// executable image on Windows, so spawning it ENOENTs.
+// ---------------------------------------------------------------------------
+test("win32 launcher selection prefers the PATHEXT launcher over the extensionless shim", t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-which-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\n");      // npm sh shim, not an image
+  writeFileSync(join(dir, "ocx.cmd"), "@echo off\r\n"); // the real launcher
+
+  // Case-insensitive compare: candidates are built with the PATHEXT spelling
+  // (".CMD") and Windows existsSync ignores case, so the resolved path carries
+  // PATHEXT casing rather than the on-disk casing. What matters is that the
+  // extensionless shim lost.
+  const want = join(dir, "ocx.cmd").toLowerCase();
+  assert.equal(
+    resolveWindowsCommand("ocx", { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" }).toLowerCase(),
+    want,
+  );
+  // A spawned child can arrive with `Path` instead of `PATH`; reading one fixed
+  // spelling resolves against the wrong list.
+  assert.equal(resolveWindowsCommand("ocx", { Path: dir }).toLowerCase(), want);
+  // Nothing on PATH: the input comes back unchanged, which whichOcx maps to null.
+  const empty = mkdtempSync(join(tmpdir(), "cxc-pb-empty-"));
+  t.after(() => rmSync(empty, { recursive: true, force: true }));
+  assert.equal(resolveWindowsCommand("ocx", { PATH: empty }), "ocx");
+});
+
+// ---------------------------------------------------------------------------
+// #131 half 2 — ComSpec routing. After CVE-2024-27980 a shell-less .cmd spawn is
+// EINVAL. Asserted on the invocation shape so it runs on every platform.
+// ---------------------------------------------------------------------------
+test("win32 .cmd routes through ComSpec with verbatim args; .exe does not", () => {
+  const cmd = commandInvocation("C:\\nvm4w\\nodejs\\ocx.cmd", ["status", "--json"], "win32", {
+    ComSpec: "C:\\Windows\\system32\\cmd.exe",
+  });
+  assert.equal(cmd.file, "C:\\Windows\\system32\\cmd.exe");
+  assert.deepEqual(cmd.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.equal(cmd.options.windowsVerbatimArguments, true);
+  assert.match(cmd.args[3], /status/);
+
+  const exe = commandInvocation("C:\\tools\\ocx.exe", ["status", "--json"], "win32", {});
+  assert.equal(exe.file, "C:\\tools\\ocx.exe");
+  assert.deepEqual(exe.args, ["status", "--json"]);
+  assert.notEqual(exe.options.windowsVerbatimArguments, true);
+
+  // A metacharacter in the launcher path must be escaped, not passed through:
+  // plain double quoting lets cmd execute only the prefix before `&`.
+  const amp = commandInvocation("C:\\a&b\\ocx.cmd", ["status"], "win32", {});
+  assert.match(amp.args[3], /\^&/);
+
+  // POSIX is a passthrough.
+  const posix = commandInvocation("/usr/local/bin/ocx", ["status"], "linux", {});
+  assert.equal(posix.file, "/usr/local/bin/ocx");
+  assert.deepEqual(posix.args, ["status"]);
+});
+
+// SHARED-HELPER-01: provider-bridge carries its own copy so a SessionStart hook
+// never depends on another component having been built. The cost is drift, which
+// this test converts into a loud failure.
+test("provider-bridge win-exec.ts is byte-identical to the cxc-ops original", () => {
+  const here = readFileSync(new URL("../src/win-exec.ts", import.meta.url));
+  const origin = readFileSync(new URL("../../cxc-ops/src/win-exec.ts", import.meta.url));
+  assert.deepEqual(here, origin);
+});
+
+// ---------------------------------------------------------------------------
+// The wiring. The tests above exercise win-exec.ts directly and all pass when
+// cli.ts is untouched. These two run the real cli.ts as a subprocess, so they are
+// the only ones that prove whichOcx/runOcxStatus are actually wired.
+// win32-only: the fixture needs a real .cmd, so Linux/macOS CI does not gate this.
+// ---------------------------------------------------------------------------
+const CLI = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+
+function detectWithPath(path: string): { status: number | null; line: Record<string, unknown> } {
+  const res = spawnSync(process.execPath, ["--experimental-strip-types", CLI, "detect"], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: path, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+  });
+  const tail = (res.stdout ?? "").trim().split(/\r?\n/).pop() ?? "";
+  return { status: res.status, line: tail ? JSON.parse(tail) : {} };
+}
+
+test("detect resolves the .cmd launcher and reads status through ComSpec end to end", { skip: process.platform !== "win32" }, t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-e2e-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\nexit 1\n");
+  writeFileSync(
+    join(dir, "ocx.cmd"),
+    // cmd has no here-doc; one echo line. No cmd metacharacters in this payload.
+    "@echo off\r\n" +
+      'echo {"proxy":{"running":true},"defaultProvider":"openai","listen":{"port":10100}}\r\n',
+  );
+
+  // dir FIRST so the crafted launcher wins over any real ocx on this machine.
+  const { status, line } = detectWithPath(`${dir};${process.env.PATH ?? ""}`);
+  assert.equal(status, 0);
+  assert.equal(line.mode, "provider");            // not "error", not "native"
+  // The launcher, not the shim. Compare case-insensitively: resolveWindowsCommand
+  // builds candidates with the PATHEXT spelling (".CMD") and Windows existsSync is
+  // case-insensitive, so the returned path carries PATHEXT casing rather than the
+  // on-disk casing. Harmless for spawning; see 010 §7.
+  assert.equal(String(line.ocxPath).toLowerCase(), join(dir, "ocx.cmd").toLowerCase());
+  assert.match(String(line.ocxPath), /\.cmd$/i);
+  assert.equal(line.running, true);                // the payload really came back
+  assert.equal(line.port, 10100);
+});
+
+test("no ocx on PATH resolves to native through the real resolver", { skip: process.platform !== "win32" }, t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-none-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const { status, line } = detectWithPath(dir);
+  assert.equal(status, 0);
+  assert.equal(line.mode, "native");
 });


### PR DESCRIPTION
Layer **L1** of the Windows issue sweep stack. Base is **L0** (`codex/win-sweep-roadmap`), not `dev` — `enforce-target` will flag this and that is expected for a manual chain. Do not retarget it at `dev`; that would collapse the chain into overlapping diffs.

Closes the Windows half of #131 for `provider-bridge`. The GUI and `cxc serve` copies are L6.

## The bug

On Windows an npm global install lays down **both** an extensionless sh shim and a `.cmd` launcher, and `where ocx` lists the extensionless one first. Two independent failures follow, measured on the reporting host:

```
C:\nvm4w\nodejs\ocx                  status=null  err=ENOENT
C:\nvm4w\nodejs\ocx.cmd              status=null  err=EINVAL
C:\nvm4w\nodejs\ocx.cmd via ComSpec  status=0     stdout=3931 bytes
```

The extensionless file is not an executable image, and after the CVE-2024-27980 hardening a shell-less `.cmd` spawn is `EINVAL`. Both land on `status === null`, so a healthy proxy was reported as `mode: "error"` with `reason: "ocx status exited null"`.

## The fix, and why not the obvious one

The obvious fix is to pick a better line out of `where` stdout and wrap the `.cmd` in a ComSpec call. That was the first implementation, and an independent review rejected it: it would have been a **third bespoke ComSpec wrapper** in a repository that already has `win-exec.ts` in four components, and its naive `"${path}"` quoting is a command injection. Reviewer reproduction: with a launcher path containing `&`, plain quoting makes cmd execute only the prefix and return status 1, while `commandInvocation` escapes it to `^&` and returns status 0.

So this layer copies `cxc-ops/src/win-exec.ts` into `provider-bridge` byte-for-byte and routes through it:

- `whichOcx` calls `resolveWindowsCommand`, which reads `PATH`/`PATHEXT` case-insensitively (a child can arrive with `Path`, `PATH`, or both), splits `PATH` on a literal `;` rather than `node:path`'s host-dependent delimiter, and retries the lowercased extension for case-sensitive filesystems. The `where`-stdout parsing is **deleted**, not patched.
- `runOcxStatus` calls `commandInvocation`, which routes only `.cmd`/`.bat` through ComSpec and escapes cmd metacharacters. `shell: true` is not used — Node does not escape there.

`cli.ts` is 66 lines deleted for 31 added. `detect.ts` is untouched; the detect-only contract holds — no `ocx ensure`, no `ocx sync`, no config write.

### Why a copy rather than the re-export `messenger-bridge` uses

A cross-component import is not illegal here — `build.mjs`'s convention is a comment, not a check, and `messenger-bridge/src/win-exec.ts` already re-exports `subagent-config/dist/win-exec.js`. But `provider-bridge` runs from a **SessionStart hook** that must always exit 0, so depending on another component's `dist/` build state would turn a resolution failure into a silent provider-status degradation. The copy removes that coupling; the drift cost is converted into a loud test failure by a byte-identity assertion.

## Verification

```
provider-bridge suite: 13 passed, 0 failed
npm run build: 180 files compiled, layout validated
npm run gate: OK
```

Live, from the built `dist/` on the reporting host:

```
$ node plugins/codexclaw/components/provider-bridge/dist/cli.js detect
{"provider":"ocx","mode":"provider","ocxPath":"C:\\nvm4w\\nodejs\\ocx.CMD","running":true,"defaultProvider":"openai","port":10100}
```

The parent commit emits `{"mode":"error","reason":"ocx status exited null"}` for the same command.

### The test that actually gates this

The three helper tests exercise `win-exec.ts` directly and **all pass when `cli.ts` is untouched** — copying the module alone would satisfy them. An audit caught that hole, so there are now two win32 subprocess tests that run the real `cli.ts detect` against a crafted `PATH` holding both an extensionless shim and a `.cmd` that answers `status --json`. They assert `mode === "provider"`, that the resolved path is the launcher, and that `running`/`port` came back, so they fail if either half regresses or if the wiring is missing.

Known coverage limit: those two are win32-only, because the fixture needs a real `.cmd`. **Linux and macOS CI do not gate the wiring** — only the Windows matrix jobs do.

## One behaviour difference, recorded rather than hidden

`resolveWindowsCommand` builds candidates with PATHEXT's own spelling and Windows `existsSync` ignores case, so the reported path ends `.CMD` where the old `where`-parsing reported the on-disk `.cmd`. Caught by the new tests on first run. Cosmetic — Windows paths are case-insensitive and the only consumer reads `ocxPath` as a path. It must **not** be normalised inside `win-exec.ts`, whose bytes are shared with four components; the tests compare case-insensitively and assert `/\.cmd$/i`, pinning that the shim lost rather than a spelling.

`dist/win-exec.js` is a new file and `.gitignore:2` ignores `dist/`, so it required `git add -f`.

Plan: `devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md`.
