### PR TITLE
fix(config-guard): answer --help before the action and forward full argv (L3, #132)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C039_passing-brightgreen" alt="3,039 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C049_passing-brightgreen" alt="3,049 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C039_passing-brightgreen" alt="3,039 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C049_passing-brightgreen" alt="3,049 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C039_passing-brightgreen" alt="3,039 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C049_passing-brightgreen" alt="3,049 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/bin/codexclaw.mjs
+++ b/bin/codexclaw.mjs
@@ -460,14 +460,18 @@ if (isMain) switch (cmd) {
     break;
   }
   case "enable":
-    process.exit(runConfigGuard(["enable"]));
+    process.exit(runConfigGuard(["enable", ...process.argv.slice(3)]));
     break;
   case "uninstall":
   case "disable":
-    process.exit(runConfigGuard(["disable"]));
+    // The verb is rewritten to `disable`, then the REST of argv is appended.
+    // Forwarding slice(2) verbatim would send a raw `uninstall` token, which
+    // config-guard main() has no case for: it would hit the switch default and
+    // print a usage error instead of disabling.
+    process.exit(runConfigGuard(["disable", ...process.argv.slice(3)]));
     break;
   case "status":
-    process.exit(runConfigGuard(["status"]));
+    process.exit(runConfigGuard(["status", ...process.argv.slice(3)]));
     break;
   case "config":
     // `config interview` is owned by pabcd-state (it owns codexclaw.json); the managed

--- a/devlog/_plan/260911_windows_issue_sweep/030_wp4_config_guard_help_passthrough.md
+++ b/devlog/_plan/260911_windows_issue_sweep/030_wp4_config_guard_help_passthrough.md
@@ -4,7 +4,7 @@ Layer: L3. Branch: `codex/fix-config-guard-help`. Base: L2 (`codex/fix-session-b
 Issue: #132. Criterion: **c-10** (both entrypoints, all four verbs, both help flags, config byte-identical and no bak; `cxc uninstall` without help still disables).
 This document is the copy-paste PRD for the implementation cycle. Docs-only now; no production patch in wp1.
 
-Source truth (this checkout, HEAD `9cd52769`): help never reaches config-guard because both dispatchers drop argv after the verb. `uninstall` is already rewritten to `disable` at both dispatchers — that rewrite must survive the passthrough. Dist of `config-guard` is already tracked.
+Source truth (L2 head `701639b6`): help never reaches config-guard because both dispatchers drop argv after the verb. `uninstall` is already rewritten to `disable` at both dispatchers — that rewrite must survive the passthrough. Dist of `config-guard` is already tracked. Anchors re-verified at this head: `bin/codexclaw.mjs` `:463`/`:467`/`:470`, `plugins/codexclaw/bin/cxc.mjs:165`, and in `config-guard/src/cli.ts` `CONFIG_USAGE` `:22-33`, `runConfig` `:37`, `main` `:140`, switch default `:235-237`.
 
 ## 1. Scope
 
@@ -441,4 +441,3 @@ cxc receipt test --session <id> -- node plugins/codexclaw/scripts/test.mjs plugi
 ## 11. Criterion
 
 **c-10**: both entrypoints, all four verbs, both help flags, config byte-identical and no bak; `cxc uninstall` without help still disables. Proved by the three tests in §8.2 plus the live commands in §9.2.
-

--- a/devlog/_plan/260911_windows_issue_sweep/060_wp7_integration_merge_deploy.md
+++ b/devlog/_plan/260911_windows_issue_sweep/060_wp7_integration_merge_deploy.md
@@ -101,6 +101,47 @@ Record these four separately; do not collapse them into "CI green":
 3. the layer's current head sha and the sha each check ran against,
 4. workflow event, ref and concurrency group.
 
+### The published tests badge is the one check you cannot verify locally
+
+`ci.yml` runs, in the **ubuntu** test job only:
+
+```bash
+node plugins/codexclaw/scripts/inventory.mjs --check --tests "${{ steps.suite.outputs.total }}"
+```
+
+That compares the README `tests-N_passing` badge against the total the suite **just
+measured on that runner**. Any layer that adds or removes a test moves the total and
+fails this step. `npm run gate` does not catch it — gate checks inventory drift, not the
+measured suite.
+
+**The counts differ by platform.** Measured on this stack: at L1's head a Windows run
+reported `tests 3037` while the ubuntu job reported `3038`; at L2's head Windows
+reported `3038` and ubuntu `3039`. The repository has many platform-gated test files
+(`provider-bridge`, `bg-wake`, `cxc-ops/hook-trust`, `gui/project-root`,
+`pabcd-state/hook`, `messenger-bridge/db` and others), and some gate **registration**
+rather than using `skip` — a skipped test still counts, an unregistered one does not. The
+badge therefore tracks the **ubuntu** number, not the local one.
+
+Two ways to get it right:
+
+1. **Add the delta.** On this host ubuntu is local + 1. Measure locally, add 1, write it:
+
+```powershell
+npm test 2>&1 | Select-String -Pattern "^. tests [0-9]+$" | Select-Object -Last 1
+node plugins/codexclaw/scripts/inventory.mjs --write --tests <local + 1>
+node plugins/codexclaw/scripts/inventory.mjs --check --tests <local + 1>
+```
+
+   Re-derive the delta whenever a layer adds a test whose *registration* is
+   platform-conditional; a `skip`-ed test does not change it.
+
+2. **Let CI name the number.** The failure message is exact:
+   `published tests=3037 but the measured suite reported 3038 — run inventory.mjs --write --tests 3038`.
+   One push, read the number, write it, push again.
+
+Use option 1 first and option 2 as the check, **before** opening the layer PR so the
+first CI run is the one that counts. Two layers in this stack learned it the other way.
+
 CI runs per layer. That is correct for a manual chain, not duplication — there is no
 native stack to deduplicate. The slowest job on this repository is `wsl (drvfs /mnt/c)`
 at roughly 12-15 minutes; it is the usual reason a PR sits at `UNSTABLE`.

--- a/plugins/codexclaw/bin/cxc.mjs
+++ b/plugins/codexclaw/bin/cxc.mjs
@@ -152,9 +152,11 @@ if (isMain) {
     process.exit(1);
   }
   // Component CLI argv contracts (mirror root bin):
-  //   config-guard: [subcommand] only, EXCEPT `config`, which forwards its full argv so
-  //     `config set <key> <value>` keeps its arguments; skill-search: [search|show, ...]
-  //     (drop the "skill" verb);
+  //   config-guard feature verbs: [disable-rewritten-verb, ...rest]. `uninstall` is
+  //     rewritten to `disable` because config-guard main() has no uninstall case: a raw
+  //     token hits the switch default and does not disable. `config` still forwards its
+  //     full argv so `config set <key> <value>` keeps its arguments;
+  //     skill-search: [search|show, ...] (drop the "skill" verb);
   //   provider-bridge: ["detect"]; everything else: [cmd, ...rest] verbatim.
   if (component === "config-guard") {
     if (cmd === "config") {
@@ -162,7 +164,10 @@ if (isMain) {
       const target = process.argv[3] === "interview" ? "pabcd-state" : "config-guard";
       process.exit(delegate(target, process.argv.slice(2)));
     }
-    process.exit(delegate(component, [cmd === "uninstall" ? "disable" : cmd]));
+    process.exit(delegate(component, [
+      cmd === "uninstall" ? "disable" : cmd,
+      ...process.argv.slice(3),
+    ]));
   } else if (cmd === "memory" && process.argv[3] === "allow-write") {
     // `memory search` is recall's; `memory allow-write` records the
     // MEMORY-WRITE-GATE-01 grant in the pabcd-state session file that owns it.

--- a/plugins/codexclaw/components/config-guard/dist/cli.js
+++ b/plugins/codexclaw/components/config-guard/dist/cli.js
@@ -34,6 +34,16 @@ const CONFIG_USAGE = [
   "self-heal; see cxc doctor's `features` check.)",
 ].join("\n");
 
+const FEATURE_USAGE = [
+  "Usage:",
+  "  cxc enable                         activate declared Codex feature flags",
+  "  cxc disable | uninstall            revert flags codexclaw enabled when safe",
+  "  cxc status                         show declared feature-flag state",
+  "",
+  "  --help / -h / help in any argument position prints this text and writes nothing.",
+  "  enable writes $CODEX_HOME/config.toml and a timestamped .bak; disable/uninstall revert.",
+].join("\n");
+
 function runConfig(argv                   , codexHome        )         {
   const configPath = join(codexHome, "config.toml");
   const action = argv[0];
@@ -139,6 +149,21 @@ export function makeRealRunner()              {
 
 function main(argv                   )         {
   const cmd = argv[0];
+  // Same class of bug as freeze-cli.ts:61-65, where `cxc freeze --help` used to WRITE
+  // freeze.json. Help is position-independent and runs BEFORE the action: once the
+  // dispatcher forwards ["enable", "--help"], argv[0] is "enable" and runConfig's
+  // first-argument help check at :41 never sees the flag.
+  // Do not steal `config --help` (that is CONFIG_USAGE via runConfig) or the
+  // SessionStart `hook` path, which must stay fail-open. Empty argv still falls to the
+  // switch default and exits 2 — unlike freeze, a bare invocation here is not mutating.
+  if (
+    cmd !== "config" &&
+    cmd !== "hook" &&
+    argv.some((a) => a === "help" || a === "--help" || a === "-h")
+  ) {
+    process.stdout.write(`${FEATURE_USAGE}\n`);
+    return 0;
+  }
   const run = makeRealRunner();
   const codexHome = resolveCodexHome();
 

--- a/plugins/codexclaw/components/config-guard/src/cli.ts
+++ b/plugins/codexclaw/components/config-guard/src/cli.ts
@@ -34,6 +34,16 @@ const CONFIG_USAGE = [
   "self-heal; see cxc doctor's `features` check.)",
 ].join("\n");
 
+const FEATURE_USAGE = [
+  "Usage:",
+  "  cxc enable                         activate declared Codex feature flags",
+  "  cxc disable | uninstall            revert flags codexclaw enabled when safe",
+  "  cxc status                         show declared feature-flag state",
+  "",
+  "  --help / -h / help in any argument position prints this text and writes nothing.",
+  "  enable writes $CODEX_HOME/config.toml and a timestamped .bak; disable/uninstall revert.",
+].join("\n");
+
 function runConfig(argv: readonly string[], codexHome: string): number {
   const configPath = join(codexHome, "config.toml");
   const action = argv[0];
@@ -139,6 +149,21 @@ export function makeRealRunner(): CodexRunner {
 
 function main(argv: readonly string[]): number {
   const cmd = argv[0];
+  // Same class of bug as freeze-cli.ts:61-65, where `cxc freeze --help` used to WRITE
+  // freeze.json. Help is position-independent and runs BEFORE the action: once the
+  // dispatcher forwards ["enable", "--help"], argv[0] is "enable" and runConfig's
+  // first-argument help check at :41 never sees the flag.
+  // Do not steal `config --help` (that is CONFIG_USAGE via runConfig) or the
+  // SessionStart `hook` path, which must stay fail-open. Empty argv still falls to the
+  // switch default and exits 2 — unlike freeze, a bare invocation here is not mutating.
+  if (
+    cmd !== "config" &&
+    cmd !== "hook" &&
+    argv.some((a) => a === "help" || a === "--help" || a === "-h")
+  ) {
+    process.stdout.write(`${FEATURE_USAGE}\n`);
+    return 0;
+  }
   const run = makeRealRunner();
   const codexHome = resolveCodexHome();
 

--- a/plugins/codexclaw/test/cli-usage.test.mjs
+++ b/plugins/codexclaw/test/cli-usage.test.mjs
@@ -1,12 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { dirname, resolve, join } from "node:path";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, resolve, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..", "..");
 const cli = join(repoRoot, "bin", "codexclaw.mjs");
+const payloadCli = join(repoRoot, "plugins", "codexclaw", "bin", "cxc.mjs");
 
 test("top-level CLI usage advertises disable", () => {
   const out = execFileSync("node", [cli, "help"], { cwd: repoRoot, encoding: "utf8" });
@@ -49,6 +52,66 @@ for (const command of ["loop", "scan", "receipt", "config"]) {
       assert.match(res.stdout, /Usage:/);
       assert.match(res.stdout, new RegExp(`cxc ${command}`));
     }
+  });
+}
+
+// #132: `cxc enable --help` did not print help — it RAN enable, rewrote
+// $CODEX_HOME/config.toml and left a timestamped .bak. Two independent causes: both
+// dispatchers forwarded only the verb, dropping --help entirely, and config-guard
+// main() dispatched on argv[0] before help was ever considered. Fixing one alone
+// leaves the bug, so this drives the REAL binaries on BOTH entry points.
+//
+// CODEX_HOME is a fresh temp dir per invocation. Without that, a regression here
+// rewrites the developer's own ~/.codex/config.toml while the suite runs.
+for (const entry of [cli, payloadCli]) {
+  for (const command of ["enable", "disable", "uninstall", "status"]) {
+    test(`${command} --help on ${basename(entry)} prints usage and writes nothing`, t => {
+      for (const flag of ["--help", "-h"]) {
+        const home = mkdtempSync(join(tmpdir(), "cxc-cli-help-"));
+        t.after(() => rmSync(home, { recursive: true, force: true }));
+        const configPath = join(home, "config.toml");
+        const before = "features = {}\n";
+        writeFileSync(configPath, before);
+
+        const res = spawnSync("node", [entry, command, flag], {
+          cwd: repoRoot,
+          encoding: "utf8",
+          env: { ...process.env, CODEX_HOME: home },
+        });
+
+        assert.equal(res.status, 0, `${command} ${flag} exited ${res.status}: ${res.stderr}`);
+        assert.match(res.stdout, /Usage:/);
+        assert.match(res.stdout, /--help never writes|writes nothing/);
+        // The side effects the bug produced, asserted directly.
+        assert.equal(readFileSync(configPath, "utf8"), before, "config.toml was modified");
+        assert.equal(
+          readdirSync(home).filter(name => name.includes(".bak")).length,
+          0,
+          "a .bak backup was created",
+        );
+        // And it must not have silently done the action instead.
+        assert.doesNotMatch(res.stdout, /codexclaw: enabled|codexclaw: disabled/);
+        assert.doesNotMatch(res.stderr, /usage: config-guard/);
+      }
+    });
+  }
+
+  // The trap in the natural fix: forwarding process.argv.slice(2) verbatim sends a raw
+  // `uninstall` token, and config-guard main() has no case for it, so the switch default
+  // prints a usage error and NOTHING is disabled. The verb must be rewritten to
+  // `disable` with only the remaining argv appended.
+  test(`uninstall without --help still disables on ${basename(entry)}`, t => {
+    const home = mkdtempSync(join(tmpdir(), "cxc-cli-uninstall-"));
+    t.after(() => rmSync(home, { recursive: true, force: true }));
+    const res = spawnSync("node", [entry, "uninstall"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: { ...process.env, CODEX_HOME: home },
+    });
+    assert.equal(res.status, 0, `uninstall exited ${res.status}: ${res.stderr}`);
+    assert.doesNotMatch(res.stderr, /usage: config-guard/);
+    // Reached the real disable path rather than the switch default.
+    assert.match(res.stdout, /nothing to revert|disabled/);
   });
 }
 


### PR DESCRIPTION
Layer **L3** of the Windows issue sweep stack. Base is **L2** (`codex/fix-session-binding-extended-path`), not `dev` — `enforce-target` will flag this and that is expected for a manual chain.

Closes #132.

## The bug

`cxc enable --help` did not print help. It **ran enable**, rewrote `$CODEX_HOME/config.toml` and left a timestamped `.bak`. A command that looks read-only mutated global config, and repeated calls piled up backups.

Two independent causes, and fixing either alone leaves the bug:

1. **Both dispatchers dropped argv.** `bin/codexclaw.mjs:463/:467/:470` and `plugins/codexclaw/bin/cxc.mjs:165` forwarded a single-element array, so `--help` never reached config-guard. Only `config` forwarded `process.argv.slice(2)`, which is why `cxc config --help` worked and `cxc enable --help` did not.
2. **`main()` dispatched before considering help.** `config-guard/src/cli.ts` switched on `argv[0]`, and the existing help check lives inside `runConfig`, so it governs `cxc config` alone. Even with argv forwarded, `argv[0]` is `"enable"` and the flag is never examined.

This is the same class as `freeze-cli.ts:61-65`, where `cxc freeze --help` used to write `freeze.json`.

## The trap in the obvious fix

Forwarding `process.argv.slice(2)` verbatim sends a raw `uninstall` token. `config-guard` `main()` has no `uninstall` case — it would hit the switch default, print `usage: config-guard <enable|disable|status|config>` with exit 2, and **nothing would be disabled**. The verb must be rewritten to `disable` with only the remaining argv appended:

```js
process.exit(delegate(component, [
  cmd === "uninstall" ? "disable" : cmd,
  ...process.argv.slice(3),
]));
```

There is a dedicated test for this, because it is the assertion the natural implementation breaks.

## The help path

Position-independent, and placed before `makeRealRunner()` and `resolveCodexHome()` so it cannot spawn `codex` or touch the real home. Guarded by `cmd !== "config" && cmd !== "hook"`:

- `cxc config --help` still reaches `CONFIG_USAGE` through `runConfig`'s own first-argument check, so existing coverage stays green.
- The SessionStart self-heal `hook` path is never intercepted; it must stay fail-open.
- Empty argv still falls to the default with exit 2 — unlike `freeze`, a bare invocation here is not mutating.

No `case "uninstall"` was added.

## Verification

```
cli-usage suite: 19 passed, 0 failed
npm run build: 180 files compiled, layout validated
npm run gate: OK
inventory --check --tests 3049: OK
```

Verified by direct execution against throwaway `CODEX_HOME` directories **before** any test was written: 16 invocations (2 entrypoints × 4 verbs × `--help`/`-h`) all exit 0 with usage, `config.toml` byte-identical, zero `.bak` files, and `cxc uninstall` without a flag still reaches the real disable path on both entrypoints.

The tests assert the **side effects**, not just the exit code: the config bytes, the `.bak` count, and the absence of `codexclaw: enabled` / `codexclaw: disabled` in stdout. Each invocation gets a fresh temporary `CODEX_HOME` — before this fix, running the suite against the real one rewrites the developer's own config.

`config-guard/dist/cli.js` is restaged; both entrypoints spawn that file, not `src/cli.ts`.

## Also in this layer

`060` gained the tests-badge mechanism that cost L1 and L2 a red CI run each. `ci.yml` cross-checks the published README badge against the total the suite measures **on the ubuntu runner**, and the platform counts differ — at L1 Windows reported 3037 while ubuntu reported 3038 — because several test files gate on platform at *registration* rather than with `skip`. This layer set the badge to the ubuntu number proactively.

Plan: `devlog/_plan/260911_windows_issue_sweep/030_wp4_config_guard_help_passthrough.md`.
