### PR TITLE
fix(sweep): route the GUI and serve provider probes through win-exec and unblock dev-install (L5)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C055_passing-brightgreen" alt="3,055 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C057_passing-brightgreen" alt="3,057 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C055_passing-brightgreen" alt="3,055 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C057_passing-brightgreen" alt="3,057 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C055_passing-brightgreen" alt="3,055 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C057_passing-brightgreen" alt="3,057 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_windows_issue_sweep/000_plan.md
+++ b/devlog/_plan/260911_windows_issue_sweep/000_plan.md
@@ -66,11 +66,25 @@ Bottom to top. Each layer PR bases on the layer below; merge bottom-up.
 | L2 | `codex/fix-session-binding-extended-path` | L1 | wp3 | #134 |
 | L3 | `codex/fix-config-guard-help` | L2 | wp4 | #132 |
 | L4 | `codex/fix-nongit-early-refusal` | L3 | wp5 | #133 |
-| L5 | `codex/fix-split-cwd-source` | L4 | wp8 | #109 |
-| L6 | `codex/windows-landmine-sweep` | L5 | wp6 | — (corpus sweep) |
+| L5 | `codex/windows-landmine-sweep` | L4 | wp6 | — (corpus sweep) |
+| L6 | `codex/fix-split-cwd-source` | L5 | wp8 | #109 |
 
 wp7 is integration only: it adds no layer, it turns the chain green and ships it.
-Execution order is wp1, wp2, wp3, wp4, wp5, wp8, wp6, wp7.
+Execution order is wp1, wp2, wp3, wp4, wp5, **wp6, wp8**, wp7.
+
+**Revision 3 swapped wp6 and wp8.** Revision 2 put #109 at L5 and the sweep at L6. The
+bound goalplan disagreed: `wp6` and `wp8` both depend only on `wp5`, so after wp5
+closed, `effectiveActiveWorkPhaseId` selected `wp6` by declaration order and the gated
+edge refused a `wp8` attest outright. Rather than fight the persisted plan, the layer
+order follows it, because the swap is harmless: the sweep writes `gui/src/server`,
+`messenger-bridge/src` and `config-guard/src`, while #109 writes only
+`pabcd-state/src/session-source.ts`, so neither can conflict with the other in either
+order. Revision 2's stated reason for putting the sweep last — that its findings may touch
+files the lower layers moved — is about L1 and L3, both of which sit below either
+arrangement.
+
+What actually protects #109 from being skipped is not the ordering but the wp7 entry
+gate: integration must not start until `c-8` is met. That gate is unchanged.
 
 ### Goalplan drift notice (read before following the bound plan)
 
@@ -79,12 +93,18 @@ titles and dependency edges are append-only — they cannot be rewritten. Three
 entries therefore disagree with this document, and **this document governs**:
 
 - `wp5` is titled `issues 133 and 109`. It covers **#133 only**.
-- `wp6` is titled `Stack L5` and does not depend on `wp8`. It is **L6** and
-  must run after `wp8`.
-- `wp7` does not depend on `wp8`. It must not start until `wp8` is done.
+- `wp6` is titled `Stack L5` and, as of revision 3, that is now correct: the sweep IS
+  L5. Revision 2 had it at L6; see "Revision 3 swapped wp6 and wp8" above for why the
+  layer order follows the persisted plan rather than the other way round.
+- `wp8` is titled `Stack L5b`. It is **L6**.
+- `wp7` does not depend on `wp8`. **It must not start until `wp8` is done.** This is
+  the one drift that still bites, and it is the only thing standing between the loop and
+  reaching integration without ever closing #109.
 
-Following the raw goalplan edges would let the loop reach integration without ever
-closing #109. A `loop steer` annotation records this correction in the ledger.
+The `loop steer` annotation recorded in the ledger names the revision-2 order. Where it
+and this document disagree, **this document governs**, and the substance that matters is
+unchanged in both: `wp5` closes #133 only, `wp8` closes #109, and `wp7` waits for
+`c-8`.
 
 ### Why a chain, and where it is genuinely required
 

--- a/devlog/_plan/260911_windows_issue_sweep/045_wp8_split_cwd_source.md
+++ b/devlog/_plan/260911_windows_issue_sweep/045_wp8_split_cwd_source.md
@@ -170,6 +170,56 @@ native that comparison is meaningless and must be skipped, using the same probe:
 Read the exact surrounding lines before patching; `:91` is the tail of a multi-line
 condition.
 
+### 5.4 Exact anchors, resolved at L4 head `96e9486a`
+
+**Correction to §5.3's naming.** There is no `verifyBinding` function. The re-derivation on
+every resolve lives in `resolveSessionSource` itself, and the comparison to relax is at
+`session-source.ts:91`, the tail of a four-clause condition:
+
+```ts
+// session-source.ts:80-95
+export function resolveSessionSource(cwd: string, sessionId: string): string {
+  const binding = readBinding(cwd, sessionId);
+  const pinned = readState(cwd, sessionId).boundSourceRoot;
+  if (!binding) {
+    if (pinned) throw new Error("Source binding is missing for the pinned worktree; restore the same binding before continuing.");
+    return cwd;
+  }
+  if (pinned && binding.sourceRoot !== pinned) throw new Error("Source binding differs from the session's pinned worktree.");
+  const native = gitIdentity(cwd);
+  const source = gitIdentity(binding.sourceRoot);
+  if (source.root !== binding.sourceRoot || source.commonDir !== binding.commonDir
+      || source.gitDir !== binding.gitDir || native.commonDir !== binding.commonDir) {
+    throw new Error("Bound source worktree moved or its repository identity changed.");
+  }
+  return binding.sourceRoot;
+}
+```
+
+Note `:88`: `gitIdentity(cwd)` **throws** for a non-git native cwd, so resolve fails before
+the comparison is even reached. Both `:88` and the `native.commonDir` clause at `:91` must
+become conditional, and the other three clauses must stay — they are what detect a moved
+or re-pointed source.
+
+**`bindSessionSource`** is `:98`, and the guard to widen is `:102-105`:
+
+```ts
+  const nativeCwd = canonical(cwd);
+  const sourceRoot = canonical(target);
+  const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
+  if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
+    throw new Error("Source must be a linked worktree root in the native session's repository.");
+  }
+```
+
+`canonical()` already exists at `:22-24` using `realpathSync.native`, so the ancestor
+comparison in §5.2 gets Windows extended-length and 8.3 handling for free. `gitIdentity`
+is `:26` and already pipes stderr and strips `GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR`/
+`GIT_INDEX_FILE`, so the non-throwing probe can wrap it without losing either property.
+
+The immutability path (`:106-110`) and the phase guard are downstream of the widened
+check and need no change.
+
 ## 6. What is deliberately NOT changed
 
 - `check-gate.ts` and `receipt-cli.ts`: untouched. `unavailable` still refuses.

--- a/devlog/_plan/260911_windows_issue_sweep/050_wp6_windows_landmine_sweep.md
+++ b/devlog/_plan/260911_windows_issue_sweep/050_wp6_windows_landmine_sweep.md
@@ -1,104 +1,62 @@
-# 050 — WP6 / L6: Windows landmine corpus sweep
+# 050 — wp6 / L5 / Windows landmine sweep
 
