### PR TITLE
fix(pabcd-state): refuse a bound cycle with no resolvable source identity (L4, #133)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C049_passing-brightgreen" alt="3,049 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C055_passing-brightgreen" alt="3,055 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C049_passing-brightgreen" alt="3,049 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C055_passing-brightgreen" alt="3,055 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C049_passing-brightgreen" alt="3,049 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C055_passing-brightgreen" alt="3,055 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_windows_issue_sweep/040_wp5_nongit_early_refusal.md
+++ b/devlog/_plan/260911_windows_issue_sweep/040_wp5_nongit_early_refusal.md
@@ -141,17 +141,30 @@ This is the earliest honest point: `loop init` is what makes the session bound i
 first place (it binds a slug and does not consult git at all today). Refusing here
 means the trap never gets built.
 
-Insert immediately before the goalplan artifact is written:
+**Guard it on the session being present.** `loop init` without `--session` is a supported
+path that writes the local artifact only and binds nothing (`goalplan-cli.ts:70` and the
+`[--session <id>]` form in the help at `:559`). An unguarded gate would reject or throw
+on that call, which is a regression this layer has no business causing — the gate's
+whole justification is that a **bound** plan promises a closable cycle.
+
+Insert after the existing-plan check and before `buildGoalplan`:
 
 ```ts
-// #133: a bound plan promises a closable cycle. Do not create the binding when
+// #133: a BOUND plan promises a closable cycle. Do not create the binding when
 // the source identity cannot be resolved - the failure would otherwise surface at
 // C, after plan/audit/build are spent.
-const gate = checkBoundSourceIdentity(cwd, session);
-if (!gate.ok) {
-  return { output: `loop init: ${gate.reason}\nNothing was written.`, code: 1 };
+// Only when a session is actually being bound: `loop init` without --session writes
+// the local artifact and binds nothing, so it keeps its current behaviour.
+if (session) {
+  const gate = checkBoundSourceIdentity(args.cwd, session);
+  if (!gate.ok) {
+    return { output: `loop init: ${gate.reason}\nNothing was written.`, code: 1 };
+  }
 }
 ```
+
+Use whatever local name the surrounding code already has for the session id; do not
+introduce a second source of truth for it.
 
 ### 5.2 `orchestrate-cli.ts` — IDLE→P on an already-bound session
 
@@ -170,6 +183,65 @@ if (state.slug) {
   }
 }
 ```
+
+### 5.3 Exact anchors, resolved at L3 head `a7e72a46`
+
+§5.1 and §5.2 told the implementer to find the right spot. Here it is.
+
+**`goalplan-cli.ts`** — `runGoalplanCli` is at `:595` and the `init` branch opens at
+`:597`. Order inside it today: objective check, `deriveSlug`, existing-plan check,
+`buildGoalplan`, then the first mutation `writeGoalplan(args.cwd, plan)` at `:612`,
+then `appendGoalplanLedger`, then the session bind. Insert the gate **after the
+existing-plan check and before `buildGoalplan`**, so nothing is constructed or written.
+
+**`orchestrate-cli.ts`** — the agent-gated phase path starts at `:557`. `:559-560` already
+validates `resolveSessionSource` with the comment "Validate before any phase/goalplan
+writes", which is exactly the right neighbourhood. Insert the gate **immediately after
+that try/catch and before the P>A plan-artifact gate at `:568`**.
+
+Guard it on `to === "P" && state.slug`, not on `state.phase === "IDLE"`: `I>P` is also
+an entry edge into a cycle and deserves the same refusal. `state.slug` is the same
+bound-session condition `:579` and `:701` already use, so an unbound HITL cycle is
+untouched by construction.
+
+Both sites return `code: 1` with the gate's reason and the words `Nothing was written`.
+
+### 5.4 Two corrections the existing suite forced during the build
+
+Both were found by running `pabcd-state`'s 1226 tests against the first implementation,
+not by reading. Recorded because each is a real design point, not a fixture nit.
+
+**1. The guard must cover ENTRY edges only, not every `to === "P"`.**
+
+`review-deadlock.test.ts:96` ("a re-plan closes the rounds it just invalidated") broke: an
+`A->P` re-plan also has `to === "P"`, so a `to === "P" && state.slug` guard silently
+blocked it and the round stayed `in_flight` instead of reaching `inconclusive`. A re-plan
+is not an entry into a cycle — the cycle is already in flight and already bound, and
+refusing it **strands** the session rather than protecting it, which is the exact
+opposite of this layer's purpose. The guard is now:
+
+```ts
+if (to === "P" && (state.phase === "IDLE" || state.phase === "I") && state.slug) {
+```
+
+The audit had flagged `I->P` as needing inclusion and it does; it did not consider
+`A->P`, and neither did I. The suite did.
+
+**2. The existing fixtures normalised the #133 trap.**
+
+`goalplan.test.ts:603` ("030.3: init --session persists the derived slug") broke, because
+it binds a session in a bare `mkdtempSync` directory — which is precisely the
+non-git-plus-bound-plan combination this issue is about. The fixture was not wrong about
+slug persistence; it was silently asserting that binding a plan into an unclosable
+workspace is fine.
+
+Fixed with a `tmpRepo()` helper that `git init`s and commits one file, used only by tests
+that actually bind a session. `loop init` **without** `--session` keeps using the bare
+`tmp()`, which is also the regression guard for the guarded-on-session rule in §5.1.
+
+This is worth naming: part of why #133 survived is that the suite's own fixtures treated
+the trap as the normal case. Result after both corrections: `pabcd-state` 1226 tests,
+1224 passed, 0 failed, 2 skipped.
 
 ## 6. Tests
 
@@ -194,6 +266,21 @@ The integration test that would have caught #133. In a non-git temp cwd:
    regression guard that proves the layer did not tighten the unbound contract.
 3. No line matching `/^fatal:/m` appears on stdout or stderr of any transition.
    This is the §3 assertion; before the fix, B→C and C emit two `fatal:` lines each.
+
+**Case 3 must `spawnSync` a real process, not call `run*Cli` in-process.** The leak is
+`execFileSync` inheriting the PARENT's stderr, so in-process it lands on the test
+runner's own stderr and never appears in the returned `output` string — the assertion
+would pass while the bug is fully present. Drive the built CLI and read `res.stderr`:
+
+```ts
+const res = spawnSync(process.execPath, [ORCHESTRATE_CLI, "C", "--session", id, "--attest-file", p], {
+  cwd: probe, encoding: "utf8", env: { ...process.env, CODEX_HOME: home },
+});
+assert.doesNotMatch(res.stderr ?? "", /^fatal:/m);
+assert.doesNotMatch(res.stdout ?? "", /^fatal:/m);
+```
+
+Cases 1 and 2 may stay in-process; only the stderr assertion needs a real child.
 
 ## 7. Reproduction (parent fails, L4 head passes)
 
@@ -228,6 +315,19 @@ Piping git stderr loses diagnostics for genuinely broken repositories (corrupt i
 permission failure). Accepted: those already surface as a thrown `execFileSync` error
 whose message the callers report, and the alternative is the #133 leak on every
 ordinary non-git transition.
+
+### 8.1 Known coverage limit — the human free-pass is outside this gate
+
+Both insertion points are on the **agent-gated CLI** path. A line-anchored chat
+`orchestrate P` is a human free-pass that reaches `applyHumanTransition`
+(`orchestrate-apply.ts:69`) without passing through `runOrchestrateCli`'s gates, so a
+human can still enter P on a bound non-git session and rediscover the stall at C.
+
+Accepted, not overlooked. The human path is deliberately ungated across this whole
+surface — that is what "human free-pass" means in `cxc-pabcd` phase-control — and
+widening it here would be a separate contract change, not a #133 fix. The agent path is
+where the unattended loop lives and where the trap actually cost a cycle. Recorded so a
+later reader does not mistake the gap for an omission.
 
 ## 9. Criterion
 

--- a/plugins/codexclaw/components/pabcd-state/dist/goalplan-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/goalplan-cli.js
@@ -43,6 +43,7 @@ import { resolve } from "node:path";
 import { isCanonicalSessionId, readState, writeState } from "./state.js";
 import { captureSourceIdentity, compareSource } from "./source-identity.js";
 import { captureSessionSourceIdentity } from "./session-source-identity.js";
+import { checkBoundSourceIdentity } from "./source-gate.js";
 import { resolveSessionSource } from "./session-source.js";
 import { parseSourceBoundReceipt } from "./source-receipt.js";
 import { applySteeringBatch } from "./steering.js";
@@ -603,6 +604,18 @@ export function runGoalplanCli(args                 )                    {
     const existing = readGoalplan(args.cwd, slug);
     if (existing) {
       return { output: `loop init: a plan already exists at slug '${slug}' (use show/validate)`, code: 1 };
+    }
+    // #133: a BOUND plan promises a closable cycle. Refuse here when the source
+    // identity cannot be resolved, rather than letting P->A->B->C succeed and then
+    // stranding the session at C with no way to produce a testReceiptPath.
+    // Guarded on --session: `loop init` without one writes the local artifact and
+    // binds nothing, so it keeps its current behaviour. Same condition the slug
+    // binding below uses.
+    if (typeof args.session === "string" && args.session.length > 0) {
+      const gate = checkBoundSourceIdentity(args.cwd, args.session);
+      if (!gate.ok) {
+        return { output: `loop init: ${gate.reason}\nNothing was written.`, code: 1 };
+      }
     }
     const plan = buildGoalplan({
       objective,

--- a/plugins/codexclaw/components/pabcd-state/dist/orchestrate-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/orchestrate-cli.js
@@ -22,6 +22,7 @@ import { canEnter, transition, isLegalEdge, VALID_TRANSITIONS } from "./fsm.js";
 import { validatePlanArtifacts } from "./plan-gate.js";
 import { compareSource, describeSource } from "./source-identity.js";
 import { resolveSessionSource } from "./session-source.js";
+import { checkBoundSourceIdentity } from "./source-gate.js";
 import { captureSessionSourceIdentity } from "./session-source-identity.js";
 import { randomBytes } from "node:crypto";
 
@@ -559,6 +560,25 @@ export function runOrchestrateCli(args                                          
   // Validate before any phase/goalplan writes; identity and artifact cwd stay native.
   try { resolveSessionSource(args.cwd, sessionId); }
   catch (err) { return { code: 1, output: `orchestrate ${args.verb}: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}` }; }
+  // #133: entry refusal for a goalplan-bound cycle with no resolvable source identity.
+  // Same neighbourhood as the SOURCE-ROOT check above and for the same reason: refuse
+  // before any phase or goalplan write. Without this, a bound non-git session enters P,
+  // passes A and B (B->C is deliberately fail-open), and strands at C because C->D
+  // needs a testReceiptPath that `receipt test` will not write.
+  // Guarded on state.slug — the same bound-session condition the work-phase gate and
+  // the receipt gate below already use — so unbound HITL cycles are untouched.
+  // ENTRY EDGES ONLY: IDLE->P and I->P. Not A->P, which is a re-plan inside a cycle
+  // that is already in flight — refusing that would strand the session rather than
+  // protect it, which is the opposite of the point. (Caught by review-deadlock.test.ts:96,
+  // whose A->P re-plan a `to === "P"`-only guard silently blocked.)
+  // The predicate is an UNRESOLVABLE SOURCE IDENTITY, never a missing `.git`: binding a
+  // git source worktree (#109) clears it, so the two fixes compose instead of fighting.
+  if (to === "P" && (state.phase === "IDLE" || state.phase === "I") && state.slug) {
+    const gate = checkBoundSourceIdentity(args.cwd, sessionId);
+    if (!gate.ok) {
+      return { code: 1, output: `orchestrate ${args.verb}: ${gate.reason}\nNothing was written.` };
+    }
+  }
   // P>A plan-artifact gate (260714 wp2, DIFFLEVEL-ROADMAP-01): the plan must
   // exist as numbered on-disk docs before Audit. Runs even when attest is null
   // so the FIRST error names planUnit. Fail-closed on this edge only.

--- a/plugins/codexclaw/components/pabcd-state/dist/source-gate.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/source-gate.js
@@ -1,0 +1,51 @@
+/**
+ * source-gate.ts — entry refusal for goalplan-bound cycles whose source identity
+ * cannot be resolved (#133).
+ *
+ * WHY AT ENTRY: the C->D gate (check-gate.ts) and `receipt test` (receipt-cli.ts) both
+ * refuse an `unavailable` identity, and that refusal is correct — CHECK-BINDING-01 is
+ * fail-closed and 075_receipt_binding.md forbids reading "I do not know" as
+ * "unchanged". But B->C is deliberately fail-open ("no git means no opinion"), so a
+ * bound session sails P->A->B->C and only discovers at C that it can never close.
+ * Plan, audit and implementation are already spent, and there is no exit. This gate
+ * moves the same verdict to the cheapest possible point.
+ *
+ * WHAT IT DOES NOT DO: it never tests for `.git`. The predicate is "the SOURCE identity
+ * is unavailable", so binding a git source worktree (#109) clears it without this file
+ * knowing anything about split cwds. Written the other way, this gate would reject the
+ * #109 case at the door and that fix would have to undo this one.
+ *
+ * Unbound sessions are untouched: they close D on checkOutput + exitCode and never
+ * enter the receipt path. Callers must only consult this for a BOUND session.
+ */
+import { captureSessionSourceIdentity } from "./session-source-identity.js";
+
+
+
+
+
+
+export function checkBoundSourceIdentity(cwd        , sessionId        )                   {
+  let kind        ;
+  try {
+    kind = captureSessionSourceIdentity(cwd, sessionId, { excludeCodexclawArtifacts: true }).kind;
+  } catch (err) {
+    // A thrown SOURCE-ROOT or binding error is also "cannot resolve".
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (kind !== "unavailable") return { ok: true };
+  return {
+    ok: false,
+    reason: [
+      "this workspace has no resolvable git source identity, and a goalplan-bound",
+      "cycle cannot be closed without one: C -> D requires a testReceiptPath",
+      "(CHECK-BINDING-01) and `cxc receipt test` refuses to write a receipt it cannot",
+      "bind to a commit.",
+      "",
+      "Pick one:",
+      "  - bind a git source tree:  cxc session source <absolute-path> --json",
+      "  - or run this cycle unbound (no `cxc loop init --session`), which closes D on",
+      "    checkOutput + exitCode alone.",
+    ].join("\n"),
+  };
+}

--- a/plugins/codexclaw/components/pabcd-state/dist/source-identity.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/source-identity.js
@@ -67,7 +67,19 @@ export function gitEnv(base                    = process.env)                   
 }
 
 function git(cwd        , args          )         {
-  return execFileSync("git", args, { cwd, env: gitEnv(), maxBuffer: 64 * 1024 * 1024 });
+  // stdio: stderr is PIPED, not inherited. Absent git is a normal, handled outcome
+  // here — captureSourceIdentity turns the throw into kind:"unavailable" — so its
+  // diagnostics must not be narrated to the user as if a command failed. Before this,
+  // every transition in a non-git workspace leaked `fatal: not a git repository`
+  // straight to the terminal, twice per gated edge (#133). session-source.ts:30 has
+  // always piped; this was the only caller that did not.
+  // stdout must stay "pipe": every caller reads the returned Buffer.
+  return execFileSync("git", args, {
+    cwd,
+    env: gitEnv(),
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 }
 
 /**

--- a/plugins/codexclaw/components/pabcd-state/src/goalplan-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/goalplan-cli.ts
@@ -43,6 +43,7 @@ import { resolve } from "node:path";
 import { isCanonicalSessionId, readState, writeState } from "./state.ts";
 import { captureSourceIdentity, compareSource } from "./source-identity.ts";
 import { captureSessionSourceIdentity } from "./session-source-identity.ts";
+import { checkBoundSourceIdentity } from "./source-gate.ts";
 import { resolveSessionSource } from "./session-source.ts";
 import { parseSourceBoundReceipt } from "./source-receipt.ts";
 import { applySteeringBatch } from "./steering.ts";
@@ -603,6 +604,18 @@ export function runGoalplanCli(args: GoalplanCliArgs): GoalplanCliResult {
     const existing = readGoalplan(args.cwd, slug);
     if (existing) {
       return { output: `loop init: a plan already exists at slug '${slug}' (use show/validate)`, code: 1 };
+    }
+    // #133: a BOUND plan promises a closable cycle. Refuse here when the source
+    // identity cannot be resolved, rather than letting P->A->B->C succeed and then
+    // stranding the session at C with no way to produce a testReceiptPath.
+    // Guarded on --session: `loop init` without one writes the local artifact and
+    // binds nothing, so it keeps its current behaviour. Same condition the slug
+    // binding below uses.
+    if (typeof args.session === "string" && args.session.length > 0) {
+      const gate = checkBoundSourceIdentity(args.cwd, args.session);
+      if (!gate.ok) {
+        return { output: `loop init: ${gate.reason}\nNothing was written.`, code: 1 };
+      }
     }
     const plan = buildGoalplan({
       objective,

--- a/plugins/codexclaw/components/pabcd-state/src/orchestrate-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/orchestrate-cli.ts
@@ -22,6 +22,7 @@ import { canEnter, transition, isLegalEdge, VALID_TRANSITIONS } from "./fsm.ts";
 import { validatePlanArtifacts } from "./plan-gate.ts";
 import { compareSource, describeSource } from "./source-identity.ts";
 import { resolveSessionSource } from "./session-source.ts";
+import { checkBoundSourceIdentity } from "./source-gate.ts";
 import { captureSessionSourceIdentity } from "./session-source-identity.ts";
 import { randomBytes } from "node:crypto";
 
@@ -559,6 +560,25 @@ export function runOrchestrateCli(args: OrchestrateCliArgs | OrchestrateCliHelpA
   // Validate before any phase/goalplan writes; identity and artifact cwd stay native.
   try { resolveSessionSource(args.cwd, sessionId); }
   catch (err) { return { code: 1, output: `orchestrate ${args.verb}: SOURCE-ROOT: ${err instanceof Error ? err.message : String(err)}` }; }
+  // #133: entry refusal for a goalplan-bound cycle with no resolvable source identity.
+  // Same neighbourhood as the SOURCE-ROOT check above and for the same reason: refuse
+  // before any phase or goalplan write. Without this, a bound non-git session enters P,
+  // passes A and B (B->C is deliberately fail-open), and strands at C because C->D
+  // needs a testReceiptPath that `receipt test` will not write.
+  // Guarded on state.slug — the same bound-session condition the work-phase gate and
+  // the receipt gate below already use — so unbound HITL cycles are untouched.
+  // ENTRY EDGES ONLY: IDLE->P and I->P. Not A->P, which is a re-plan inside a cycle
+  // that is already in flight — refusing that would strand the session rather than
+  // protect it, which is the opposite of the point. (Caught by review-deadlock.test.ts:96,
+  // whose A->P re-plan a `to === "P"`-only guard silently blocked.)
+  // The predicate is an UNRESOLVABLE SOURCE IDENTITY, never a missing `.git`: binding a
+  // git source worktree (#109) clears it, so the two fixes compose instead of fighting.
+  if (to === "P" && (state.phase === "IDLE" || state.phase === "I") && state.slug) {
+    const gate = checkBoundSourceIdentity(args.cwd, sessionId);
+    if (!gate.ok) {
+      return { code: 1, output: `orchestrate ${args.verb}: ${gate.reason}\nNothing was written.` };
+    }
+  }
   // P>A plan-artifact gate (260714 wp2, DIFFLEVEL-ROADMAP-01): the plan must
   // exist as numbered on-disk docs before Audit. Runs even when attest is null
   // so the FIRST error names planUnit. Fail-closed on this edge only.

--- a/plugins/codexclaw/components/pabcd-state/src/source-gate.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/source-gate.ts
@@ -1,0 +1,51 @@
+/**
+ * source-gate.ts — entry refusal for goalplan-bound cycles whose source identity
+ * cannot be resolved (#133).
+ *
+ * WHY AT ENTRY: the C->D gate (check-gate.ts) and `receipt test` (receipt-cli.ts) both
+ * refuse an `unavailable` identity, and that refusal is correct — CHECK-BINDING-01 is
+ * fail-closed and 075_receipt_binding.md forbids reading "I do not know" as
+ * "unchanged". But B->C is deliberately fail-open ("no git means no opinion"), so a
+ * bound session sails P->A->B->C and only discovers at C that it can never close.
+ * Plan, audit and implementation are already spent, and there is no exit. This gate
+ * moves the same verdict to the cheapest possible point.
+ *
+ * WHAT IT DOES NOT DO: it never tests for `.git`. The predicate is "the SOURCE identity
+ * is unavailable", so binding a git source worktree (#109) clears it without this file
+ * knowing anything about split cwds. Written the other way, this gate would reject the
+ * #109 case at the door and that fix would have to undo this one.
+ *
+ * Unbound sessions are untouched: they close D on checkOutput + exitCode and never
+ * enter the receipt path. Callers must only consult this for a BOUND session.
+ */
+import { captureSessionSourceIdentity } from "./session-source-identity.ts";
+
+export interface SourceGateResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export function checkBoundSourceIdentity(cwd: string, sessionId: string): SourceGateResult {
+  let kind: string;
+  try {
+    kind = captureSessionSourceIdentity(cwd, sessionId, { excludeCodexclawArtifacts: true }).kind;
+  } catch (err) {
+    // A thrown SOURCE-ROOT or binding error is also "cannot resolve".
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (kind !== "unavailable") return { ok: true };
+  return {
+    ok: false,
+    reason: [
+      "this workspace has no resolvable git source identity, and a goalplan-bound",
+      "cycle cannot be closed without one: C -> D requires a testReceiptPath",
+      "(CHECK-BINDING-01) and `cxc receipt test` refuses to write a receipt it cannot",
+      "bind to a commit.",
+      "",
+      "Pick one:",
+      "  - bind a git source tree:  cxc session source <absolute-path> --json",
+      "  - or run this cycle unbound (no `cxc loop init --session`), which closes D on",
+      "    checkOutput + exitCode alone.",
+    ].join("\n"),
+  };
+}

--- a/plugins/codexclaw/components/pabcd-state/src/source-identity.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/source-identity.ts
@@ -67,7 +67,19 @@ export function gitEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv
 }
 
 function git(cwd: string, args: string[]): Buffer {
-  return execFileSync("git", args, { cwd, env: gitEnv(), maxBuffer: 64 * 1024 * 1024 });
+  // stdio: stderr is PIPED, not inherited. Absent git is a normal, handled outcome
+  // here — captureSourceIdentity turns the throw into kind:"unavailable" — so its
+  // diagnostics must not be narrated to the user as if a command failed. Before this,
+  // every transition in a non-git workspace leaked `fatal: not a git repository`
+  // straight to the terminal, twice per gated edge (#133). session-source.ts:30 has
+  // always piped; this was the only caller that did not.
+  // stdout must stay "pipe": every caller reads the returned Buffer.
+  return execFileSync("git", args, {
+    cwd,
+    env: gitEnv(),
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 }
 
 /**

--- a/plugins/codexclaw/components/pabcd-state/test/goalplan.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/goalplan.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, existsSync, readFileSync, mkdirSync, rmSync, writeFileSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -39,6 +40,26 @@ function escapeRe(text: string): string {
 
 function tmp(): string {
   return mkdtempSync(join(tmpdir(), "cxc-goalplan-"));
+}
+
+/**
+ * A temp cwd that is a real Git repository.
+ *
+ * #133: `loop init --session` now refuses a workspace with no resolvable git source
+ * identity, because a BOUND plan promises a closable cycle and C->D cannot produce a
+ * testReceiptPath without one. A bare `tmp()` is exactly the trap that issue describes,
+ * so any test that binds a session needs a repository rather than an empty directory.
+ * `loop init` WITHOUT --session is unaffected and keeps using tmp().
+ */
+function tmpRepo(): string {
+  const cwd = tmp();
+  const env = { ...process.env, GIT_CONFIG_GLOBAL: join(cwd, "gitconfig"), GIT_CONFIG_SYSTEM: join(cwd, "gitconfig") };
+  const git = (...args: string[]) => execFileSync("git", args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+  git("init", "-q");
+  writeFileSync(join(cwd, "seed.txt"), "seed\n");
+  git("add", "seed.txt");
+  git("-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "seed");
+  return cwd;
 }
 
 test("030: schema round-trips (write then read returns an equal Goalplan)", () => {
@@ -601,7 +622,7 @@ test("030.2: unknown verb -> parse error; show/validate need a slug source", () 
 });
 
 test("030.3: init --session persists the derived slug into that session's state", () => {
-  const cwd = tmp();
+  const cwd = tmpRepo(); // #133: binding a session requires a resolvable source identity
   const args = parseGoalplanCliArgs(["init", "--objective", "Bound objective", "--session", "sess-1"], cwd);
   assert.ok(!("error" in args));
   assert.equal((args as any).session, "sess-1");

--- a/plugins/codexclaw/components/pabcd-state/test/nongit-bound-cycle.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/nongit-bound-cycle.test.ts
@@ -1,0 +1,112 @@
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// #133 integration. A goalplan-bound cycle in a NON-GIT workspace used to sail
+// P->A->B->C and then strand at C forever, because C->D needs a testReceiptPath and
+// `receipt test` refuses to write a receipt it cannot bind to a commit. Meanwhile every
+// transition leaked `fatal: not a git repository` to the terminal.
+//
+// These run the REAL CLI as a child process. That is load-bearing for case 3: the leak
+// was execFileSync inheriting the PARENT stderr, so in-process it would land on the test
+// runner own stderr and never appear in a returned string - the assertion would pass
+// while the bug was fully present.
+const CLI = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+const SESSION = "019a0000-0000-7000-8000-000000000133";
+// The standalone-terminal session id. `orchestrate` requires existing session state,
+// and its own error names `cli` as the id to use outside a native Codex session.
+// `loop init` does not require pre-existing state, so SESSION is fine there.
+const TERM = "cli";
+
+function probe(t: TestContext): string {
+  const cwd = mkdtempSync(join(tmpdir(), "cxc-nongit-cycle-"));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  // Sanity: the fixture must NOT be inside a repository, or the test proves nothing.
+  const inside = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], { cwd, encoding: "utf8" });
+  assert.notEqual(inside.status, 0, "fixture is inside a git repository");
+  return cwd;
+}
+
+function cxc(cwd: string, args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const res = spawnSync(process.execPath, ["--experimental-strip-types", CLI, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, CODEX_HOME: join(cwd, "codexhome") },
+  });
+  return { status: res.status, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+function attest(cwd: string, body: Record<string, unknown>): string[] {
+  const path = join(cwd, "attest.json");
+  writeFileSync(path, JSON.stringify(body));
+  return ["--attest-file", path];
+}
+
+test("a bound cycle in a non-git workspace is refused at loop init and writes nothing", t => {
+  const cwd = probe(t);
+  const res = cxc(cwd, ["loop", "init", "--objective", "bound probe in a non-git tree", "--session", SESSION, "--criterion", "probe closes a cycle"]);
+  assert.equal(res.status, 1);
+  // Actionable, with BOTH exits named.
+  assert.match(res.stdout, /no resolvable git source identity/);
+  assert.match(res.stdout, /cxc session source/);
+  assert.match(res.stdout, /unbound/);
+  assert.match(res.stdout, /Nothing was written/);
+  // The trap must never be built in the first place.
+  assert.equal(existsSync(join(cwd, ".codexclaw", "goalplans")), false);
+});
+
+// The regression guard. This layer must NOT tighten the unbound contract: an unbound
+// cycle closes D on checkOutput + exitCode alone and never touches the receipt path.
+test("an unbound cycle in the same non-git workspace still closes D to IDLE", t => {
+  const cwd = probe(t);
+  const unit = join("devlog", "_plan", "260911_probe");
+  mkdirSync(join(cwd, unit), { recursive: true });
+  writeFileSync(join(cwd, unit, "000_plan.md"), "# probe plan\n\nobjective and constraints.\n");
+
+  const toP = cxc(cwd, ["orchestrate", "P", "--session", TERM]);
+  assert.equal(toP.status, 0, toP.stdout + toP.stderr);
+  const toA = cxc(cwd, ["orchestrate", "A", "--session", TERM, ...attest(cwd, {
+    from: "P", to: "A", did: "wrote the probe plan", planUnit: unit.replaceAll("\\", "/"),
+  })]);
+  assert.equal(toA.status, 0, toA.stdout + toA.stderr);
+  const toB = cxc(cwd, ["orchestrate", "B", "--session", TERM, ...attest(cwd, {
+    from: "A", to: "B", did: "folded nothing", auditOutput: "VERDICT: PASS", auditVerdict: "pass",
+  })]);
+  assert.equal(toB.status, 0, toB.stdout + toB.stderr);
+  const toC = cxc(cwd, ["orchestrate", "C", "--session", TERM, ...attest(cwd, {
+    from: "B", to: "C", did: "implemented the probe",
+  })]);
+  assert.equal(toC.status, 0, toC.stdout + toC.stderr);
+  const toD = cxc(cwd, ["orchestrate", "D", "--session", TERM, ...attest(cwd, {
+    from: "C", to: "D", did: "verified the probe", checkOutput: "probe ok", exitCode: 0,
+  })]);
+  assert.equal(toD.status, 0, toD.stdout + toD.stderr);
+  assert.match(toD.stdout, /IDLE|cycle closed/);
+
+  const status = cxc(cwd, ["orchestrate", "status", "--session", TERM]);
+  assert.match(status.stdout, /phase=IDLE/);
+});
+
+// #133 second half. Before the fix, source-identity git() inherited stderr, so B->C and
+// C each emitted `fatal: not a git repository` even though the transition SUCCEEDED.
+test("no git fatal line reaches user output on any transition", t => {
+  const cwd = probe(t);
+  const unit = join("devlog", "_plan", "260911_probe");
+  mkdirSync(join(cwd, unit), { recursive: true });
+  writeFileSync(join(cwd, unit, "000_plan.md"), "# probe plan\n\nobjective and constraints.\n");
+
+  const runs = [
+    cxc(cwd, ["orchestrate", "P", "--session", TERM]),
+    cxc(cwd, ["orchestrate", "A", "--session", TERM, ...attest(cwd, { from: "P", to: "A", did: "plan", planUnit: unit.replaceAll("\\", "/") })]),
+    cxc(cwd, ["orchestrate", "B", "--session", TERM, ...attest(cwd, { from: "A", to: "B", did: "audit", auditOutput: "VERDICT: PASS", auditVerdict: "pass" })]),
+    cxc(cwd, ["orchestrate", "C", "--session", TERM, ...attest(cwd, { from: "B", to: "C", did: "build" })]),
+  ];
+  for (const [i, res] of runs.entries()) {
+    assert.doesNotMatch(res.stderr, /^fatal:/m, `transition ${i} leaked git stderr: ${res.stderr}`);
+    assert.doesNotMatch(res.stdout, /^fatal:/m, `transition ${i} leaked git stdout: ${res.stdout}`);
+  }
+});

--- a/plugins/codexclaw/components/pabcd-state/test/source-gate.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/source-gate.test.ts
@@ -1,0 +1,53 @@
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkBoundSourceIdentity } from "../src/source-gate.ts";
+
+const SESSION = "019a0000-0000-7000-8000-000000000001";
+
+function dir(t: TestContext, prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  t.after(() => rmSync(d, { recursive: true, force: true }));
+  return d;
+}
+
+function initRepo(cwd: string): void {
+  const env = { ...process.env, GIT_CONFIG_GLOBAL: join(cwd, "gitconfig"), GIT_CONFIG_SYSTEM: join(cwd, "gitconfig") };
+  const git = (...args: string[]) => execFileSync("git", args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+  git("init", "-q");
+  writeFileSync(join(cwd, "tracked.txt"), "x\n");
+  git("add", "tracked.txt");
+  git("-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init");
+}
+
+// #133: the predicate is "the SOURCE identity is unavailable", NOT "there is no .git".
+// Written the other way it would reject the #109 split-cwd case at the door and the
+// #109 fix would have to undo this gate.
+test("a non-git workspace has no resolvable source identity", t => {
+  const cwd = dir(t, "cxc-gate-nongit-");
+  const res = checkBoundSourceIdentity(cwd, SESSION);
+  assert.equal(res.ok, false);
+  // The message must offer both exits, or the user is told to stop without being told how.
+  assert.match(res.reason ?? "", /cxc session source/);
+  assert.match(res.reason ?? "", /unbound/);
+  assert.match(res.reason ?? "", /CHECK-BINDING-01/);
+});
+
+test("a clean git workspace resolves", t => {
+  const cwd = dir(t, "cxc-gate-git-");
+  initRepo(cwd);
+  assert.equal(checkBoundSourceIdentity(cwd, SESSION).ok, true);
+});
+
+// Dirty is a RESOLVED identity. Confusing "dirty" with "unavailable" would refuse every
+// real working session, which is the failure mode this case exists to prevent.
+test("a dirty git workspace still resolves", t => {
+  const cwd = dir(t, "cxc-gate-dirty-");
+  initRepo(cwd);
+  writeFileSync(join(cwd, "tracked.txt"), "changed\n");
+  writeFileSync(join(cwd, "untracked.txt"), "new\n");
+  assert.equal(checkBoundSourceIdentity(cwd, SESSION).ok, true);
+});


### PR DESCRIPTION
Layer **L4** of the Windows issue sweep stack. Base is **L3** (`codex/fix-config-guard-help`). `enforce-target` will flag the non-`dev` base; expected for a manual chain.

Closes #133. **Does not close #109** — that is L5, deliberately separate.

## The bug

A goalplan-bound PABCD cycle in a non-git workspace was **permanently stuck at C**. `C -> D` requires a `testReceiptPath`, and `cxc receipt test` refuses to write a receipt it cannot bind to a commit. But `B -> C` is deliberately fail-open ("no git means no opinion"), so the cycle sailed `P -> A -> B -> C` and only then discovered it could never close — after plan, audit and implementation were all spent, with no exit.

Separately, `source-identity.ts` `git()` inherited stderr, so `fatal: not a git repository` leaked to the terminal on transitions that **succeeded**.

## The fix

1. `git()` pipes stderr. Absent git is a handled outcome here — `captureSourceIdentity` turns the throw into `kind: "unavailable"` — so its diagnostics must not be narrated as a failure. `session-source.ts:30` had always piped; this was the only caller that did not.
2. New `src/source-gate.ts` refuses at entry, at two agent-gated points: `loop init` (before `buildGoalplan`) and `IDLE|I -> P`.

## The predicate is the whole design

The refusal fires on **an unresolvable SOURCE identity**, never on a missing `.git`. Written the other way it would reject #109's split-cwd case at the door and L5 would have to undo this layer. Written this way they compose: once L5 lets a non-git cwd bind a git source, the same call returns `resolved` and this gate switches itself off. An independent reviewer confirmed that composition against both plans.

`check-gate.ts` and `receipt-cli.ts` are untouched. `unavailable` still refuses. This layer adds an earlier refusal, never a way through.

## Two corrections the existing suite forced

Both found by running the 1226-test `pabcd-state` suite against the first implementation.

**The guard covers entry edges only.** `A -> P` also has `to === "P"`, so a `to === "P"` guard silently blocked a re-plan — `review-deadlock.test.ts:96` stuck at `in_flight` instead of `inconclusive`. A re-plan is not an entry: the cycle is already in flight and already bound, and refusing it **strands** the session. Now `(state.phase === "IDLE" || state.phase === "I")`. The audit flagged `I -> P` as needing inclusion; nobody considered `A -> P` until the suite said so.

**The fixtures had normalised the trap.** `goalplan.test.ts:603` binds a session in a bare `mkdtempSync` directory — precisely the non-git-plus-bound-plan combination this issue is about. The fixture was silently asserting that binding a plan into an unclosable workspace is fine. Fixed with a `tmpRepo()` helper used only by tests that actually bind; the without-`--session` test keeps the bare `tmp()` and doubles as the regression guard for the guarded-on-session rule. Part of why #133 survived is that the suite treated the trap as normal.

## Verification

```
pabcd-state suite: 1226 tests, 1224 passed, 0 failed, 2 skipped
npm run build: 181 files compiled, layout validated
npm run gate: OK
inventory --check --tests 3055: OK
```

Live, in a fresh non-git temp directory, before any test existed:

```
$ cxc loop init --objective ... --session <id> --criterion ...
loop init: this workspace has no resolvable git source identity, and a goalplan-bound
cycle cannot be closed without one: C -> D requires a testReceiptPath ...
Pick one:
  - bind a git source tree:  cxc session source <absolute-path> --json
  - or run this cycle unbound (no `cxc loop init --session`) ...
exit=1   goalplans dir created? false   stderr: ""

$ cxc loop init --objective ... --criterion ...     # no --session
exit=0   (unchanged)
```

`nongit-bound-cycle.test.ts` **spawns a real child process**, which is load-bearing: the leak was `execFileSync` inheriting the *parent's* stderr, so an in-process call would land it on the test runner's own stderr and the assertion would pass while the bug was fully present.

## Known coverage limit

Both insertion points are on the agent-gated CLI path. A line-anchored chat `orchestrate P` reaches `applyHumanTransition` without passing them, so a human can still enter P on a bound non-git session. Accepted, not overlooked — the human free-pass is deliberately ungated across this surface and closing it is a separate contract change.

`dist/source-gate.js` is a new file and `.gitignore:2` ignores `dist/`, so it required `git add -f`.

Plan: `devlog/_plan/260911_windows_issue_sweep/040_wp5_nongit_early_refusal.md`.
