### PR TITLE
fix(pabcd-state): canonicalise the native session cwd with realpathSync.native (L2, #134)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C039_passing-brightgreen" alt="3,039 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C039_passing-brightgreen" alt="3,039 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C039_passing-brightgreen" alt="3,039 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_windows_issue_sweep/020_wp3_session_binding_extended_path.md
+++ b/devlog/_plan/260911_windows_issue_sweep/020_wp3_session_binding_extended_path.md
@@ -4,7 +4,7 @@ Layer: L2. Branch: `codex/fix-session-binding-extended-path`. Base: L1 (`codex/f
 Issue: #134. Criterion: **c-3** (`cxc session current` succeeds against an extended-length stored cwd).
 This document is the copy-paste PRD for the implementation cycle. Docs-only now; no production patch in wp1.
 
-Source truth (this checkout, HEAD `9cd52769`): `realpathSync` call sites in `session-binding.ts` are **`:31` and `:74`**, not the `:38`/`:78` pair in `000_plan.md` wp3. Dist matches src. Implement against the file.
+Source truth (L1 head `1f34a30a`): `realpathSync` call sites in `session-binding.ts` are **`:31` and `:74`**, not the `:38`/`:78` pair in `000_plan.md` wp3. Dist matches src. Both were re-verified byte-for-byte at this head by an independent reviewer. Implement against the file.
 
 ## 1. Scope
 
@@ -94,7 +94,7 @@ function canonical(path: string): string {
 }
 ```
 
-Insert the sibling helper in `session-binding.ts` immediately before `export function resolveNativeSession` (after `NativeSessionResult`, currently line 19). The comment names the #134 prefix, not 8.3. `realpathSync` stays imported from `node:fs` (`:1`); `.native` is a property of that function.
+Insert the sibling helper in `session-binding.ts` **after the `NativeSessionResult` type ends at `:14`**, i.e. in the blank line at `:15`, before the `resolveNativeSession` JSDoc. That JSDoc occupies `:16-19` and the `export` is at `:20`, so inserting at `:19` would split the comment. The new comment names the #134 prefix, not 8.3. `realpathSync` stays imported from `node:fs` (`:1`); `.native` is a property of that function.
 
 after (insert at `session-binding.ts:19`, before the `resolveNativeSession` JSDoc):
 
@@ -281,7 +281,7 @@ Skip on non-win32: `toNamespacedPath` is a no-op on POSIX and the extended-lengt
 
 ## 6. Reproduction (parent fails, L2 head passes)
 
-Parent = L1 head (today: this checkout at `9cd52769` still has JS `realpathSync` at both sites). Layer head = L2 after the patch + rebuild.
+Parent = L1 head `1f34a30a`, which still has JS `realpathSync` at both sites. Layer head = L2 after the patch + rebuild.
 
 PowerShell. Check native status with `$LASTEXITCODE`, never `$?`.
 

--- a/plugins/codexclaw/components/pabcd-state/dist/session-binding.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/session-binding.js
@@ -13,6 +13,27 @@ const ROOT_SOURCES = new Set(["cli", "vscode", "exec", "mcp"]);
 
 
 
+/**
+ * Canonical absolute path. JS `realpathSync` THROWS on the Windows
+ * extended-length prefix that Codex stores in the native thread DB:
+ * `realpathSync("\\\\?\\C:\\...")` fails with
+ * `EISDIR: illegal operation on a directory, lstat 'C:'` because it parses the
+ * prefix as a path segment. `realpathSync.native` resolves that shape. Measured on
+ * a Windows desktop install: 159 of 159 `threads.cwd` rows carried the prefix, so
+ * this is the normal shape, not an edge case (#134). Native additionally expands
+ * 8.3 short names, which is why `session-source.ts` already keeps its own copy of
+ * this helper.
+ *
+ * Deliberately private and duplicated rather than shared: `session-source.ts`
+ * does not export its copy, and `worktree-guard.ts` `canonicalize()` must NOT be
+ * reused here because it walks a missing path up to its nearest existing ancestor
+ * and RETURNS a string instead of throwing, which would silently reclassify a
+ * missing cwd as a mismatch and break the fail-closed contract below.
+ */
+function canonical(path        )         {
+  return realpathSync.native(path);
+}
+
 /** CLI-only corroboration. Never use as a hook's identity resolver: subagent
  * hook session_id is the root ID, unlike the child's native CODEX_THREAD_ID.
  * Protects accidental cross-session writes, not hostile same-user DB/env edits.
@@ -28,7 +49,7 @@ export function resolveNativeSession(cwd        , env                    = proce
 
   let canonicalCwd        ;
   try {
-    canonicalCwd = realpathSync(cwd);
+    canonicalCwd = canonical(cwd);
     if (!lstatSync(canonicalCwd).isDirectory()) throw new Error();
   } catch {
     return { ok: false, error: "Cannot resolve the working directory. Run from the native session's directory." };
@@ -71,7 +92,7 @@ export function resolveNativeSession(cwd        , env                    = proce
         return { ok: false, error: "Native session has an invalid working directory." };
       }
       try {
-        if (realpathSync(row.cwd) !== canonicalCwd) {
+        if (canonical(row.cwd) !== canonicalCwd) {
           return { ok: false, error: "Working directory does not match the native session. Run from its exact directory." };
         }
       } catch {

--- a/plugins/codexclaw/components/pabcd-state/src/session-binding.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/session-binding.ts
@@ -13,6 +13,27 @@ export type NativeSessionResult =
   | { ok: true; sessionId: string; cwd: string; dbPath: string }
   | { ok: false; error: string };
 
+/**
+ * Canonical absolute path. JS `realpathSync` THROWS on the Windows
+ * extended-length prefix that Codex stores in the native thread DB:
+ * `realpathSync("\\\\?\\C:\\...")` fails with
+ * `EISDIR: illegal operation on a directory, lstat 'C:'` because it parses the
+ * prefix as a path segment. `realpathSync.native` resolves that shape. Measured on
+ * a Windows desktop install: 159 of 159 `threads.cwd` rows carried the prefix, so
+ * this is the normal shape, not an edge case (#134). Native additionally expands
+ * 8.3 short names, which is why `session-source.ts` already keeps its own copy of
+ * this helper.
+ *
+ * Deliberately private and duplicated rather than shared: `session-source.ts`
+ * does not export its copy, and `worktree-guard.ts` `canonicalize()` must NOT be
+ * reused here because it walks a missing path up to its nearest existing ancestor
+ * and RETURNS a string instead of throwing, which would silently reclassify a
+ * missing cwd as a mismatch and break the fail-closed contract below.
+ */
+function canonical(path: string): string {
+  return realpathSync.native(path);
+}
+
 /** CLI-only corroboration. Never use as a hook's identity resolver: subagent
  * hook session_id is the root ID, unlike the child's native CODEX_THREAD_ID.
  * Protects accidental cross-session writes, not hostile same-user DB/env edits.
@@ -28,7 +49,7 @@ export function resolveNativeSession(cwd: string, env: NodeJS.ProcessEnv = proce
 
   let canonicalCwd: string;
   try {
-    canonicalCwd = realpathSync(cwd);
+    canonicalCwd = canonical(cwd);
     if (!lstatSync(canonicalCwd).isDirectory()) throw new Error();
   } catch {
     return { ok: false, error: "Cannot resolve the working directory. Run from the native session's directory." };
@@ -71,7 +92,7 @@ export function resolveNativeSession(cwd: string, env: NodeJS.ProcessEnv = proce
         return { ok: false, error: "Native session has an invalid working directory." };
       }
       try {
-        if (realpathSync(row.cwd) !== canonicalCwd) {
+        if (canonical(row.cwd) !== canonicalCwd) {
           return { ok: false, error: "Working directory does not match the native session. Run from its exact directory." };
         }
       } catch {

--- a/plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/session-binding.test.ts
@@ -2,7 +2,7 @@ import { test, type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import fs, { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, toNamespacedPath } from "node:path";
 import { createRequire, syncBuiltinESMExports } from "node:module";
 import { Worker } from "node:worker_threads";
 import { resolveNativeSession } from "../src/session-binding.ts";
@@ -13,7 +13,10 @@ const CHILD = "019a0000-0000-7000-8000-000000000001";
 const PARENT = "019a0000-0000-7000-8000-000000000002";
 
 function fixture(t: TestContext) {
-  const root = realpathSync(mkdtempSync(join(tmpdir(), "cxc-session-binding-")));
+  // realpathSync.native, matching the production helper. On windows-latest TEMP can
+  // be an 8.3 short path that the JS implementation leaves intact, which would make
+  // the long-form cwd the production code resolves differ from this fixture value.
+  const root = realpathSync.native(mkdtempSync(join(tmpdir(), "cxc-session-binding-")));
   t.after(() => rmSync(root, { recursive: true, force: true }));
   const cwd = join(root, "work");
   const home = join(root, "native");
@@ -164,6 +167,43 @@ test("cwd must match exactly after realpath, not a parent or sibling", t => {
   const f = fixture(t);
   nativeDb(f.home, f.root);
   assert.equal(resolveNativeSession(f.cwd, f.env).ok, false);
+});
+
+// #134. Codex on Windows stores threads.cwd with the extended-length prefix; a
+// desktop install measured 159 of 159 rows in that shape. JS realpathSync throws
+// EISDIR (lstat 'C:') on it, so the stored-cwd comparison fell into its catch and
+// reported "Cannot resolve the native session's working directory." The process cwd
+// is the plain form, which is why only the stored side failed.
+//
+// toNamespacedPath produces the real shape rather than hardcoding a prefix, and it
+// is a no-op off win32, so the assertion below is meaningful on Windows and
+// trivially true elsewhere. This is NOT the 8.3 short-name case: that is a
+// different alias class that merely shares the same fix.
+test("an extended-length stored cwd still matches the native session", t => {
+  const f = fixture(t);
+  const stored = toNamespacedPath(f.cwd);
+  const dbPath = nativeDb(f.home, stored);
+
+  if (process.platform === "win32") {
+    // Pin the premise: the JS implementation cannot read this shape, the native one
+    // can. If this ever stops holding, the fix below is no longer load-bearing.
+    assert.notEqual(stored, f.cwd);
+    assert.throws(() => realpathSync(stored));
+    assert.equal(realpathSync.native(stored), f.cwd);
+  }
+
+  const result = resolveNativeSession(f.cwd, f.env);
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.sessionId, CHILD);
+    assert.equal(result.cwd, f.cwd);   // the plain form, not the prefixed one
+    assert.equal(result.dbPath, dbPath);
+  }
+
+  // And the CLI surface the issue actually reported.
+  const { code, body } = jsonResult(["current"], f);
+  assert.equal(code, 0);
+  assert.equal(body.ok, true);
 });
 
 test("highest numeric database wins and CODEX_SQLITE_HOME takes precedence", t => {


### PR DESCRIPTION
Layer **L2** of the Windows issue sweep stack. Base is **L1** (`codex/fix-ocx-windows-detect`), not `dev` — `enforce-target` will flag this and that is expected for a manual chain.

Closes #134.

## The bug, and why the issue's own diagnosis was wrong

#134 guessed that the thread-database lookup comes back empty. It does not. The row is present and readable; what fails is resolving the `cwd` it stores.

Codex on Windows stores `threads.cwd` with the **extended-length prefix**. Measured by reading `state_5.sqlite` read-only on the reporting host:

```
total=159  extendedPrefix=159  plain=0
this session row: {"cwd":"\\\\?\\C:\\Users\\super\\Developers\\codexclaw","source":"vscode"}

JS     realpathSync(row.cwd) -> THREW EISDIR: illegal operation on a directory, lstat 'C:'
native realpathSync(row.cwd) -> C:\Users\super\Developers\codexclaw
       realpathSync(process.cwd()) -> C:\Users\super\Developers\codexclaw
```

That is the whole asymmetry. `session-binding.ts:31` canonicalises the **process** cwd, which is the plain form, so it succeeds. `:74` canonicalises the **stored** cwd and throws, and its `catch` emits the issue's exact string. `session-source.ts:17` already used `realpathSync.native` for the same class of Windows path aliasing; `session-binding.ts` was the only holdout.

## The fix

A private `canonical()` helper and both call sites routed through it. Two lines of behaviour change, plus a comment that records the measured premise so a later reader does not undo it.

It is inserted after the `NativeSessionResult` type rather than immediately before the `export`, because the reviewer pointed out that `resolveNativeSession`'s JSDoc occupies the four lines above it and inserting there would split the comment.

`worktree-guard.ts`'s `canonicalize()` is **not** reused, and the helper comment says why: it walks a missing path up to its nearest existing ancestor and returns a string instead of throwing, so reusing it would silently reclassify a missing cwd as a mismatch and break the fail-closed contract. The reviewer independently confirmed that behaviour against `/does-not-exist-cxc`.

`ROOT_SOURCES` is untouched — a subagent thread is still refused, which is correct and outside this issue.

## Verification

```
session-binding suite: 62 passed, 0 failed, 0 skipped
npm run build: 180 files compiled, layout validated
npm run gate: OK
inventory --check --tests 3038: OK
```

Live, from the built `dist/`:

```
$ node plugins/codexclaw/components/pabcd-state/dist/cli.js session current --json
{"ok":true,"sessionId":"01a08fba-...","cwd":"C:\\Users\\super\\Developers\\codexclaw","dbPath":"C:\\Users\\super\\.codex\\state_5.sqlite","phase":"B",...}
```

Every invocation earlier in the same session returned `{"ok":false,"error":"Cannot resolve the native session's working directory."}`. This restores the `SESSION-IDENTITY-01` corroboration step that the loop delivering this stack had been running without.

## The regression test

It builds the stored value with `toNamespacedPath` rather than hardcoding a prefix, so it produces the real shape and is a no-op off win32. On win32 it first **pins the premise** — JS `realpathSync` throws, native resolves to the plain form — so if that ever stops holding, the test says the fix is no longer load-bearing rather than passing silently. Then it asserts `resolveNativeSession` returns `ok` with the plain cwd, and finally drives the `session current` CLI surface the issue actually reported.

Deliberately **not** the 8.3 short-name shape. 8.3 is a different alias class that merely shares the same fix, and it is not what this host stores; one draft of the plan proposed it and that was corrected.

The test fixture now normalises its temp root with `realpathSync.native` to match the production helper — on `windows-latest` TEMP can be an 8.3 short path that the JS implementation leaves intact, which would otherwise make the fixture value differ from what production resolves.

Plan: `devlog/_plan/260911_windows_issue_sweep/020_wp3_session_binding_extended_path.md`.