-Layer: L6. Branch: `codex/windows-landmine-sweep`. Base: L5 `codex/fix-split-cwd-source` (after L1–L5). Work-phase: wp6. Criteria: **c-11** (every risk=high corpus finding in this stack) and the "every copy" clause of **c-9** (GUI + serve provider endpoints report provider, never error from the #131 spawn bugs).
+Branch `codex/windows-landmine-sweep`, base **L4** (`codex/fix-nongit-early-refusal`, `96e9486a`).
+Criteria **c-11** and the "every copy" half of **c-9**.
 
-Scope is the six-row table in `000_plan.md` "Corpus sweep scope". Do not expand it. Deferred (risk=medium, out of this issue set — do not touch): `messenger-bridge/src/service.ts:245` BOM-less `.cmd`; `payload-bin.test.mjs:72` and `live-catalog.test.ts:79` colon-PATH fixtures.
+Revision 2. Revision 1 was audited and returned FAIL on three structural errors, all
+folded here: its `after` blocks propagated a design L1 did not ship, its Row 5 line
+numbers pointed at the wrong function, and its header had the stack order backwards.
 
-`build.mjs` allows only `node:*` and relative imports inside a component. Copy helpers; do not import `cxc-ops`. GUI is not a `build.mjs` component and already relative-imports other packages, but this layer still copies. messenger-bridge already has `src/win-exec.ts` (re-export of `subagent-config/dist/win-exec.js`); reuse that `commandInvocation`, do not add a second copy.
+## 1. Scope, fixed by preflight rather than by code review
 
-L3 (`030`) also edits `config-guard/src/cli.ts`. If `makeRealRunner` has moved by L5, apply the same substitution in place. Do not create a second runner.
+Every row below was produced by running the fuck-powershell corpus preflight against
+this repository's Windows execution surfaces, then mapping each finding to a corpus case.
+Findings that map to no case were dropped; this is not a general code review.
 
-The `where` selector is the L1 helper from `010` (`selectExecutableFromWhereOutput`). Copy the function into each spawn site; do not add it to `win-exec.ts` (that would fail SHARED-HELPER-01 byte identity).
+| # | path:line | corpus case | risk | disposition |
+|---|---|---|---|---|
+| 1 | `gui/src/server/middleware.ts:75` | `get-command-where-disagree` | high | fix |
+| 2 | `gui/src/server/middleware.ts:79` | `spawn-npm-enoent-einval` | high | fix |
+| 3 | `messenger-bridge/src/api-compat.ts:40` | `get-command-where-disagree` | high | fix |
+| 4 | `messenger-bridge/src/api-compat.ts:45` | `spawn-npm-enoent-einval` | high | fix |
+| 5 | `config-guard/src/cli.ts:141` | `spawn-npm-enoent-einval`, `windowsapps-alias-eperm` | medium | **defer**, §7 |
+| 6 | `gui/src/server/middleware.ts:88` | `windowsapps-alias-eperm` | medium | fix |
+| 7 | `scripts/dev-install.sh:44-50` | `windowsapps-alias-eperm` + `pathext-bare-name-enoent` | high | fix |
 
-## Change list
+Rows 1-4 are **three more live copies of #131**. Fixing `provider-bridge` alone (L1) leaves
+the GUI `/api/provider` endpoint and the `cxc serve` provider endpoint reporting `error`
+on this host. That is why c-9 says "in every copy".
 
-- NEW `plugins/codexclaw/gui/src/server/win-exec.ts`
-- NEW `plugins/codexclaw/gui/src/server/codex-bin.ts`
-- NEW `plugins/codexclaw/gui/test/codex-bin.test.ts`
-- NEW `plugins/codexclaw/components/config-guard/src/win-exec.ts`
-- NEW `plugins/codexclaw/components/config-guard/src/codex-bin.ts`
-- NEW `plugins/codexclaw/components/config-guard/test/codex-bin.test.ts`
-- NEW `plugins/codexclaw/components/config-guard/dist/win-exec.js` (build output; `git add -f`)
-- NEW `plugins/codexclaw/components/config-guard/dist/codex-bin.js` (build output; `git add -f`)
-- MODIFY `plugins/codexclaw/gui/src/server/middleware.ts`
-- MODIFY `plugins/codexclaw/gui/test/crlf-where.test.ts`
-- MODIFY `plugins/codexclaw/components/messenger-bridge/src/api-compat.ts`
-- MODIFY `plugins/codexclaw/components/messenger-bridge/test/crlf-where.test.ts`
-- MODIFY `plugins/codexclaw/components/messenger-bridge/dist/api-compat.js` (restage after build; already tracked)
-- MODIFY `plugins/codexclaw/components/config-guard/src/cli.ts`
-- MODIFY `plugins/codexclaw/components/config-guard/dist/cli.js` (restage after build; already tracked)
-- DELETE none (the `splitLines` import in the two detectDeps sites becomes unused and is removed as part of those MODIFY after-blocks)
+## 2. Change map
 
-## NEW copies of win-exec.ts and codex-bin.ts
+| file | NEW/MODIFY/DELETE | change |
+|---|---|---|
+| `plugins/codexclaw/gui/src/server/middleware.ts` | MODIFY | rows 1, 2, 6 — import the existing helpers directly |
+| `plugins/codexclaw/gui/test/crlf-where.test.ts` | MODIFY | its premise ("the exact expression detectDeps now uses") stops being true |
+| `plugins/codexclaw/components/messenger-bridge/src/api-compat.ts` | MODIFY | rows 3, 4 — use the package's existing `./win-exec.ts` re-export |
+| `plugins/codexclaw/components/messenger-bridge/test/crlf-where.test.ts` | MODIFY | same premise expiry as the gui twin; see §8.2 |
+| `plugins/codexclaw/components/messenger-bridge/dist/api-compat.js` | MODIFY | `npm run build`, already tracked |
+| `scripts/dev-install.sh` | MODIFY | row 7 — read the manifest with node, not python3 |
 
-Byte-identical copies. Do not retype.
+**No new `win-exec.ts` copies.** Revision 1 called for one in `gui` and one in
+`messenger-bridge`, and both were wrong:
 
-```
+- `gui` is a Vite package, not a component. `middleware.ts:17-19` already imports
+  `../../../components/provider-bridge/src/detect.ts` and two `config-guard` sources, and
+  `gui/vite.config.ts` imposes no boundary. It imports the existing helpers directly.
+- `messenger-bridge/src/win-exec.ts` already exists as a two-line re-export of
+  `../../subagent-config/dist/win-exec.js`. A second copy in the same package would be
+  pure drift surface.
 
-## L1 helper (paste into both detectDeps files)
+So this layer adds **zero** copies of that module. Revision 1's regression section claimed
+"eight places"; the real count stays at four byte-identical copies plus one re-export,
+plus L1's `provider-bridge` copy.
 
-Copy from 010's `cli.ts` after-block. Export it. Do not put it in `win-exec.ts`.
+## 3. Rows 1 and 2 — `gui/src/server/middleware.ts` `detectDeps()`
 
-```ts
-const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
-
-function whereLines(stdout: string): string[] {
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
-
-function pathExt(filePath: string): string {
-  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
-}
-
-function pathextList(pathext: string | undefined): string[] {
-  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
-  return raw
-    .split(";")
-    .map((ext) => ext.trim().toLowerCase())
-    .filter((ext) => ext.length > 0);
-}
-
-export function selectExecutableFromWhereOutput(
-  stdout: string,
-  options: { platform: NodeJS.Platform; pathext?: string },
-): string | null {
-  const lines = whereLines(stdout);
-  if (lines.length === 0) return null;
-  if (options.platform !== "win32") return lines[0] ?? null;
-  const allowed = pathextList(options.pathext);
-  const match = lines.find((line) => {
-    const ext = pathExt(line);
-    return ext.length > 0 && allowed.includes(ext);
-  });
-  return match ?? lines[0] ?? null;
-}
-```
-
-gui: add `extname` to `middleware.ts:23` (`import { dirname, join } from "node:path"` → `import { dirname, extname, join } from "node:path"`).
-messenger-bridge: add `import { extname } from "node:path";` next to the spawnSync import.
-
-## Row 1 — gui/src/server/middleware.ts:75 (get-command-where-disagree)
-
-Before `middleware.ts:20-21`:
+before (`:67-83`):
 
 ```ts
-import { spawnSync } from "node:child_process";
-import { splitLines } from "./text-lines.ts";
-```
-
-Before `middleware.ts:23`:
-
-```ts
-import { dirname, join } from "node:path";
-```
-
-Before `middleware.ts:66-77`:
-
-```ts
-// Real ocx detection deps for the dev server (detect-only).
 function detectDeps() {
   return {
     which: (cmd: string) => {
@@ -110,236 +68,110 @@ function detectDeps() {
       const out = res.status === 0 && typeof res.stdout === "string" ? splitLines(res.stdout)[0]?.trim() ?? "" : null;
       return out && out.length > 0 ? out : null;
     },
+    runStatus: (ocxPath: string) => {
+      const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+      return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
+    },
+  };
+}
 ```
 
-After imports (delete splitLines; keep spawnSync; add win-exec + codex-bin + extname):
-
-```ts
-import { spawnSync } from "node:child_process";
-import { dirname, extname, join } from "node:path";
-import { commandInvocation, envValue } from "./win-exec.ts";
-import { resolveCodexInvocation } from "./codex-bin.ts";
-```
-
-After `which` (paste the L1 helper above `detectDeps`):
+after — **this mirrors what L1 actually shipped** (`provider-bridge/src/cli.ts`), which
+deletes the `where` parsing on win32 rather than picking a better line out of it:
 
 ```ts
 function detectDeps() {
   return {
     which: (cmd: string) => {
-      const res = spawnSync(process.platform === "win32" ? "where" : "command", process.platform === "win32" ? [cmd] : ["-v", cmd], {
-        encoding: "utf8",
-        shell: process.platform !== "win32",
-      });
-      if (res.status !== 0 || typeof res.stdout !== "string") return null;
-      return selectExecutableFromWhereOutput(res.stdout, {
-        platform: process.platform,
-        pathext: envValue(process.env, "PATHEXT"),
-      });
+      if (process.platform === "win32") {
+        // #131: `where ocx` lists the extensionless npm sh shim FIRST, and that file is
+        // not an executable image, so spawning it ENOENTs. Resolve PATH+PATHEXT directly
+        // instead of parsing `where` stdout: resolveWindowsCommand reads PATH/PATHEXT
+        // case-insensitively and retries lowercased extensions, which a `where` parse
+        // cannot do. Returns its input unchanged on a miss.
+        const resolved = resolveWindowsCommand(cmd, process.env);
+        return resolved === cmd ? null : resolved;
+      }
+      const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
+      const out = res.status === 0 && typeof res.stdout === "string" ? splitLines(res.stdout)[0]?.trim() ?? "" : null;
+      return out && out.length > 0 ? out : null;
     },
-```
-
-## Row 2 — gui/src/server/middleware.ts:79 (spawn-npm-enoent-einval)
-
-Before `middleware.ts:78-81`:
-
-```ts
     runStatus: (ocxPath: string) => {
-      const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
-      return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
-    },
-```
-
-After:
-
-```ts
-    runStatus: (ocxPath: string) => {
+      // #131 second half: after CVE-2024-27980 a shell-less `.cmd` spawn is EINVAL.
+      // commandInvocation routes only `.cmd`/`.bat` through ComSpec and escapes cmd
+      // metacharacters; `shell: true` would not escape them.
       const inv = commandInvocation(ocxPath, ["status", "--json"]);
       const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 8000, ...inv.options });
       return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
     },
-```
-
-## Row 3 — messenger-bridge/src/api-compat.ts:40 (get-command-where-disagree)
-
-Before `api-compat.ts:15-21`:
-
-```ts
-import { spawnSync } from "node:child_process";
-// Compiled component dists — runtime-typed, so minimal local shapes below.
-import { getSettings, updateSettings, settingsResponse } from "../../subagent-config/dist/settings-api.js";
-import { readCatalog } from "../../subagent-config/dist/live-catalog.js";
-import { detectOcx } from "../../provider-bridge/dist/detect.js";
-import type { ApiRoute, ApiResponse } from "./server.ts";
-import { splitLines } from "./text-lines.ts";
-```
-
-Before `api-compat.ts:28-43`:
-
-```ts
-/** Real ocx detection deps (detect-only) — mirrored from gui/src/server/middleware.ts. */
-function detectDeps(): Record<string, unknown> {
-  return {
-    which: (cmd: string) => {
-      const res = spawnSync(
-        process.platform === "win32" ? "where" : "command",
-        process.platform === "win32" ? [cmd] : ["-v", cmd],
-        { encoding: "utf8", shell: process.platform !== "win32" },
-      );
-      // where.exe emits CRLF; the trailing .trim() saved this by accident.
-      const out =
-        res.status === 0 && typeof res.stdout === "string"
-          ? splitLines(res.stdout)[0]?.trim() ?? ""
-          : null;
-      return out && out.length > 0 ? out : null;
-    },
-```
-
-After imports (delete splitLines; reuse existing win-exec re-export):
-
-```ts
-import { spawnSync } from "node:child_process";
-import { extname } from "node:path";
-// Compiled component dists — runtime-typed, so minimal local shapes below.
-import { getSettings, updateSettings, settingsResponse } from "../../subagent-config/dist/settings-api.js";
-import { readCatalog } from "../../subagent-config/dist/live-catalog.js";
-import { detectOcx } from "../../provider-bridge/dist/detect.js";
-import type { ApiRoute, ApiResponse } from "./server.ts";
-import { commandInvocation, envValue } from "./win-exec.ts";
-```
-
-After `which` (paste the L1 helper above `detectDeps`):
-
-```ts
-function detectDeps(): Record<string, unknown> {
-  return {
-    which: (cmd: string) => {
-      const res = spawnSync(
-        process.platform === "win32" ? "where" : "command",
-        process.platform === "win32" ? [cmd] : ["-v", cmd],
-        { encoding: "utf8", shell: process.platform !== "win32" },
-      );
-      if (res.status !== 0 || typeof res.stdout !== "string") return null;
-      return selectExecutableFromWhereOutput(res.stdout, {
-        platform: process.platform,
-        pathext: envValue(process.env, "PATHEXT"),
-      });
-    },
-```
-
-## Row 4 — messenger-bridge/src/api-compat.ts:45 (spawn-npm-enoent-einval)
-
-Before `api-compat.ts:44-50`:
-
-```ts
-    runStatus: (ocxPath: string) => {
-      const res = spawnSync(ocxPath, ["status", "--json"], {
-        encoding: "utf8",
-        timeout: 8000,
-      });
-      return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
-    },
-```
-
-After:
-
-```ts
-    runStatus: (ocxPath: string) => {
-      const inv = commandInvocation(ocxPath, ["status", "--json"]);
-      const res = spawnSync(inv.file, inv.args, {
-        encoding: "utf8",
-        timeout: 8000,
-        ...inv.options,
-      });
-      return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
-    },
-```
-
-## Row 5 — config-guard/src/cli.ts:131 (spawn-npm-enoent-einval, bare codex)
-
-Before `cli.ts:5`:
-
-```ts
-import { spawnSync } from "node:child_process";
-```
-
-After — keep that line and insert immediately under it:
-
-```ts
-import { resolveCodexInvocation } from "./codex-bin.ts";
-```
-
-Before `cli.ts:129-138`:
-
-```ts
-export function makeRealRunner(): CodexRunner {
-  return (args) => {
-    const res = spawnSync("codex", [...args], { encoding: "utf8" });
-    return {
-      stdout: res.stdout ?? "",
-      stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
-      exitCode: typeof res.status === "number" ? res.status : 1,
-    };
   };
 }
 ```
 
-After:
+Import, alongside the existing component imports at `:17-19`:
 
 ```ts
-export function makeRealRunner(): CodexRunner {
-  return (args) => {
-    const inv = resolveCodexInvocation("codex", [...args]);
-    const res = spawnSync(inv.file, inv.args, { encoding: "utf8", ...inv.options });
-    return {
-      stdout: res.stdout ?? "",
-      stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
-      exitCode: typeof res.status === "number" ? res.status : 1,
-    };
-  };
-}
+import { commandInvocation, resolveWindowsCommand } from "../../../components/cxc-ops/src/win-exec.ts";
+import { resolveCodexInvocation } from "../../../components/cxc-ops/src/codex-bin.ts";
 ```
 
-## Row 6 — gui/src/server/middleware.ts:88 (windowsapps-alias-eperm, same bare codex spawn)
+`splitLines` stays imported: the POSIX branch still uses it.
 
-Before `middleware.ts:85-94`:
+That POSIX branch deliberately keeps `splitLines` rather than copying L1's inline
+`split(/\r?\n/)`. These two packages own a `text-lines` helper and their tests pin it
+(§8.1, §8.2); `provider-bridge` has no such helper, which is why L1 inlined the regex.
+Same behaviour, each package using the idiom it already owns.
+
+## 4. Row 6 — the bare `codex` spawn in the same file
+
+before (`:85-96`):
 
 ```ts
 function codexFeatureDeps() {
   const run: CodexRunner = (args) => {
     const command = process.env.CODEX_CLI_PATH?.trim() || "codex";
     const res = spawnSync(command, [...args], { encoding: "utf8", timeout: 15000 });
-    return {
-      stdout: res.stdout ?? "",
-      stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
-      exitCode: typeof res.status === "number" ? res.status : 1,
-    };
-  };
 ```
 
-After (keep `CODEX_CLI_PATH` as the command argument so the existing GUI override still wins when `CODEX_BIN` is unset; `resolveCodexInvocation` still honors `CODEX_BIN` when set, matching cxc-ops):
+after:
 
 ```ts
 function codexFeatureDeps() {
   const run: CodexRunner = (args) => {
     const command = process.env.CODEX_CLI_PATH?.trim() || "codex";
+    // A bare name skips PATHEXT, and an npm-installed `codex.cmd` is EINVAL shell-less.
+    // resolveCodexInvocation additionally detects the Microsoft Store WindowsApps alias,
+    // which exits EPERM without running. Note it does NOT pass a miss through unchanged:
+    // it falls back to a cmd-shell invocation (cxc-ops/src/codex-bin.ts:120).
     const inv = resolveCodexInvocation(command, [...args]);
     const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 15000, ...inv.options });
-    return {
-      stdout: res.stdout ?? "",
-      stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),
-      exitCode: typeof res.status === "number" ? res.status : 1,
-    };
-  };
 ```
 
+## 5. Rows 3 and 4 — `messenger-bridge/src/api-compat.ts` `detectDeps()`
 
-## Row 7 — scripts/dev-install.sh reads the manifest with python3 (install)
+The same two edits as §3, in the same shape. This package already crosses its own
+boundary through `dist` (`api-compat.ts` imports `../../subagent-config/dist/settings-api.js`,
+`../../provider-bridge/dist/detect.js`), and it already owns a re-export, so the import is:
 
-Not in the original preflight table. Found while writing `060`, and it **blocks c-12**:
-the reinstall this stack has to prove cannot run on this host at all.
+```ts
+import { commandInvocation, resolveWindowsCommand } from "./win-exec.ts";
+```
 
-`scripts/dev-install.sh:44-50`:
+`messenger-bridge/src/win-exec.ts` is:
+
+```ts
+/** Compatibility export; subprocess escaping is shared with live model discovery. */
+export * from "../../subagent-config/dist/win-exec.js";
+```
+
+Do not add a second copy to this package.
+
+## 6. Row 7 — `scripts/dev-install.sh` reads the manifest with `python3`
+
+Not from the preflight; found while writing `060`. It **blocks c-12 outright**: the
+reinstall this stack has to prove cannot run at all on a Windows host without Python.
+
+before (`scripts/dev-install.sh:44-50`):
 
 ```bash
 installed_version() {
@@ -351,119 +183,196 @@ PY
 }
 ```
 
-`VERSION="$(installed_version)"` runs on every path, not only `--status`. On this host
-`python`, `python3` and `py` all resolve to the Microsoft Store alias or nothing, so
-under `set -euo pipefail` the script aborts before it builds. A Node project whose
-dogfood install depends on Python is the landmine; the corpus case is
-`windowsapps-alias-eperm` (the Store alias that exits without running) compounded by
-`pathext-bare-name-enoent`.
+`VERSION="$(installed_version)"` runs on **every** path, not only `--status`. On this host
+`python`, `python3` and `py` all resolve to the Microsoft Store alias or nothing, so under
+`set -euo pipefail` the script aborts before it builds anything.
 
 after:
 
 ```bash
 installed_version() {
-  # node, not python3: the toolchain this repo already requires. A Windows host with
-  # no Python otherwise kills the whole dev-install under `set -e`, and the Microsoft
-  # Store `python3` alias can exit without running at all.
+  # node, not python3: the toolchain this repo already requires. A Windows host with no
+  # Python otherwise kills the whole dev-install under `set -e`, and the Microsoft Store
+  # `python3` alias can exit without running at all.
+  #
+  # process.stdout.write, NOT console.log: a trailing newline would enter $VERSION and
+  # break the `[ "$(basename "$dir")" != "$VERSION" ]` prune comparison below, whose
+  # else-branch is `rm -rf "$dir"` — it would delete the cache root just installed.
   node -e 'process.stdout.write(require(process.argv[1]).version)' "$PLUGIN_SRC/.codex-plugin/plugin.json"
 }
 ```
 
-`require()` of an absolute `.json` path is fine here: the script always passes an
-absolute `$PLUGIN_SRC`. `process.stdout.write` rather than `console.log` so no trailing
-newline enters `$VERSION` — a trailing newline would break the
-`[ "$(basename "$dir")" != "$VERSION" ]` prune comparison and delete the freshly
-installed cache root.
+That newline hazard is why this row is risk=high rather than a convenience fix.
 
-That last point is why this is risk=high rather than a convenience fix: the prune loop
-`rm -rf`s every cache directory whose name differs from `$VERSION`.
-
-### Test
-
-Shell scripts have no suite here. Verify by execution, both ways:
+### Verification (no suite covers shell scripts here)
 
 ```powershell
 & "C:\Program Files\Git\usr\bin\bash.exe" scripts/dev-install.sh --status
 ```
 
-Before: exits non-zero with `python3: command not found`. After: prints `source:`,
-`manifest: 0.2.24`, `marketplace:` and the cache roots. Confirm `manifest:` has no
-blank line after the version, which would indicate a trailing newline survived.
+Before: non-zero with `python3: command not found`. After: prints `source:`,
+`manifest: <version>`, `marketplace:` and the cache roots, with **no blank line** after the
+version — a blank line would mean a trailing newline survived.
 
-## Regression risk (all rows)
+## 7. Row 5 deferred, with the reason
 
-Rows 1-4 are the same edit applied to two more copies of the `#131` bug. The risk is
-**copy drift**: `win-exec.ts` now exists in eight places once `gui` and
-`messenger-bridge` get theirs. Each copy needs the byte-identity test from `010` §5,
-otherwise a later edit to the `cxc-ops` original silently diverges. `build.mjs` forbids
-cross-component imports, so deduplication is not available and the test is the only
-defence.
-
-Rows 5-6 replace a bare `codex` spawn with `resolveCodexInvocation`. Both call sites are
-fail-open today — `config-guard`'s SessionStart self-heal swallows the failure — so the
-observable change is that the self-heal starts working on hosts where `codex` is a
-`.cmd`. Nothing that currently succeeds can start failing: the resolver returns the
-input unchanged when nothing matches.
-
-Row 7 is the only row that touches a destructive path. See above.
-
-`gui/test/crlf-where.test.ts` pins the first-line behaviour being replaced; update its
-expectation in the same commit or the layer fails its own suite. Note that
-`gui/test/router.test.ts` is a **pre-existing** failure on this host (recorded in
-`000_plan.md`) and is not this layer's regression.
-
-## Criteria
-
-**c-11**: every risk=high corpus finding is fixed inside this stack; deferral with a
-recorded reason is permitted only for risk=medium. Rows 1-4 are risk=high and fixed
-here. Row 7 is risk=high and fixed here. Rows 5-6 are risk=medium and fixed here
-anyway because `wp4` already opens `config-guard/src/cli.ts`. The deferred set is
-recorded in `000_plan.md`: the BOM-less `.cmd` in `messenger-bridge/src/service.ts:245`
-(risk=medium, needs a non-ASCII home path to bite) and the colon-PATH test fixtures in
-`payload-bin.test.mjs:72` and `live-catalog.test.ts:79` (risk=medium, test-only,
-currently green).
-
-**c-9**, "every copy" half: rows 1-4 bring the GUI `/api/provider` and the `cxc serve`
-provider endpoint to `mode: provider` on this host. Prove by starting each surface and
-reading the endpoint, not by reading the diff.
-Copy-Item -LiteralPath plugins/codexclaw/components/cxc-ops/src/win-exec.ts -Destination plugins/codexclaw/gui/src/server/win-exec.ts
-Copy-Item -LiteralPath plugins/codexclaw/components/cxc-ops/src/win-exec.ts -Destination plugins/codexclaw/components/config-guard/src/win-exec.ts
-Copy-Item -LiteralPath plugins/codexclaw/components/cxc-ops/src/codex-bin.ts -Destination plugins/codexclaw/gui/src/server/codex-bin.ts
-Copy-Item -LiteralPath plugins/codexclaw/components/cxc-ops/src/codex-bin.ts -Destination plugins/codexclaw/components/config-guard/src/codex-bin.ts
-```
-
-`win-exec.ts`: LF, 89 lines, 3657 bytes, hash `B7B07DE668F622EA1AC0CD1A82FE04B61C85A41E9390233D22AEBAA4AF175E3D`. Full text is in `010_wp2_provider_bridge_windows_detect.md` NEW win-exec.ts (same bytes as cxc-ops).
-
-`codex-bin.ts`: LF, 125 lines, 5437 bytes. Full text is `plugins/codexclaw/components/cxc-ops/src/codex-bin.ts` as of L0 `9cd52769`. The load-bearing export is `resolveCodexInvocation` at `codex-bin.ts:106-125`. Quoted here so the copy cannot silently drift; if this block disagrees with the cxc-ops file, the cxc-ops file wins and the identity test will catch a bad retype.
-
-Before (cxc-ops, the function this layer copies), `codex-bin.ts:101-125`:
+`config-guard/src/cli.ts:139-148` `makeRealRunner` spawns a bare `codex`:
 
 ```ts
-/**
- * Build the spawn shape for the `codex` CLI.
- *
- * POSIX is a passthrough; `CODEX_BIN` wins on every platform when it is set.
- */
-export function resolveCodexInvocation(
-  command: string,
-  args: string[],
-  platform: NodeJS.Platform = process.platform,
-  env: NodeJS.ProcessEnv = process.env,
-): Invocation {
-  const override = envValue(env, "CODEX_BIN")?.trim();
-  const target = override && override.length > 0 ? override : command;
-  if (platform !== "win32") return { file: target, args: [...args], options: {} };
-
-  // An explicit override is honored as written; only PATH discovery filters.
-  const resolved = override && override.length > 0
-    ? (spawnableWindowsCandidates(override, env)[0] ?? null)
-    : (spawnableWindowsCandidates(command, env)[0] ?? null);
-  if (resolved === null) return cmdShellInvocation(target, args, env);
-  // commandInvocation already routes .cmd/.bat through ComSpec and spawns a
-  // resolved .exe directly; the path it gets here is absolute, so it re-resolves
-  // nothing.
-  return commandInvocation(resolved, args, platform, env);
-}
+export function makeRealRunner(): CodexRunner {
+  return (args) => {
+    const res = spawnSync("codex", [...args], { encoding: "utf8" });
 ```
 
-After: the NEW files are that entire cxc-ops file, unmodified. Do not trim `isWindowsAppsAlias`, `spawnableWindowsCandidates`, or `cmdShellInvocation` — `resolveCodexInvocation` needs all three.
+(Revision 1 cited `:131`; that is inside `renderSoftFailureWarning`. The function bytes
+were right, the anchor was not.)
+
+**Deferred.** risk=medium, which c-11 permits deferring with a recorded reason. The reason
+is copy scope, and specifically **not** "wp4 already opened this file" — an audit correctly
+rejected that as a non-reason.
+
+`config-guard` imports only `node:*` and relative `./` files, strictly, and it runs a
+SessionStart hook. A GUI-style cross-package import would break that property for a
+fail-open code path. Doing it properly means porting `resolveCodexInvocation` plus
+`spawnableWindowsCandidates` and `isWindowsAppsAlias` (`cxc-ops/src/codex-bin.ts:35-125`),
+which itself needs `win-exec` — a copy larger than the bug it fixes, in the one package
+in this repository that has never crossed its boundary.
+
+Impact while deferred: on a host where `codex` is an npm `.cmd` or the Store alias, the
+SessionStart self-heal silently does nothing. It is fail-open by design, so no session
+breaks. Note it is **not** hook-only — `makeRealRunner` also serves `enable`/`disable`/
+`status` (`config-guard/src/cli.ts:167`), so the deferral is wider than "just the hook" and
+is recorded as such.
+
+## 8. Tests
+
+### 8.1 `gui/test/crlf-where.test.ts` — its premise expires
+
+Its docstring says it exercises "the exact expression `detectDeps()` now uses". After §3
+that is false on win32: the `splitLines(...)[0]` idiom survives only on the POSIX branch.
+Leaving it unchanged would leave a test asserting a retired contract.
+
+Keep the three `splitLines` cases — they still pin the POSIX branch and the `?? ""` guard —
+and correct the docstring to say so. Then add the launcher case the suite lacks, matching
+L1's §5 half 1:
+
+```ts
+test("win32 launcher selection prefers the PATHEXT launcher over the extensionless shim", t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-gui-which-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\n");      // npm sh shim, not an image
+  writeFileSync(join(dir, "ocx.cmd"), "@echo off\r\n"); // the real launcher
+  // Case-insensitive compare: candidates are built with the PATHEXT spelling.
+  assert.equal(
+    resolveWindowsCommand("ocx", { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" }).toLowerCase(),
+    join(dir, "ocx.cmd").toLowerCase(),
+  );
+});
+```
+
+### 8.2 `messenger-bridge` — same addition
+
+That package has its own `crlf-where`-equivalent pinning the same idiom. Apply the same
+two changes: correct the premise, add the launcher case against `./win-exec.ts`.
+
+## 9. Reproduction (parent fails, L5 head passes)
+
+The GUI and serve endpoints are the point, so prove them, not the diff:
+
+**Both** surfaces, because c-9 says every copy and they are two separate copies.
+
+```powershell
+# 1. serve surface (messenger-bridge). --port is real: messenger-bridge/src/cli.ts:47
+node plugins/codexclaw/components/messenger-bridge/dist/cli.js serve --port 10199
+(Invoke-WebRequest -UseBasicParsing http://127.0.0.1:10199/api/provider).Content
+```
+
+```powershell
+# 2. GUI surface (Vite dev-server middleware). Read the dev-server entry from the gui
+#    package scripts first; the middleware answers /api/provider on that port.
+node plugins/codexclaw/bin/cxc.mjs gui
+(Invoke-WebRequest -UseBasicParsing http://127.0.0.1:<gui-port>/api/provider).Content
+```
+
+Parent, on both: `"mode":"error"` with `"reason":"ocx status exited null"`. L5 head, on
+both: `"mode":"provider"` with a `.cmd` launcher path.
+
+If the GUI dev server cannot be reached non-interactively on this host, call `getProvider`
+through the middleware's own module instead and record that substitution — but do not
+claim the GUI copy is proven from the `serve` result alone. They are different files.
+
+Then the suites and the build:
+
+```powershell
+node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/gui/test/*.test.ts"
+node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/components/messenger-bridge/test/*.test.ts"
+npm run build
+npm run gate
+```
+
+### 9.1 Measured result, and the GUI substitution that was used
+
+**serve surface** — ran as specified:
+
+```text
+$ node plugins/codexclaw/components/messenger-bridge/dist/cli.js serve --port 10199
+cxc serve: listening on http://127.0.0.1:10199
+$ (Invoke-WebRequest -UseBasicParsing http://127.0.0.1:10199/api/provider).Content
+{"mode":"provider","port":10100}
+```
+
+**GUI surface** — the dev server could not be started: `node bin/codexclaw.mjs gui` exits
+with `dependencies not installed. Run npm install in .../gui first`, and the payload
+dispatcher refuses `gui` outright as repo-checkout-only. §9's substitution was used, and
+here is exactly what it was, so the claim can be checked:
+
+the real `middleware.ts` module was imported and its exported `codexclawApiMiddleware()`
+driven with a synthetic `GET /api/provider`. That runs the actual private `detectDeps()`
+closure in that file — the thing under test — rather than a reimplementation of it. The
+`import type { Connect } from "vite"` at `:8` is type-only and erased by strip-types, so
+no Vite runtime is needed.
+
+```text
+GUI /api/provider status=200
+GUI /api/provider body={"mode":"provider","port":10100}
+```
+
+Both surfaces returned `error` before this layer. The two results are from two different
+files, which is what c-9's "every copy" requires; neither was inferred from the other.
+
+## 10. Regression risk
+
+Rows 1-4 apply L1's landed shape to two more call sites and add **no** new shared-module
+copies, so there is no new drift surface. The behaviour difference L1 recorded carries
+over: the resolved path ends in PATHEXT's casing (`.CMD`) rather than the on-disk casing,
+which is cosmetic on a case-insensitive filesystem, so any assertion must compare
+case-insensitively.
+
+Row 6 changes a path that is fail-open today, so the observable change is that the GUI's
+feature probe starts working on hosts where `codex` is a `.cmd`. Nothing that currently
+succeeds can start failing, because a miss falls back to a cmd-shell invocation rather
+than erroring.
+
+Row 7 is the only row touching a destructive path — see the newline hazard in §6.
+
+`gui` is a Vite package and its build output is not staged the way component `dist/` is;
+`messenger-bridge/dist/api-compat.js` is already tracked and restages normally. No new
+`dist` file is introduced by this layer, so no `git add -f` is needed — unlike L1 and L4.
+
+Pre-existing failure on this host, unrelated and recorded in `000_plan.md`:
+`gui/test/router.test.ts`.
+
+## 11. Criteria
+
+**c-11**: every risk=high finding is fixed in this layer — rows 1-4 and row 7. Row 5 and
+the two entries below are risk=medium and deferred with reasons, which c-11 permits. Row 6
+is risk=medium and fixed anyway because the direct import makes it nearly free.
+
+Deferred set, recorded in `000_plan.md` and §7: row 5 above; the BOM-less `.cmd` written by
+`messenger-bridge/src/service.ts:245` (needs a non-ASCII home path to bite); and the
+colon-PATH test fixtures in `payload-bin.test.mjs:72` and `live-catalog.test.ts:79`
+(test-only, currently green, product paths already use `commandInvocation`).
+
+**c-9, "every copy" half**: rows 1-4 bring the GUI `/api/provider` and the `cxc serve`
+provider endpoint to `mode: provider` on this host. Proved by §9 against the running
+surfaces, not by reading the diff.

--- a/plugins/codexclaw/components/messenger-bridge/dist/api-compat.js
+++ b/plugins/codexclaw/components/messenger-bridge/dist/api-compat.js
@@ -19,6 +19,7 @@ import { readCatalog } from "../../subagent-config/dist/live-catalog.js";
 import { detectOcx } from "../../provider-bridge/dist/detect.js";
 
 import { splitLines } from "./text-lines.js";
+import { commandInvocation, resolveWindowsCommand } from "./win-exec.js";
 
 
 
@@ -29,12 +30,15 @@ import { splitLines } from "./text-lines.js";
 function detectDeps()                          {
   return {
     which: (cmd        ) => {
-      const res = spawnSync(
-        process.platform === "win32" ? "where" : "command",
-        process.platform === "win32" ? [cmd] : ["-v", cmd],
-        { encoding: "utf8", shell: process.platform !== "win32" },
-      );
-      // where.exe emits CRLF; the trailing .trim() saved this by accident.
+      if (process.platform === "win32") {
+        // #131: `where ocx` lists the extensionless npm sh shim FIRST, and that file is
+        // not an executable image, so spawning it ENOENTs. Resolve PATH+PATHEXT directly
+        // instead of parsing `where` stdout. Same shape as provider-bridge/src/cli.ts;
+        // this is the `cxc serve` copy of that bug. Returns its input on a miss.
+        const resolved = resolveWindowsCommand(cmd, process.env);
+        return resolved === cmd ? null : resolved;
+      }
+      const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
       const out =
         res.status === 0 && typeof res.stdout === "string"
           ? splitLines(res.stdout)[0]?.trim() ?? ""
@@ -42,9 +46,14 @@ function detectDeps()                          {
       return out && out.length > 0 ? out : null;
     },
     runStatus: (ocxPath        ) => {
-      const res = spawnSync(ocxPath, ["status", "--json"], {
+      // #131 second half: after CVE-2024-27980 a shell-less `.cmd` spawn is EINVAL.
+      // commandInvocation routes only `.cmd`/`.bat` through ComSpec and escapes cmd
+      // metacharacters; `shell: true` would not escape them.
+      const inv = commandInvocation(ocxPath, ["status", "--json"]);
+      const res = spawnSync(inv.file, inv.args, {
         encoding: "utf8",
         timeout: 8000,
+        ...inv.options,
       });
       return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
     },

--- a/plugins/codexclaw/components/messenger-bridge/src/api-compat.ts
+++ b/plugins/codexclaw/components/messenger-bridge/src/api-compat.ts
@@ -19,6 +19,7 @@ import { readCatalog } from "../../subagent-config/dist/live-catalog.js";
 import { detectOcx } from "../../provider-bridge/dist/detect.js";
 import type { ApiRoute, ApiResponse } from "./server.ts";
 import { splitLines } from "./text-lines.ts";
+import { commandInvocation, resolveWindowsCommand } from "./win-exec.ts";
 
 interface ProviderStatusShape {
   mode: "native" | "provider" | "error";
@@ -29,12 +30,15 @@ interface ProviderStatusShape {
 function detectDeps(): Record<string, unknown> {
   return {
     which: (cmd: string) => {
-      const res = spawnSync(
-        process.platform === "win32" ? "where" : "command",
-        process.platform === "win32" ? [cmd] : ["-v", cmd],
-        { encoding: "utf8", shell: process.platform !== "win32" },
-      );
-      // where.exe emits CRLF; the trailing .trim() saved this by accident.
+      if (process.platform === "win32") {
+        // #131: `where ocx` lists the extensionless npm sh shim FIRST, and that file is
+        // not an executable image, so spawning it ENOENTs. Resolve PATH+PATHEXT directly
+        // instead of parsing `where` stdout. Same shape as provider-bridge/src/cli.ts;
+        // this is the `cxc serve` copy of that bug. Returns its input on a miss.
+        const resolved = resolveWindowsCommand(cmd, process.env);
+        return resolved === cmd ? null : resolved;
+      }
+      const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
       const out =
         res.status === 0 && typeof res.stdout === "string"
           ? splitLines(res.stdout)[0]?.trim() ?? ""
@@ -42,9 +46,14 @@ function detectDeps(): Record<string, unknown> {
       return out && out.length > 0 ? out : null;
     },
     runStatus: (ocxPath: string) => {
-      const res = spawnSync(ocxPath, ["status", "--json"], {
+      // #131 second half: after CVE-2024-27980 a shell-less `.cmd` spawn is EINVAL.
+      // commandInvocation routes only `.cmd`/`.bat` through ComSpec and escapes cmd
+      // metacharacters; `shell: true` would not escape them.
+      const inv = commandInvocation(ocxPath, ["status", "--json"]);
+      const res = spawnSync(inv.file, inv.args, {
         encoding: "utf8",
         timeout: 8000,
+        ...inv.options,
       });
       return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
     },

--- a/plugins/codexclaw/components/messenger-bridge/test/crlf-where.test.ts
+++ b/plugins/codexclaw/components/messenger-bridge/test/crlf-where.test.ts
@@ -1,14 +1,21 @@
 /**
  * crlf-where.test.ts - where.exe stdout is CRLF (wp08 / 002 B9).
  *
- * detectDeps() is a private, non-injectable closure over spawnSync, so the exact
- * expression it now uses is exercised here against this package's own text-lines
- * copy. That also pins the SHARED-HELPER-01 requirement that the copy exists at
- * this path: a cross-package import would not resolve at build time.
+ * SCOPE NARROWED (#131, wp6). detectDeps() no longer parses `where` stdout on win32:
+ * it resolves PATH+PATHEXT through resolveWindowsCommand, because `where` lists the
+ * extensionless npm sh shim first and that file is not an executable image. The
+ * splitLines idiom below now pins only the POSIX `command -v` branch, plus the `?? ""`
+ * guard. It is kept because that branch is still live and this package owns the helper.
+ *
+ * The win32 half is pinned by the launcher case at the bottom of this file.
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { splitLines } from "../src/text-lines.ts";
+import { commandInvocation, resolveWindowsCommand } from "../src/win-exec.ts";
 
 /** The idiom detectDeps() uses on `where` / `command -v` stdout. */
 function firstPath(stdout: string): string {
@@ -31,4 +38,30 @@ test("empty stdout does not throw", () => {
   assert.equal(firstPath(""), "");
   assert.doesNotThrow(() => firstPath(""));
   assert.equal(splitLines("").filter((l) => l.length > 0)[0]?.trim() ?? "", "");
+});
+
+// #131 win32 half. An npm global install lays down BOTH an extensionless sh shim and a
+// .cmd launcher, and `where` lists the extensionless one first. detectDeps() no longer
+// asks `where` at all on win32; this pins the replacement.
+test("win32 launcher selection prefers the PATHEXT launcher over the extensionless shim", t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-which-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\n");      // npm sh shim, not an image
+  writeFileSync(join(dir, "ocx.cmd"), "@echo off\r\n"); // the real launcher
+
+  // Case-insensitive compare: candidates are built with the PATHEXT spelling (".CMD")
+  // and Windows existsSync ignores case, so the resolved path carries PATHEXT casing.
+  // What is pinned is that the extensionless shim LOST.
+  const want = join(dir, "ocx.cmd").toLowerCase();
+  assert.equal(resolveWindowsCommand("ocx", { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" }).toLowerCase(), want);
+  // A child can arrive with `Path` instead of `PATH`.
+  assert.equal(resolveWindowsCommand("ocx", { Path: dir }).toLowerCase(), want);
+
+  // A .cmd must route through ComSpec with verbatim args; an .exe must not.
+  const cmd = commandInvocation(join(dir, "ocx.cmd"), ["status", "--json"], "win32", { ComSpec: "cmd.exe" });
+  assert.equal(cmd.file, "cmd.exe");
+  assert.deepEqual(cmd.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.equal(cmd.options.windowsVerbatimArguments, true);
+  const exe = commandInvocation(join(dir, "ocx.exe"), ["status"], "win32", {});
+  assert.notEqual(exe.options.windowsVerbatimArguments, true);
 });

--- a/plugins/codexclaw/gui/src/server/middleware.ts
+++ b/plugins/codexclaw/gui/src/server/middleware.ts
@@ -15,6 +15,8 @@ import {
   postMultiAgentSurface,
 } from "./handlers.ts";
 import { detectOcx } from "../../../components/provider-bridge/src/detect.ts";
+import { commandInvocation, resolveWindowsCommand } from "../../../components/cxc-ops/src/win-exec.ts";
+import { resolveCodexInvocation } from "../../../components/cxc-ops/src/codex-bin.ts";
 import { resolveCodexHome } from "../../../components/config-guard/src/cli.ts";
 import type { CodexRunner } from "../../../components/config-guard/src/features.ts";
 import { spawnSync } from "node:child_process";
@@ -67,16 +69,26 @@ export function resolveProjectRoot(start: string = process.cwd(), env: NodeJS.Pr
 function detectDeps() {
   return {
     which: (cmd: string) => {
-      const res = spawnSync(process.platform === "win32" ? "where" : "command", process.platform === "win32" ? [cmd] : ["-v", cmd], {
-        encoding: "utf8",
-        shell: process.platform !== "win32",
-      });
-      // where.exe emits CRLF; the trailing .trim() saved this by accident.
+      if (process.platform === "win32") {
+        // #131: `where ocx` lists the extensionless npm sh shim FIRST, and that file is
+        // not an executable image, so spawning it ENOENTs. Resolve PATH+PATHEXT directly
+        // instead of parsing `where` stdout — resolveWindowsCommand reads PATH/PATHEXT
+        // case-insensitively and retries lowercased extensions, which a `where` parse
+        // cannot do. Returns its input unchanged on a miss, which maps to null here.
+        // Same shape as provider-bridge/src/cli.ts; this is the GUI copy of that bug.
+        const resolved = resolveWindowsCommand(cmd, process.env);
+        return resolved === cmd ? null : resolved;
+      }
+      const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
       const out = res.status === 0 && typeof res.stdout === "string" ? splitLines(res.stdout)[0]?.trim() ?? "" : null;
       return out && out.length > 0 ? out : null;
     },
     runStatus: (ocxPath: string) => {
-      const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+      // #131 second half: after CVE-2024-27980 a shell-less `.cmd` spawn is EINVAL.
+      // commandInvocation routes only `.cmd`/`.bat` through ComSpec and escapes cmd
+      // metacharacters; `shell: true` would not escape them.
+      const inv = commandInvocation(ocxPath, ["status", "--json"]);
+      const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 8000, ...inv.options });
       return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
     },
   };
@@ -85,7 +97,12 @@ function detectDeps() {
 function codexFeatureDeps() {
   const run: CodexRunner = (args) => {
     const command = process.env.CODEX_CLI_PATH?.trim() || "codex";
-    const res = spawnSync(command, [...args], { encoding: "utf8", timeout: 15000 });
+    // A bare name skips PATHEXT, and an npm-installed `codex.cmd` is EINVAL shell-less.
+    // resolveCodexInvocation also detects the Microsoft Store WindowsApps alias, which
+    // exits EPERM without running. On a miss it does NOT pass the input through: it
+    // falls back to a cmd-shell invocation (cxc-ops/src/codex-bin.ts:120).
+    const inv = resolveCodexInvocation(command, [...args]);
+    const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 15000, ...inv.options });
     return {
       stdout: res.stdout ?? "",
       stderr: res.stderr ?? (res.error ? String(res.error.message) : ""),

--- a/plugins/codexclaw/gui/test/crlf-where.test.ts
+++ b/plugins/codexclaw/gui/test/crlf-where.test.ts
@@ -1,14 +1,21 @@
 /**
  * crlf-where.test.ts - where.exe stdout is CRLF (wp08 / 002 B9).
  *
- * detectDeps() is a private, non-injectable closure over spawnSync, so the exact
- * expression it now uses is exercised here against this package's own text-lines
- * copy. That also pins the SHARED-HELPER-01 requirement that the copy exists at
- * this path: a cross-package import would not resolve at build time.
+ * SCOPE NARROWED (#131, wp6). detectDeps() no longer parses `where` stdout on win32:
+ * it resolves PATH+PATHEXT through resolveWindowsCommand, because `where` lists the
+ * extensionless npm sh shim first and that file is not an executable image. The
+ * splitLines idiom below now pins only the POSIX `command -v` branch, plus the `?? ""`
+ * guard. It is kept because that branch is still live and this package owns the helper.
+ *
+ * The win32 half is pinned by the launcher case at the bottom of this file.
  */
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { splitLines } from "../src/server/text-lines.ts";
+import { commandInvocation, resolveWindowsCommand } from "../../components/cxc-ops/src/win-exec.ts";
 
 /** The idiom detectDeps() uses on `where` / `command -v` stdout. */
 function firstPath(stdout: string): string {
@@ -31,4 +38,30 @@ test("empty stdout does not throw", () => {
   assert.equal(firstPath(""), "");
   assert.doesNotThrow(() => firstPath(""));
   assert.equal(splitLines("").filter((l) => l.length > 0)[0]?.trim() ?? "", "");
+});
+
+// #131 win32 half. An npm global install lays down BOTH an extensionless sh shim and a
+// .cmd launcher, and `where` lists the extensionless one first. detectDeps() no longer
+// asks `where` at all on win32; this pins the replacement.
+test("win32 launcher selection prefers the PATHEXT launcher over the extensionless shim", t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-which-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\n");      // npm sh shim, not an image
+  writeFileSync(join(dir, "ocx.cmd"), "@echo off\r\n"); // the real launcher
+
+  // Case-insensitive compare: candidates are built with the PATHEXT spelling (".CMD")
+  // and Windows existsSync ignores case, so the resolved path carries PATHEXT casing.
+  // What is pinned is that the extensionless shim LOST.
+  const want = join(dir, "ocx.cmd").toLowerCase();
+  assert.equal(resolveWindowsCommand("ocx", { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" }).toLowerCase(), want);
+  // A child can arrive with `Path` instead of `PATH`.
+  assert.equal(resolveWindowsCommand("ocx", { Path: dir }).toLowerCase(), want);
+
+  // A .cmd must route through ComSpec with verbatim args; an .exe must not.
+  const cmd = commandInvocation(join(dir, "ocx.cmd"), ["status", "--json"], "win32", { ComSpec: "cmd.exe" });
+  assert.equal(cmd.file, "cmd.exe");
+  assert.deepEqual(cmd.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.equal(cmd.options.windowsVerbatimArguments, true);
+  const exe = commandInvocation(join(dir, "ocx.exe"), ["status"], "win32", {});
+  assert.notEqual(exe.options.windowsVerbatimArguments, true);
 });

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -42,11 +42,14 @@ marketplace_root() {
 command -v codex >/dev/null 2>&1 || die "codex CLI not on PATH"
 
 installed_version() {
-  python3 - "$PLUGIN_SRC/.codex-plugin/plugin.json" <<'PY'
-import json, sys
-with open(sys.argv[1], encoding="utf-8") as fh:
-    print(json.load(fh)["version"])
-PY
+  # node, not python3: the toolchain this repo already requires. A Windows host with no
+  # Python otherwise kills the whole dev-install under `set -e` before it builds, and the
+  # Microsoft Store `python3` alias can exit without running at all.
+  #
+  # process.stdout.write, NOT console.log: a trailing newline would enter $VERSION and
+  # break the `[ "$(basename "$dir")" != "$VERSION" ]` prune comparison below, whose
+  # else-branch is `rm -rf "$dir"` — it would delete the cache root just installed.
+  node -e 'process.stdout.write(require(process.argv[1]).version)' "$PLUGIN_SRC/.codex-plugin/plugin.json"
 }
 
 report_status() {


### PR DESCRIPTION
Layer **L5** of the Windows issue sweep stack. Base is **L4** (`codex/fix-nongit-early-refusal`). `enforce-target` will flag the non-`dev` base; expected for a manual chain.

Completes #131 by fixing the copies L1 could not reach, and unblocks the reinstall this stack has to prove.

## Scope came from a preflight, not a code review

Every row was produced by running the `fuck-powershell` corpus preflight against this repository's Windows execution surfaces and mapping each finding to a corpus case. Findings that mapped to no case were dropped.

| # | path:line | corpus case | risk | this PR |
|---|---|---|---|---|
| 1-2 | `gui/src/server/middleware.ts:75,79` | `get-command-where-disagree`, `spawn-npm-enoent-einval` | high | fixed |
| 3-4 | `messenger-bridge/src/api-compat.ts:40,45` | same pair | high | fixed |
| 5 | `config-guard/src/cli.ts:141` | `spawn-npm-enoent-einval`, `windowsapps-alias-eperm` | medium | **deferred** |
| 6 | `gui/src/server/middleware.ts:88` | `windowsapps-alias-eperm` | medium | fixed |
| 7 | `scripts/dev-install.sh:44-50` | `windowsapps-alias-eperm` + `pathext-bare-name-enoent` | high | fixed |

Rows 1-4 are **three more live copies of #131**. Fixing `provider-bridge` alone left the GUI `/api/provider` and the `cxc serve` provider endpoint reporting `error` on this host. That is why c-9 says "in every copy".

## Row 7 blocked the reinstall outright

`scripts/dev-install.sh` read the manifest version with `python3`, on **every** code path rather than only `--status`. This host has no Python — `python`, `python3` and `py` all resolve to the Microsoft Store alias or nothing — so under `set -euo pipefail` the script aborted before it built anything. A Node project whose dogfood install depends on Python.

The replacement uses `process.stdout.write`, not `console.log`, and that matters: a trailing newline would enter `$VERSION` and break the `[ "$(basename "$dir")" != "$VERSION" ]` prune comparison, whose else-branch is `rm -rf "$dir"`. It would delete the cache root just installed. That hazard is why this row is risk=high and not a convenience fix.

```
$ bash scripts/dev-install.sh --status
source:      /c/Users/super/Developers/codexclaw/plugins/codexclaw
manifest:    0.2.24+codex.20260908031619
marketplace: C:\Users\super\.codex\.tmp\marketplaces\codexclaw
cache roots:
  0.2.24+codex.20260908031619
symlinks in cache: 0
```

Before: non-zero with `python3: command not found`. No blank line after `manifest:` — that is the check that the newline hazard did not reappear.

## Zero new copies of `win-exec.ts`

An earlier draft of the plan called for a copy in `gui` and another in `messenger-bridge`. An audit rejected both, correctly:

- `gui` is a Vite package, not a component. `middleware.ts` already imports `../../../components/provider-bridge/src/detect.ts` and two `config-guard` sources, and `vite.config.ts` imposes no boundary. It imports the existing helpers directly.
- `messenger-bridge/src/win-exec.ts` already exists as a two-line re-export of `subagent-config/dist/win-exec.js`. A second copy in the same package would be pure drift surface.

The count stays at four byte-identical copies plus one re-export, plus L1's `provider-bridge` copy.

The same audit caught that the draft's `after` blocks propagated a design **L1 never shipped** — they still used a `selectExecutableFromWhereOutput` helper, where L1 landed by *deleting* the `where` parsing in favour of `resolveWindowsCommand`. Following the draft verbatim would have spread the rejected implementation to two more call sites.

## Row 5 deferred, and why

`config-guard/src/cli.ts:141` `makeRealRunner` spawns a bare `codex`. risk=medium, which c-11 permits deferring with a recorded reason. The reason is **copy scope**, and explicitly *not* "wp4 already opened this file" — an audit rejected that as a non-reason.

`config-guard` imports only `node:*` and relative `./` files, strictly, and it runs a SessionStart hook. A GUI-style cross-package import would break that property for a fail-open path. Doing it properly means porting `resolveCodexInvocation` plus `spawnableWindowsCandidates` and `isWindowsAppsAlias` — which itself needs `win-exec` — into the one package in this repository that has never crossed its boundary. A copy larger than the bug.

Impact while deferred: on a host where `codex` is an npm `.cmd` or the Store alias, the SessionStart self-heal silently does nothing. It is fail-open by design. Note it is **not** hook-only — `makeRealRunner` also serves `enable`/`disable`/`status`, so the deferral is wider than "just the hook" and is recorded as such.

## Verification — both surfaces, from two different files

```
$ node .../messenger-bridge/dist/cli.js serve --port 10199
$ (Invoke-WebRequest http://127.0.0.1:10199/api/provider).Content
{"mode":"provider","port":10100}

GUI /api/provider status=200
GUI /api/provider body={"mode":"provider","port":10100}
```

Both returned `mode: "error"` before. Neither result was inferred from the other.

The GUI dev server could not be started here — `gui` needs its own `npm install`, and the payload dispatcher refuses `gui` as repo-checkout-only — so the plan's documented substitution was used and is recorded in `050` §9.1: the real `middleware.ts` module was imported and its exported `codexclawApiMiddleware()` driven with a synthetic `GET /api/provider`, which runs that file's own private `detectDeps()` closure rather than a reimplementation. The `import type { Connect } from "vite"` is type-only and erased by strip-types.

```
messenger-bridge suite: 405 tests, 402 passed, 0 failed, 3 skipped
gui suite: 32 tests, 31 passed, 1 failed (pre-existing router.test.ts)
crlf-where twins: 8 passed, 0 failed
npm run build: 181 files compiled
npm run gate: OK
inventory --check --tests 3057: OK
```

## The two `crlf-where` tests had an expired premise

Both claimed to exercise "the exact expression `detectDeps()` now uses". After this change that is false on win32 — the `splitLines(...)[0]` idiom survives only on the POSIX branch. Leaving them would leave tests asserting a retired contract. Their docstrings now say what they actually pin, and each gained the L1-style launcher case plus ComSpec routing assertions.

The POSIX branch deliberately keeps `splitLines` rather than copying L1's inline regex: these two packages own a `text-lines` helper their own tests pin, while `provider-bridge` has none, which is why L1 inlined it.

Plan: `devlog/_plan/260911_windows_issue_sweep/050_wp6_windows_landmine_sweep.md`.
