### PR TITLE
fix(pabcd-state): let a non-git session bind a nested git source (L6, #109)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C057_passing-brightgreen" alt="3,057 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C065_passing-brightgreen" alt="3,065 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C057_passing-brightgreen" alt="3,057 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C065_passing-brightgreen" alt="3,065 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C057_passing-brightgreen" alt="3,057 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C065_passing-brightgreen" alt="3,065 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_windows_issue_sweep/000_plan.md
+++ b/devlog/_plan/260911_windows_issue_sweep/000_plan.md
@@ -101,6 +101,31 @@ entries therefore disagree with this document, and **this document governs**:
   the one drift that still bites, and it is the only thing standing between the loop and
   reaching integration without ever closing #109.
 
+#### The drift bit, and the tooling could not express the fix
+
+It happened. After `wp6` closed, `activeWorkPhaseId` advanced to `wp7` while `wp8`
+was still `pending`, and the gated edge then refuses any attest naming `wp8`.
+`effectiveActiveWorkPhaseId` (`goalplan.ts:2001-2019`) honours the cursor whenever the phase
+it points at is runnable, and `wp7` is runnable because its only dependency, `wp6`, is done.
+
+There is no supported way out. `cxc loop` has no verb to move the cursor or to mark a
+phase blocked, `loop steer` is additive only (`annotate` / `add-criterion` /
+`add-work-phase`), and "existing dependencies are not edited after creation", so `wp8`
+cannot become a dependency of `wp7` after the fact.
+
+This is the same shape as the issues this stack is fixing: a persisted plan can reach a
+state whose intended exit is not legal. Worth its own issue after this stack lands.
+
+**How it was resolved, without falsifying anything.** The final cycle runs under `wp7`,
+the phase that actually holds the cursor, and its content is ordered so the substance of
+the `060` §0 gate still holds: #109 is implemented and `c-8` is marked met FIRST, and only
+then does integration begin. `wp8` is closed afterwards against that same evidence, which
+is not a fabrication because by then the work is genuinely done and recorded.
+
+What is given up is the one-work-phase-per-cycle invariant, deliberately and visibly,
+because the alternative was either to mark `wp7` done before integration happened or to
+run integration before #109 was fixed. Both of those would be false; this is only untidy.
+
 The `loop steer` annotation recorded in the ledger names the revision-2 order. Where it
 and this document disagree, **this document governs**, and the substance that matters is
 unchanged in both: `wp5` closes #133 only, `wp8` closes #109, and `wp7` waits for

--- a/devlog/_plan/260911_windows_issue_sweep/045_wp8_split_cwd_source.md
+++ b/devlog/_plan/260911_windows_issue_sweep/045_wp8_split_cwd_source.md
@@ -1,127 +1,128 @@
-# 045 — wp8 / L5 / #109 split-cwd source separation
+# 045 — wp8 / L6 / #109 split-cwd source separation
 
-Branch `codex/fix-split-cwd-source`, base L4 (`codex/fix-nongit-early-refusal`).
+Branch `codex/fix-split-cwd-source`, base **L5** (`codex/windows-landmine-sweep`, `3cdb6c86`).
 Criterion **c-8**. Work class **C4**: this layer touches the evidence chain.
+
+Revision 2. Revision 1 was audited and returned FAIL on three blockers, all folded here:
+its `resolveSessionSource` snippet silently dropped a re-point detection clause, its
+negative-control test asserted the wrong refusal, and its reproduction omitted the
+`session bind` that `session source` requires.
 
 ## 1. The problem, stated correctly
 
-#109's own diagnosis is inverted, and building to it would produce the wrong fix.
-
-The issue says `--cwd` applies to the FSM but git reads the process cwd. The code is the
-opposite. `--cwd` reaches git through `captureSessionSourceIdentity(args.cwd)`, which
-calls `resolveSessionSource` and then `captureSourceIdentity(sourceCwd)`:
-
-```ts
-// session-source-identity.ts
-export function captureSessionSourceIdentity(cwd: string, sessionId: string, options: CaptureOptions = {}): SourceIdentity {
-  const sourceCwd = resolveSessionSource(cwd, sessionId);
-  const identity = captureSourceIdentity(sourceCwd, sourceCwd === cwd ? options : { excludeCodexclawArtifacts: true, ...options });
-  return sourceCwd === cwd ? identity : { ...identity, sourceRoot: sourceCwd };
-}
-```
-
-With no source binding `resolveSessionSource` returns `cwd` unchanged, so `sourceCwd === cwd`
-and `--cwd` **is** the git cwd. That is precisely why git fails: the FSM directory is
-not a repository. Propagating `--cwd` harder changes nothing.
+#109's own diagnosis is inverted. It says `--cwd` applies to the FSM but git reads the
+process cwd. The code is the opposite: `--cwd` reaches git through
+`captureSessionSourceIdentity(args.cwd)`, which calls `resolveSessionSource` and then
+`captureSourceIdentity(sourceCwd)`. With no binding `resolveSessionSource` returns `cwd`
+unchanged, so `--cwd` **is** the git cwd. That is exactly why git fails: the FSM directory
+is not a repository. Propagating `--cwd` harder changes nothing.
 
 The real gap is that the one mechanism designed to separate them refuses this shape.
 
 ## 2. Why `cxc session source` cannot express it today
 
-```ts
-// session-source.ts, bindSessionSource
-const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
-if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
-  throw new Error("Source must be a linked worktree root in the native session's repository.");
-}
-```
-
-Two independent blocks:
-
-1. `gitIdentity(cwd)` **throws** when the native cwd is not a repository. #109's FSM
-   directory is not one, so the call dies before any comparison runs.
-2. Even surviving that, `source.commonDir !== native.commonDir` demands the target be a
-   linked worktree of the **same** repository. A non-git parent holding an unrelated
-   git child has no shared `commonDir` and can never satisfy it.
-
-The same asymmetry exists in `verifyBinding` (`session-source.ts:91`), which re-derives
-`native.commonDir` on every resolve.
-
-## 3. Options considered
-
-### Option A — a per-command `--source-cwd` flag
-
-Add `--source-cwd <path>` to `receipt test` and `orchestrate`, used for git while
-`--cwd` stays the FSM.
-
-**Rejected.** It makes source identity a per-invocation argument. The B→C baseline and
-the C→D check would be free to pass different values, and `compareSource` would then
-be comparing two different trees while reporting `same`. That is a forgery surface
-aimed straight at CHECK-BINDING-01, and it is worse than the bug: today the cycle
-cannot close, which is safe; with Option A it can close on the wrong tree. It also
-duplicates a binding that is already supposed to be immutable and session-owned.
-
-### Option B — widen `bindSessionSource` to accept a non-git native cwd (**recommended**)
-
-Keep exactly one immutable, session-owned, on-disk binding. Relax only the premise
-that the native cwd must itself be a repository. When it is not, accept a target that
-is a git **root** in its own right.
-
-Everything downstream is already written for this: `resolveSessionSource` returns the
-bound root, `captureSessionSourceIdentity` captures against it with
-`excludeCodexclawArtifacts: true` and stamps `sourceRoot`, and the receipt then carries
-a real commit sha. No gate is loosened; a previously unreachable input becomes
-reachable.
-
-It also composes with L4 by construction: L4 refuses on an **unavailable source
-identity**, and after this binding the identity resolves, so L4 stops firing without
-knowing anything about split cwds.
-
-## 4. Change map
-
-| file | NEW/MODIFY/DELETE | change |
-|---|---|---|
-| `plugins/codexclaw/components/pabcd-state/src/session-source.ts` | MODIFY | `gitIdentity` gains a non-throwing probe; `bindSessionSource` and `verifyBinding` accept a non-git native cwd |
-| `plugins/codexclaw/components/pabcd-state/src/session-cli.ts` | MODIFY | `session source` error text names the new accepted shape |
-| `plugins/codexclaw/components/pabcd-state/dist/*.js` | MODIFY | `npm run build` |
-| `plugins/codexclaw/components/pabcd-state/test/session-source.test.ts` | MODIFY | binding acceptance/rejection matrix for a non-git native |
-| `plugins/codexclaw/components/pabcd-state/test/split-cwd-cycle.test.ts` | NEW | the c-8 positive path, end to end |
-
-## 5. Design detail
-
-### 5.1 A non-throwing native probe
-
-`gitIdentity` stays as-is for the source side, where a repository is mandatory. Add a
-probe for the native side:
+`session-source.ts:102-105`, inside `bindSessionSource` (`:98`):
 
 ```ts
-/**
- * Native-side git identity, or null when the native cwd is not a repository.
- *
- * #109: an FSM directory need not be a repository. When it is one, the existing
- * linked-worktree rule applies unchanged. When it is not, there is no `commonDir`
- * to compare against and the only meaningful requirement is that the target is a
- * repository root. `gitIdentity` keeps throwing for the SOURCE, where a repository
- * is mandatory.
- */
-function nativeGitIdentity(cwd: string): { root: string; commonDir: string; gitDir: string } | null {
-  try { return gitIdentity(cwd); } catch { return null; }
-}
-```
-
-The `catch` is safe because `gitIdentity` already pipes stderr (`session-source.ts:30`),
-so a non-repository probe is silent.
-
-### 5.2 The widened guard
-
-before (`session-source.ts:100-104`):
-
-```ts
+  const nativeCwd = canonical(cwd);
+  const sourceRoot = canonical(target);
   const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
   if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
     throw new Error("Source must be a linked worktree root in the native session's repository.");
   }
 ```
+
+Two independent blocks:
+
+1. `gitIdentity(cwd)` **throws** when the native cwd is not a repository, so the call dies
+   before any comparison runs.
+2. Even surviving that, `source.commonDir !== native.commonDir` demands a linked worktree of
+   the **same** repository. A non-git parent holding an unrelated git child can never
+   satisfy it.
+
+The same asymmetry is in `resolveSessionSource` (`:80-95`), which re-derives
+`gitIdentity(cwd)` at `:88` on every resolve.
+
+## 3. Options
+
+### Option A — a per-command `--source-cwd` flag: rejected
+
+It makes source identity a per-invocation argument. The B baseline and the C check would
+be free to pass different values while `compareSource` reported `same`. That is a forgery
+surface aimed at CHECK-BINDING-01, and it is **worse than the bug**: today the cycle
+cannot close, which is safe; with Option A it can close on the wrong tree.
+
+### Option B — widen `bindSessionSource` to accept a non-git native cwd: chosen
+
+Keep one immutable, session-owned, on-disk binding. Relax only the premise that the
+native cwd must itself be a repository. Everything downstream is already written for it:
+`resolveSessionSource` returns the bound root, `captureSessionSourceIdentity` captures
+against it with `excludeCodexclawArtifacts: true` and stamps `sourceRoot`, and the receipt
+then carries a real commit sha.
+
+It composes with L4 by construction. L4 refuses on an **unavailable source identity**
+(`source-gate.ts`), so once the identity resolves, that gate switches itself off.
+
+## 4. Change map
+
+| file | NEW/MODIFY/DELETE | change |
+|---|---|---|
+| `pabcd-state/src/session-source.ts` | MODIFY | §5 — the probe, the widened bind guard, the conditional resolve clause |
+| `pabcd-state/dist/session-source.js` | MODIFY | `npm run build`, already tracked |
+| `pabcd-state/test/worktree-source-integration.test.ts` | MODIFY | the existing binding matrix lives here (`:209`), **not** in a `session-source.test.ts`, which does not exist |
+| `pabcd-state/test/split-cwd-cycle.test.ts` | NEW | the c-8 positive path |
+
+## 5. Design
+
+### 5.1 A non-throwing native probe that does NOT swallow every git failure
+
+Revision 1 wrapped `gitIdentity` in a bare `catch` returning `null`. The audit was right
+that this is too broad: it would treat a **corrupt or unreadable** repository as "not a
+repository" and then allow binding an unrelated repo, quietly relaxing the linked-worktree
+guard for a case that has nothing to do with #109.
+
+Discriminate instead. `git rev-parse --git-dir` succeeds inside any repository, including
+one whose fuller identity resolution failed, so it separates "no repo here" from "repo is
+broken":
+
+```ts
+/**
+ * Native-side git identity, or null ONLY when the native cwd is genuinely not inside a
+ * repository.
+ *
+ * #109: an FSM directory need not be a repository. When it is one, the existing
+ * linked-worktree rule applies unchanged. When it is not, there is no `commonDir` to
+ * compare against and the only meaningful requirement is that the target is a
+ * repository root. `gitIdentity` keeps throwing for the SOURCE, where a repository is
+ * mandatory.
+ *
+ * The discriminator matters: a bare catch would also swallow a corrupt or unreadable
+ * repository and then let an UNRELATED repo be bound as this session's source, relaxing
+ * the linked-worktree guard for a reason that has nothing to do with #109.
+ * `rev-parse --git-dir` succeeds inside any repository, so a failure there is the
+ * canonical "not a repository" signal; anything else is rethrown.
+ */
+function nativeGitIdentity(cwd: string): { root: string; commonDir: string; gitDir: string } | null {
+  try {
+    return gitIdentity(cwd);
+  } catch (err) {
+    try {
+      execFileSync("git", ["rev-parse", "--git-dir"], { cwd, env: gitEnvForProbe(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    } catch {
+      return null; // not inside a repository at all
+    }
+    throw err; // inside a repository, but its identity could not be resolved
+  }
+}
+```
+
+Reuse whatever env sanitisation `gitIdentity` already applies (it strips `GIT_DIR`,
+`GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE` at `:27-29`); extract it rather than
+re-inlining, so the probe cannot be redirected by a stray `GIT_DIR`.
+
+### 5.2 The widened bind guard
+
+before (`session-source.ts:102-105`) — quoted in §2.
 
 after:
 
@@ -136,107 +137,72 @@ after:
       throw new Error("Source must be a linked worktree root in the native session's repository.");
     }
   } else {
-    // #109: non-git native cwd. There is no repository to be a worktree OF, so the
-    // root check above is the whole requirement. Reject a source that would contain
-    // the FSM's own .codexclaw tree: the identity capture excludes those artifacts,
-    // but a source root ABOVE the FSM directory would also sweep in unrelated
-    // siblings and silently widen what the receipt certifies.
-    const fsmArtifacts = canonical(cwd);
-    if (fsmArtifacts === sourceRoot || fsmArtifacts.startsWith(sourceRoot + sep)) {
+    // #109: non-git native cwd. There is no repository to be a worktree OF, so the root
+    // check above is the whole requirement -- EXCEPT that the source must not contain the
+    // FSM directory. captureSourceIdentity excludes only `.codexclaw/`
+    // (source-identity.ts excludeCodexclawArtifacts), so binding an ANCESTOR of the FSM
+    // directory would sweep the session's own siblings into the certified tree and
+    // silently widen what the receipt attests to.
+    if (nativeCwd === sourceRoot || nativeCwd.startsWith(sourceRoot + sep)) {
       throw new Error("Source root must not contain the session's own working directory; bind the repository itself, not an ancestor of it.");
     }
   }
 ```
 
-Import `sep` from `node:path`.
+Import `sep` from `node:path`. Both sides of the containment test are `canonical()`
+output (`:23-25`, `realpathSync.native`), so Windows extended-length and 8.3 aliases are
+already normalised — a raw string prefix comparison would be unsound on this platform.
 
-`commonDir` and `gitDir` are still recorded in the binding from the **source** side, so
-`verifyBinding` keeps detecting a moved or re-pointed source worktree.
+### 5.3 `resolveSessionSource` — make ONE clause conditional, not three
 
-### 5.3 `verifyBinding` symmetry
+Revision 1's snippet dropped `source.commonDir !== binding.commonDir` along with the native
+clause. That is the blocker the audit caught: on a non-git native it would stop detecting
+a **re-pointed source**. All three source-side clauses stay; only the native one is
+conditional.
 
-`session-source.ts:91` compares `native.commonDir !== binding.commonDir`. With a non-git
-native that comparison is meaningless and must be skipped, using the same probe:
-
-```ts
-  const native = nativeGitIdentity(cwd);
-  if (source.root !== binding.sourceRoot
-      || source.gitDir !== binding.gitDir
-      || (native !== null && native.commonDir !== binding.commonDir)) {
-    throw new Error("Bound source worktree moved or its repository identity changed.");
-  }
-```
-
-Read the exact surrounding lines before patching; `:91` is the tail of a multi-line
-condition.
-
-### 5.4 Exact anchors, resolved at L4 head `96e9486a`
-
-**Correction to §5.3's naming.** There is no `verifyBinding` function. The re-derivation on
-every resolve lives in `resolveSessionSource` itself, and the comparison to relax is at
-`session-source.ts:91`, the tail of a four-clause condition:
+before (`session-source.ts:88-93`):
 
 ```ts
-// session-source.ts:80-95
-export function resolveSessionSource(cwd: string, sessionId: string): string {
-  const binding = readBinding(cwd, sessionId);
-  const pinned = readState(cwd, sessionId).boundSourceRoot;
-  if (!binding) {
-    if (pinned) throw new Error("Source binding is missing for the pinned worktree; restore the same binding before continuing.");
-    return cwd;
-  }
-  if (pinned && binding.sourceRoot !== pinned) throw new Error("Source binding differs from the session's pinned worktree.");
   const native = gitIdentity(cwd);
   const source = gitIdentity(binding.sourceRoot);
   if (source.root !== binding.sourceRoot || source.commonDir !== binding.commonDir
       || source.gitDir !== binding.gitDir || native.commonDir !== binding.commonDir) {
     throw new Error("Bound source worktree moved or its repository identity changed.");
   }
-  return binding.sourceRoot;
-}
 ```
 
-Note `:88`: `gitIdentity(cwd)` **throws** for a non-git native cwd, so resolve fails before
-the comparison is even reached. Both `:88` and the `native.commonDir` clause at `:91` must
-become conditional, and the other three clauses must stay — they are what detect a moved
-or re-pointed source.
-
-**`bindSessionSource`** is `:98`, and the guard to widen is `:102-105`:
+after:
 
 ```ts
-  const nativeCwd = canonical(cwd);
-  const sourceRoot = canonical(target);
-  const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
-  if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
-    throw new Error("Source must be a linked worktree root in the native session's repository.");
+  const native = nativeGitIdentity(cwd);
+  const source = gitIdentity(binding.sourceRoot);
+  // The three SOURCE clauses are what detect a moved or re-pointed source worktree and
+  // stay unconditional. Only the NATIVE clause is conditional, because a non-git native
+  // cwd has no commonDir to compare (#109).
+  if (source.root !== binding.sourceRoot || source.commonDir !== binding.commonDir
+      || source.gitDir !== binding.gitDir
+      || (native !== null && native.commonDir !== binding.commonDir)) {
+    throw new Error("Bound source worktree moved or its repository identity changed.");
   }
 ```
-
-`canonical()` already exists at `:22-24` using `realpathSync.native`, so the ancestor
-comparison in §5.2 gets Windows extended-length and 8.3 handling for free. `gitIdentity`
-is `:26` and already pipes stderr and strips `GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR`/
-`GIT_INDEX_FILE`, so the non-throwing probe can wrap it without losing either property.
-
-The immutability path (`:106-110`) and the phase guard are downstream of the widened
-check and need no change.
 
 ## 6. What is deliberately NOT changed
 
 - `check-gate.ts` and `receipt-cli.ts`: untouched. `unavailable` still refuses.
 - `compareSource`: untouched. `unavailable` vs `unavailable` is still never `same`.
-- The binding remains **immutable** and session-owned, and still cannot be created
-  after B (`["IDLE","I","P","A"]` phase guard).
-- `GIT_ROUTING_VARS` sanitisation in `gitEnv()`: untouched, so a stray `GIT_DIR` cannot
-  redirect the capture.
-- `excludeCodexclawArtifacts: true` on the bound path: untouched, so FSM bookkeeping
-  never registers as a source change.
+- The binding stays **immutable** and session-owned, and still cannot be created after B
+  (the `["IDLE","I","P","A"]` phase guard at `:106-118`).
+- `GIT_*` sanitisation: untouched, and the new probe inherits it.
+- `excludeCodexclawArtifacts: true` on the bound path: untouched.
 
-This layer makes a real git identity **reachable**. It does not make an absent one
-acceptable.
+An independent reviewer confirmed there is no CHECK-BINDING-01 bypass here: this layer
+makes a real git identity **reachable**, and never makes an absent one acceptable.
 
 ## 7. Tests
 
-### 7.1 MODIFY `test/session-source.test.ts` — acceptance matrix
+### 7.1 MODIFY `test/worktree-source-integration.test.ts` — acceptance matrix
+
+The existing binding matrix is in this file (around `:209`). Extend it:
 
 | native cwd | target | expected |
 |---|---|---|
@@ -246,30 +212,53 @@ acceptable.
 | not a repo | an **ancestor** directory containing the FSM dir | rejected, "must not contain" |
 | repo | linked worktree, same repo | accepted (unchanged) |
 | repo | unrelated repo root | rejected (unchanged) |
+| **repo present but identity unresolvable** | any | **throws, not treated as non-git** (§5.1) |
 | any | relative path | rejected (unchanged) |
-| any | second, different target after binding | rejected, immutable (unchanged) |
+| any | a second, different target after binding | rejected, immutable (unchanged) |
+
+The seventh row is the §5.1 discriminator. Without it, a later "simplify the catch"
+refactor silently re-opens the linked-worktree guard.
 
 ### 7.2 NEW `test/split-cwd-cycle.test.ts` — the c-8 positive path
 
-This is the test whose absence let #109 sit open. Fixture: a temp directory that is
-**not** a repository, containing a `src/` child that is `git init` with one commit.
+Fixture: a temp directory that is **not** a repository, containing a `src/` child that is
+`git init` with one commit.
 
-1. `loop init --session <id>` in the FSM dir. Under L4 this refuses, so the test binds
-   first: `cxc session source <fsm>/src --json`, then `loop init` succeeds. **This
-   ordering is the L4/L5 composition assertion** — it proves the two layers compose
-   rather than contradict.
-2. `orchestrate P → A → B → C` with real attests.
-3. `cxc receipt test --session <id> -- <trivially passing command>` writes a receipt,
-   exit 0.
-4. **Assert the receipt's `sourceIdentity.kind` is not `unavailable` and its
-   `commitSha` equals `git -C <fsm>/src rev-parse HEAD`.** This is the criterion. A
-   receipt that merely exists does not satisfy c-8.
-5. `orchestrate D` with `testReceiptPath` closes to IDLE.
-6. Negative control: mutate a tracked file in `src/` between the B baseline and the
-   check, and confirm `receipt test` still refuses with `changed the source while running`.
-   Separation must not cost staleness detection.
+**`session bind` comes first.** `session-cli.ts:96` refuses `session source` when the
+session has no state, so revision 1's ordering would have failed for a reason unrelated to
+#109 and looked like a c-8 failure. Either drive `session bind` first or seed the state
+file directly; the test must not depend on a native Codex thread existing.
 
-## 8. Reproduction (parent fails, L5 head passes)
+1. Seed session state, then `cxc session source <fsm>/src --json` succeeds.
+2. `loop init --session <id>` succeeds. **This is the L4/L6 composition assertion**: under
+   L4 the same call in this directory is refused, and it passes here only because the
+   binding made the source identity resolvable.
+3. `orchestrate P → A → B → C` with real attests.
+4. `cxc receipt test --session <id> -- <trivially passing command>` writes a receipt, exit 0.
+5. **Assert the receipt's `sourceIdentity.kind` is not `unavailable` and its `commitSha`
+   equals `git -C <fsm>/src rev-parse HEAD`.** This is the criterion. A receipt that
+   merely exists does not satisfy c-8.
+6. `orchestrate D` with `testReceiptPath` closes to IDLE.
+
+### 7.3 The negative control — assert the RIGHT refusal
+
+Revision 1 mutated the tree between B and the check and expected `receipt test` to say
+`changed the source while running`. The audit showed that is a different assertion:
+that message fires when the command mutates the tree **during** its own run
+(`receipt-cli.ts:154`), and a mutation made *before* `receipt test` starts leaves its
+before/after snapshots equal, so it passes.
+
+Two separate controls, each aimed at its real gate:
+
+- **During-run mutation** → `receipt test` refuses with `changed the source while running`.
+  Use a check command that writes a tracked file.
+- **Between-check-and-D mutation** → `C→D` refuses via `check-gate.ts:77`, the
+  "source changed after the check ran" path. Write the receipt first, then mutate a
+  tracked file, then attempt `orchestrate D`.
+
+Together they prove staleness detection survived the separation. Revision 1 proved neither.
+
+## 8. Reproduction (parent fails, L6 head passes)
 
 ```powershell
 $fsm = Join-Path $env:TEMP ("cxc-split-" + [guid]::NewGuid())
@@ -279,40 +268,35 @@ cd (Join-Path $fsm "src")
 git init -q; "x" | Set-Content -Encoding utf8 a.txt; git add a.txt
 git -c user.name=t -c user.email=t@t commit -q -m init
 cd $fsm
+# session state must exist BEFORE `session source`: session-cli.ts:96 refuses otherwise,
+# and that failure has nothing to do with #109. In a standalone terminal the id is `cli`.
+cxc session bind --session cli
 cxc session source (Join-Path $fsm "src") --json
 ```
 
-On the L4 head that last command fails with `Source must be a linked worktree root in`
-`the native session's repository.` (and on the pre-L4 parent, `gitIdentity(cwd)` throws
-first). On the L5 head it succeeds, `cxc session current --json` reports `sourceCwd`
-and `sourceIdentity`, and the full bound cycle closes with a receipt carrying the
-`src` HEAD sha.
+On the L5 head that last command fails with `Source must be a linked worktree root in the`
+`native session's repository.` — or, before L4, `gitIdentity(cwd)` throws first. On the L6
+head it succeeds, and the full bound cycle closes with a receipt carrying the `src` HEAD sha.
 
 ## 9. Regression risk
 
-Highest in this stack. The guard being widened is the one that decides which tree a
-receipt certifies.
+Highest in this stack. The guard being widened decides which tree a receipt certifies.
 
-- **Widening too far.** The `source.root !== sourceRoot` check is retained and now runs
+- **Widening too far.** `source.root !== sourceRoot` is retained and now runs
   unconditionally, so a subdirectory can never be bound. §7.1 row 3 pins it.
-- **Binding an ancestor.** The FSM directory would then be inside the certified tree,
-  and its `.codexclaw` churn plus unrelated siblings would enter the identity. The
-  explicit ancestor rejection plus §7.1 row 4 pin it.
-- **Losing staleness detection.** §7.2 case 6 is the negative control.
-- **Weakening the `unavailable` refusal.** Nothing in the gate files is touched; §6
-  enumerates what stays.
-- **`verifyBinding` drift.** Skipping the `commonDir` comparison for a non-git native
-  must not skip the `gitDir`/`root` comparisons, which are what detect a re-pointed
-  source. §5.3 keeps both.
-
-A POSIX-only reviewer should note the ancestor test uses `canonical()` on both sides,
-so `realpathSync.native` handles the Windows extended-length and 8.3 aliases that L2
-addressed; a prefix comparison on raw strings would be unsound on this platform.
+- **Binding an ancestor.** The FSM directory would then be inside the certified tree, and
+  its siblings would enter the identity, since `excludeCodexclawArtifacts` only excludes
+  `.codexclaw/`. Explicit rejection plus §7.1 row 4.
+- **Swallowing a broken repository.** §5.1's discriminator plus §7.1 row 7.
+- **Losing re-point detection.** All three source clauses stay in §5.3; this was revision
+  1's blocker.
+- **Losing staleness detection.** §7.3's two controls, each on its real gate.
+- **Weakening the `unavailable` refusal.** Nothing in the gate files is touched; §6 lists
+  what stays.
 
 ## 10. Criterion
 
-**c-8**: a goalplan-bound session whose FSM directory is not a git repository but
-whose source tree is, completes P through D and the written receipt carries a real
-commit sha rather than an unavailable identity. Proved by §7.2 cases 4 and 5, with §7.2
-case 1 additionally proving L4/L5 composition and case 6 proving staleness detection
-survived.
+**c-8**: a goalplan-bound session whose FSM directory is not a git repository but whose
+source tree is, completes P through D and the written receipt carries a real commit sha
+rather than an unavailable identity. Proved by §7.2 steps 5 and 6, with step 2 proving
+L4/L6 composition and §7.3 proving staleness detection survived.

--- a/plugins/codexclaw/components/pabcd-state/dist/session-source.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/session-source.js
@@ -2,7 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, constants, fstatSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, sep } from "node:path";
 import { isCanonicalSessionId, readState } from "./state.js";
 
 
@@ -25,8 +25,7 @@ function canonical(path        )         {
 }
 
 function gitIdentity(cwd        )                                                      {
-  const env = { ...process.env };
-  for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) delete env[name];
+  const env = gitProbeEnv();
   const git = (...args          ) => execFileSync("git", args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
   try {
     return {
@@ -35,6 +34,41 @@ function gitIdentity(cwd        )                                               
       gitDir: canonical(git("rev-parse", "--absolute-git-dir")),
     };
   } catch { throw new Error("Cannot resolve source Git worktree identity."); }
+}
+
+/** Routing vars stripped so a stray GIT_DIR cannot redirect any probe below. */
+function gitProbeEnv()                    {
+  const env = { ...process.env };
+  for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) delete env[name];
+  return env;
+}
+
+/**
+ * Native-side git identity, or null ONLY when the native cwd is genuinely not inside a
+ * repository.
+ *
+ * #109: an FSM directory need not be a repository. When it is one, the existing
+ * linked-worktree rule applies unchanged. When it is not, there is no `commonDir` to
+ * compare against and the only meaningful requirement is that the target is a repository
+ * root. `gitIdentity` keeps THROWING for the source side, where a repository is mandatory.
+ *
+ * The discriminator is load-bearing. A bare `catch` here would also swallow a corrupt or
+ * unreadable repository and then let an UNRELATED repo be bound as this session's source,
+ * relaxing the linked-worktree guard for a reason that has nothing to do with #109.
+ * `rev-parse --git-dir` succeeds inside any repository, so a failure there is the
+ * canonical "not a repository" signal; anything else is rethrown.
+ */
+function nativeGitIdentity(cwd        )                                                             {
+  try {
+    return gitIdentity(cwd);
+  } catch (err) {
+    try {
+      execFileSync("git", ["rev-parse", "--git-dir"], { cwd, env: gitProbeEnv(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    } catch {
+      return null; // not inside a repository at all
+    }
+    throw err; // inside a repository, but its identity could not be resolved
+  }
 }
 
 function bindingPath(cwd        , sessionId        )         {
@@ -85,10 +119,14 @@ export function resolveSessionSource(cwd        , sessionId        )         {
     return cwd;
   }
   if (pinned && binding.sourceRoot !== pinned) throw new Error("Source binding differs from the session's pinned worktree.");
-  const native = gitIdentity(cwd);
+  const native = nativeGitIdentity(cwd);
   const source = gitIdentity(binding.sourceRoot);
+  // The three SOURCE clauses are what detect a moved or re-pointed source worktree and
+  // stay UNCONDITIONAL. Only the native clause is conditional, because a non-git native
+  // cwd has no commonDir to compare (#109).
   if (source.root !== binding.sourceRoot || source.commonDir !== binding.commonDir
-      || source.gitDir !== binding.gitDir || native.commonDir !== binding.commonDir) {
+      || source.gitDir !== binding.gitDir
+      || (native !== null && native.commonDir !== binding.commonDir)) {
     throw new Error("Bound source worktree moved or its repository identity changed.");
   }
   return binding.sourceRoot;
@@ -99,9 +137,36 @@ export function bindSessionSource(cwd        , sessionId        , target        
   if (!isAbsolute(target)) throw new Error("Source worktree path must be absolute.");
   const nativeCwd = canonical(cwd);
   const sourceRoot = canonical(target);
-  const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
-  if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
-    throw new Error("Source must be a linked worktree root in the native session's repository.");
+  const native = nativeGitIdentity(cwd), source = gitIdentity(sourceRoot);
+  if (source.root !== sourceRoot) {
+    throw new Error("Source must be the root of a Git repository or worktree.");
+  }
+  if (native) {
+    // Unchanged contract for a git native cwd: same repository, different worktree.
+    if (source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
+      throw new Error("Source must be a linked worktree root in the native session's repository.");
+    }
+  } else {
+    // #109: non-git native cwd. There is no repository to be a worktree OF, so the root
+    // check above is the whole requirement.
+    //
+    // The containment test below is a DEFENSIVE INVARIANT, not a reachable branch, and
+    // saying so is the point. Entering this else-branch means nativeGitIdentity returned
+    // null, i.e. the FSM cwd is not inside ANY repository. A source root that CONTAINED
+    // the FSM cwd would put that cwd inside the source repository, which would have made
+    // the probe non-null and sent us down the `native` branch instead. So the condition
+    // cannot fire today. It is kept because the consequence of it ever firing is bad and
+    // silent -- captureSourceIdentity excludes only `.codexclaw/`, so an ancestor binding
+    // would sweep the session's own siblings into the certified tree and widen what the
+    // receipt attests to -- and because a future change to the probe's definition of
+    // "non-git" could make it reachable without anyone noticing.
+    //
+    // Both sides are canonical() output, so Windows extended-length and 8.3 aliases are
+    // already normalised; a raw string prefix test would be unsound on this platform.
+    // A test proving the unreachability lives in worktree-source-integration.test.ts.
+    if (nativeCwd === sourceRoot || nativeCwd.startsWith(sourceRoot + sep)) {
+      throw new Error("Source root must not contain the session's own working directory; bind the repository itself, not an ancestor of it.");
+    }
   }
   const previous = readBinding(cwd, sessionId);
   if (previous) {

--- a/plugins/codexclaw/components/pabcd-state/src/session-source.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/session-source.ts
@@ -2,7 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { closeSync, constants, fstatSync, linkSync, lstatSync, mkdirSync, openSync, readFileSync, realpathSync, unlinkSync, writeFileSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, sep } from "node:path";
 import { isCanonicalSessionId, readState } from "./state.ts";
 
 interface SourceBinding {
@@ -25,8 +25,7 @@ function canonical(path: string): string {
 }
 
 function gitIdentity(cwd: string): { root: string; commonDir: string; gitDir: string } {
-  const env = { ...process.env };
-  for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) delete env[name];
+  const env = gitProbeEnv();
   const git = (...args: string[]) => execFileSync("git", args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
   try {
     return {
@@ -35,6 +34,41 @@ function gitIdentity(cwd: string): { root: string; commonDir: string; gitDir: st
       gitDir: canonical(git("rev-parse", "--absolute-git-dir")),
     };
   } catch { throw new Error("Cannot resolve source Git worktree identity."); }
+}
+
+/** Routing vars stripped so a stray GIT_DIR cannot redirect any probe below. */
+function gitProbeEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const name of ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"]) delete env[name];
+  return env;
+}
+
+/**
+ * Native-side git identity, or null ONLY when the native cwd is genuinely not inside a
+ * repository.
+ *
+ * #109: an FSM directory need not be a repository. When it is one, the existing
+ * linked-worktree rule applies unchanged. When it is not, there is no `commonDir` to
+ * compare against and the only meaningful requirement is that the target is a repository
+ * root. `gitIdentity` keeps THROWING for the source side, where a repository is mandatory.
+ *
+ * The discriminator is load-bearing. A bare `catch` here would also swallow a corrupt or
+ * unreadable repository and then let an UNRELATED repo be bound as this session's source,
+ * relaxing the linked-worktree guard for a reason that has nothing to do with #109.
+ * `rev-parse --git-dir` succeeds inside any repository, so a failure there is the
+ * canonical "not a repository" signal; anything else is rethrown.
+ */
+function nativeGitIdentity(cwd: string): { root: string; commonDir: string; gitDir: string } | null {
+  try {
+    return gitIdentity(cwd);
+  } catch (err) {
+    try {
+      execFileSync("git", ["rev-parse", "--git-dir"], { cwd, env: gitProbeEnv(), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    } catch {
+      return null; // not inside a repository at all
+    }
+    throw err; // inside a repository, but its identity could not be resolved
+  }
 }
 
 function bindingPath(cwd: string, sessionId: string): string {
@@ -85,10 +119,14 @@ export function resolveSessionSource(cwd: string, sessionId: string): string {
     return cwd;
   }
   if (pinned && binding.sourceRoot !== pinned) throw new Error("Source binding differs from the session's pinned worktree.");
-  const native = gitIdentity(cwd);
+  const native = nativeGitIdentity(cwd);
   const source = gitIdentity(binding.sourceRoot);
+  // The three SOURCE clauses are what detect a moved or re-pointed source worktree and
+  // stay UNCONDITIONAL. Only the native clause is conditional, because a non-git native
+  // cwd has no commonDir to compare (#109).
   if (source.root !== binding.sourceRoot || source.commonDir !== binding.commonDir
-      || source.gitDir !== binding.gitDir || native.commonDir !== binding.commonDir) {
+      || source.gitDir !== binding.gitDir
+      || (native !== null && native.commonDir !== binding.commonDir)) {
     throw new Error("Bound source worktree moved or its repository identity changed.");
   }
   return binding.sourceRoot;
@@ -99,9 +137,36 @@ export function bindSessionSource(cwd: string, sessionId: string, target: string
   if (!isAbsolute(target)) throw new Error("Source worktree path must be absolute.");
   const nativeCwd = canonical(cwd);
   const sourceRoot = canonical(target);
-  const native = gitIdentity(cwd), source = gitIdentity(sourceRoot);
-  if (source.root !== sourceRoot || source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
-    throw new Error("Source must be a linked worktree root in the native session's repository.");
+  const native = nativeGitIdentity(cwd), source = gitIdentity(sourceRoot);
+  if (source.root !== sourceRoot) {
+    throw new Error("Source must be the root of a Git repository or worktree.");
+  }
+  if (native) {
+    // Unchanged contract for a git native cwd: same repository, different worktree.
+    if (source.commonDir !== native.commonDir || source.gitDir === native.gitDir) {
+      throw new Error("Source must be a linked worktree root in the native session's repository.");
+    }
+  } else {
+    // #109: non-git native cwd. There is no repository to be a worktree OF, so the root
+    // check above is the whole requirement.
+    //
+    // The containment test below is a DEFENSIVE INVARIANT, not a reachable branch, and
+    // saying so is the point. Entering this else-branch means nativeGitIdentity returned
+    // null, i.e. the FSM cwd is not inside ANY repository. A source root that CONTAINED
+    // the FSM cwd would put that cwd inside the source repository, which would have made
+    // the probe non-null and sent us down the `native` branch instead. So the condition
+    // cannot fire today. It is kept because the consequence of it ever firing is bad and
+    // silent -- captureSourceIdentity excludes only `.codexclaw/`, so an ancestor binding
+    // would sweep the session's own siblings into the certified tree and widen what the
+    // receipt attests to -- and because a future change to the probe's definition of
+    // "non-git" could make it reachable without anyone noticing.
+    //
+    // Both sides are canonical() output, so Windows extended-length and 8.3 aliases are
+    // already normalised; a raw string prefix test would be unsound on this platform.
+    // A test proving the unreachability lives in worktree-source-integration.test.ts.
+    if (nativeCwd === sourceRoot || nativeCwd.startsWith(sourceRoot + sep)) {
+      throw new Error("Source root must not contain the session's own working directory; bind the repository itself, not an ancestor of it.");
+    }
   }
   const previous = readBinding(cwd, sessionId);
   if (previous) {

--- a/plugins/codexclaw/components/pabcd-state/test/split-cwd-cycle.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/split-cwd-cycle.test.ts
@@ -1,0 +1,183 @@
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { runSessionCli } from "../src/session-cli.ts";
+import { runGoalplanCli, parseGoalplanCliArgs } from "../src/goalplan-cli.ts";
+import { runOrchestrateCli, parseOrchestrateCliArgs } from "../src/orchestrate-cli.ts";
+import { runReceiptCli, receiptPathFor } from "../src/receipt-cli.ts";
+import { defaultState, writeState, readState } from "../src/state.ts";
+
+/**
+ * #109 positive path. The criterion (c-8) is not that a bound cycle CLOSES in a split cwd;
+ * it is that the receipt it closes on carries a REAL commit sha rather than an unavailable
+ * identity. A receipt that merely exists would satisfy a weaker reading and prove nothing
+ * about the evidence chain.
+ *
+ * Layer composition is asserted in step 2: under L4 the same bound `loop init` call in this
+ * directory is REFUSED, because the source identity is unavailable. It succeeds here only
+ * because the binding in step 1 made that identity resolvable. The two layers compose
+ * rather than one undoing the other.
+ */
+const id = "019a0000-0000-7000-8000-000000000109";
+
+function splitCwd(t: TestContext) {
+  const root = realpathSync.native(mkdtempSync(join(tmpdir(), "cxc-split-cycle-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  // The FSM directory is deliberately NOT a repository; the source tree under it is.
+  const cwd = join(root, "fsm"), source = join(cwd, "src"), home = join(root, "home");
+  mkdirSync(cwd); mkdirSync(source); mkdirSync(home);
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: source, stdio: "pipe" });
+  git("init", "-q");
+  git("config", "user.name", "test");
+  git("config", "user.email", "test@example.invalid");
+  writeFileSync(join(source, "tracked.txt"), "x\n");
+  git("add", ".");
+  git("commit", "-qm", "init");
+  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: source, encoding: "utf8" }).trim();
+  const db = new DatabaseSync(join(home, "state_5.sqlite"));
+  db.exec("CREATE TABLE threads (id TEXT, cwd TEXT, archived INTEGER, source TEXT)");
+  db.prepare("INSERT INTO threads VALUES (?, ?, 0, " + JSON.stringify("cli").replace(/"/g, "'") + ")").run(id, cwd);
+  db.close();
+  writeState(cwd, defaultState(id));
+  // Premise: git does not consider the FSM directory a repository.
+  assert.throws(() => execFileSync("git", ["rev-parse", "--git-dir"], { cwd, stdio: "pipe" }));
+  return { root, cwd, source, home, head, env: { CODEX_THREAD_ID: id, CODEX_HOME: home } };
+}
+
+function edge(cwd: string, verb: string, extra: Record<string, unknown> = {}) {
+  const from = verb === "A" ? "P" : verb === "B" ? "A" : verb === "C" ? "B" : "C";
+  // A bound goalplan with registered work phases requires workPhaseId on every gated edge
+  // (LOOP-UNIT-CHAIN-01), and D additionally refuses a plan with no work-phase to close
+  // (CYCLE-COMPLETION-01), which is why boundInit registers one.
+  const att = { from, to: verb, did: "split-cwd probe work", workPhaseId: "wp0", ...extra };
+  const args = parseOrchestrateCliArgs([verb, "--session", id, "--attest", JSON.stringify(att)], cwd);
+  assert.ok(!("error" in args), JSON.stringify(args));
+  return runOrchestrateCli(args);
+}
+
+function enter(cwd: string, verb: string) {
+  const args = parseOrchestrateCliArgs([verb, "--session", id], cwd);
+  assert.ok(!("error" in args));
+  return runOrchestrateCli(args);
+}
+
+function planUnit(cwd: string): string {
+  const rel = join("devlog", "_plan", "260911_probe");
+  mkdirSync(join(cwd, rel), { recursive: true });
+  writeFileSync(join(cwd, rel, "000_plan.md"), "# probe\n\nobjective and constraints.\n");
+  return rel.split("\\").join("/");
+}
+
+function boundInit(f: ReturnType<typeof splitCwd>) {
+  const args = parseGoalplanCliArgs(["init", "--objective", "split cwd probe objective", "--session", id, "--criterion", "the probe closes a cycle"], f.cwd);
+  assert.ok(!("error" in args), JSON.stringify(args));
+  const init = runGoalplanCli(args as never);
+  if (init.code !== 0) return init;
+  const wp = parseGoalplanCliArgs(["add-work-phase", "--session", id, "--id", "wp0", "--title", "the split-cwd probe unit"], f.cwd);
+  assert.ok(!("error" in wp), JSON.stringify(wp));
+  const added = runGoalplanCli(wp as never);
+  assert.equal(added.code, 0, added.output);
+  return init;
+}
+
+function driveToC(f: ReturnType<typeof splitCwd>) {
+  const unit = planUnit(f.cwd);
+  assert.equal(enter(f.cwd, "P").code, 0);
+  const toA = edge(f.cwd, "A", { planUnit: unit });
+  assert.equal(toA.code, 0, toA.output);
+  const toB = edge(f.cwd, "B", { auditOutput: "VERDICT: PASS", auditVerdict: "pass" });
+  assert.equal(toB.code, 0, toB.output);
+  // SOURCE-DELTA-01: B->C refuses when the source is unchanged since B began, because
+  // nothing was implemented in this B. Implement INSIDE B, in the bound source tree --
+  // which is itself a small proof that the bound tree is the one the gate watches.
+  writeFileSync(join(f.source, "implemented.txt"), "work done in B\n");
+  const toC = edge(f.cwd, "C");
+  assert.equal(toC.code, 0, toC.output);
+}
+
+test("#109 c-8: a bound cycle in a split cwd closes on a receipt carrying a real commit sha", t => {
+  const f = splitCwd(t);
+
+  // 1. bind the nested repository as this session source
+  assert.equal(runSessionCli(["source", f.source, "--json"], f.cwd, f.env).code, 0);
+
+  // 2. L4 + L6 composition: this call is refused when the identity is unavailable.
+  const init = boundInit(f);
+  assert.equal(init.code, 0, init.output);
+  assert.equal(readState(f.cwd, id).slug.length > 0, true);
+
+  // 3. drive the cycle
+  driveToC(f);
+
+  // 4. the receipt, and the criterion is its CONTENT rather than its existence
+  const receipt = runReceiptCli({ verb: "test", cwd: f.cwd, session: id,
+    command: [process.execPath, "-e", "process.stdout.write(\"probe ok\")"] } as never);
+  assert.equal(receipt.code, 0, receipt.output);
+  const written = JSON.parse(readFileSync(receiptPathFor(f.cwd, id), "utf8"));
+  assert.notEqual(written.sourceIdentity?.kind, "unavailable");
+  assert.equal(written.sourceIdentity?.commitSha, f.head);
+  // The receipt stays in the NATIVE cwd while the identity follows the source.
+  assert.equal(written.sourceIdentity?.sourceRoot, f.source);
+});
+
+// Control A. A mutation made DURING the check command is what "changed the source while
+// running" detects. A mutation made BEFORE the command starts leaves the before/after
+// snapshots equal and would pass, which is why this control writes from inside the command.
+test("#109: a check that rewrites the source still refuses to produce a receipt", t => {
+  const f = splitCwd(t);
+  assert.equal(runSessionCli(["source", f.source, "--json"], f.cwd, f.env).code, 0);
+  assert.equal(boundInit(f).code, 0);
+  driveToC(f);
+
+  const target = JSON.stringify(join(f.source, "tracked.txt"));
+  const script = "require(" + JSON.stringify("node:fs") + ").writeFileSync(" + target + ", " + JSON.stringify("rewritten\n") + ")";
+  const receipt = runReceiptCli({ verb: "test", cwd: f.cwd, session: id, command: [process.execPath, "-e", script] } as never);
+  assert.equal(receipt.code, 1);
+  assert.match(receipt.output, /changed the source while running/);
+});
+
+// Control B. A mutation made AFTER the check ran is a different gate: the receipt is
+// already written and internally consistent, so `receipt test` has nothing to say about
+// it. C->D is what must refuse, via the "source changed after the check ran" path in
+// check-gate. Asserting control A alone would leave this half unproven, and between them
+// they are what shows the split-cwd separation did not cost staleness detection.
+test("#109: a source mutated after the check cannot close C to D", t => {
+  const f = splitCwd(t);
+  assert.equal(runSessionCli(["source", f.source, "--json"], f.cwd, f.env).code, 0);
+  assert.equal(boundInit(f).code, 0);
+  driveToC(f);
+
+  const receipt = runReceiptCli({ verb: "test", cwd: f.cwd, session: id,
+    command: [process.execPath, "-e", "process.stdout.write(\"probe ok\")"] } as never);
+  assert.equal(receipt.code, 0, receipt.output);
+  const receiptPath = receiptPathFor(f.cwd, id);
+
+  // Now move the tree out from under the receipt.
+  writeFileSync(join(f.source, "tracked.txt"), "changed after the check\n");
+
+  const toD = edge(f.cwd, "D", { checkOutput: "probe ok", exitCode: 0, testReceiptPath: receiptPath });
+  assert.equal(toD.code, 1, toD.output);
+  assert.match(toD.output, /source changed after the check ran/);
+  // And the cycle is still at C, not silently advanced.
+  assert.equal(readState(f.cwd, id).phase, "C");
+});
+
+// The closing half of c-8: with the tree untouched, the same edge DOES close to IDLE.
+test("#109 c-8: the untouched cycle closes C to D and back to IDLE", t => {
+  const f = splitCwd(t);
+  assert.equal(runSessionCli(["source", f.source, "--json"], f.cwd, f.env).code, 0);
+  assert.equal(boundInit(f).code, 0);
+  driveToC(f);
+
+  const receipt = runReceiptCli({ verb: "test", cwd: f.cwd, session: id,
+    command: [process.execPath, "-e", "process.stdout.write(\"probe ok\")"] } as never);
+  assert.equal(receipt.code, 0, receipt.output);
+
+  const toD = edge(f.cwd, "D", { checkOutput: "probe ok", exitCode: 0, testReceiptPath: receiptPathFor(f.cwd, id) });
+  assert.equal(toD.code, 0, toD.output);
+  assert.equal(readState(f.cwd, id).phase, "IDLE");
+});

--- a/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/worktree-source-integration.test.ts
@@ -313,3 +313,112 @@ test("receipt command runs without inherited Git routing variables", t => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// #109 split cwd. The FSM directory need not be a repository; the source tree must be.
+// Before this, gitIdentity(cwd) threw for a non-git native cwd and binding was
+// unreachable, so a bound cycle could never obtain a real commit sha.
+// ---------------------------------------------------------------------------
+function splitFixture(t: TestContext) {
+  const root = realpathSync.native(mkdtempSync(join(tmpdir(), "cxc-split-cwd-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  // The native cwd is deliberately NOT a repository.
+  const cwd = join(root, "fsm"), source = join(cwd, "src"), home = join(root, "home");
+  mkdirSync(cwd); mkdirSync(source); mkdirSync(home);
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: source, stdio: "pipe" });
+  git("init", "-q"); git("config", "user.name", "test"); git("config", "user.email", "test@example.invalid");
+  writeFileSync(join(source, "a.txt"), "x"); git("add", "."); git("commit", "-qm", "init");
+  const db = new DatabaseSync(join(home, "state_5.sqlite"));
+  db.exec("CREATE TABLE threads (id TEXT, cwd TEXT, archived INTEGER, source TEXT)");
+  db.prepare("INSERT INTO threads VALUES (?, ?, 0, 'cli')").run(id, cwd); db.close();
+  const env = { CODEX_THREAD_ID: id, CODEX_HOME: home };
+  writeState(cwd, { ...defaultState(id), phase: "A" });
+  const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: source, encoding: "utf8" }).trim();
+  return { root, cwd, source, home, env, head };
+}
+
+test("#109: a non-git native cwd can bind a nested git source root", t => {
+  const f = splitFixture(t);
+  // Sanity: the premise is that the FSM cwd is NOT inside a repository. Without this the
+  // test would silently exercise the ordinary linked-worktree path instead.
+  assert.throws(() => execFileSync("git", ["rev-parse", "--git-dir"], { cwd: f.cwd, stdio: "pipe" }));
+  assert.equal(runSessionCli(["source", f.source, "--json"], f.cwd, f.env).code, 0);
+  assert.equal(resolveSessionSource(f.cwd, id), f.source);
+});
+
+test("#109: the widened guard still refuses a subdirectory, an ancestor and a second target", t => {
+  const f = splitFixture(t);
+  const child = join(f.source, "child"); mkdirSync(child);
+  // Not a repository ROOT.
+  const sub = runSessionCli(["source", child], f.cwd, f.env);
+  assert.equal(sub.code, 1);
+  assert.match(sub.output, /root of a Git repository/);
+  // The ancestor case gets its own fixture below: initialising a repository at the
+  // ancestor turns the FSM cwd into a git cwd, which would contaminate the immutability
+  // assertions that follow here.
+  // Relative paths stay refused.
+  assert.equal(runSessionCli(["source", "relative"], f.cwd, f.env).code, 1);
+  // Immutability survives the widening.
+  assert.equal(runSessionCli(["source", f.source, "--json"], f.cwd, f.env).code, 0);
+  const other = join(f.cwd, "other"); mkdirSync(other);
+  execFileSync("git", ["init", "-q"], { cwd: other, stdio: "pipe" });
+  assert.equal(runSessionCli(["source", other], f.cwd, f.env).code, 1);
+});
+
+// The discriminator in nativeGitIdentity. A bare `catch` would treat ANY git failure as
+// "not a repository" and then allow binding an unrelated repo, quietly relaxing the
+// linked-worktree guard for a reason unrelated to #109.
+//
+// A BARE repository is the precise case: `rev-parse --git-dir` succeeds, so git does
+// consider this a repository, but `--show-toplevel` fails because there is no work tree,
+// so gitIdentity() throws. The probe must rethrow rather than report non-git.
+//
+// Note the contrast that makes this test meaningful: when `--git-dir` ALSO fails, git
+// itself does not consider the directory a repository, and taking the #109 path is then
+// correct. This case is the other side of that line.
+test("#109: a bare repository is NOT treated as non-git", t => {
+  const root = realpathSync.native(mkdtempSync(join(tmpdir(), "cxc-bare-native-")));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const cwd = join(root, "bare"), home = join(root, "home");
+  mkdirSync(cwd); mkdirSync(home);
+  execFileSync("git", ["init", "--bare", "-q"], { cwd, stdio: "pipe" });
+  // Premise: git owns this directory, but it has no work tree.
+  assert.doesNotThrow(() => execFileSync("git", ["rev-parse", "--git-dir"], { cwd, stdio: "pipe" }));
+  assert.throws(() => execFileSync("git", ["rev-parse", "--show-toplevel"], { cwd, stdio: "pipe" }));
+
+  const foreign = join(root, "foreign-repo"); mkdirSync(foreign);
+  execFileSync("git", ["init", "-q"], { cwd: foreign, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "test"], { cwd: foreign, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "t@example.invalid"], { cwd: foreign, stdio: "pipe" });
+  writeFileSync(join(foreign, "a.txt"), "x");
+  execFileSync("git", ["add", "."], { cwd: foreign, stdio: "pipe" });
+  execFileSync("git", ["commit", "-qm", "init"], { cwd: foreign, stdio: "pipe" });
+
+  const db = new DatabaseSync(join(home, "state_5.sqlite"));
+  db.exec("CREATE TABLE threads (id TEXT, cwd TEXT, archived INTEGER, source TEXT)");
+  db.prepare("INSERT INTO threads VALUES (?, ?, 0, 'cli')").run(id, cwd); db.close();
+  const env = { CODEX_THREAD_ID: id, CODEX_HOME: home };
+  writeState(cwd, { ...defaultState(id), phase: "A" });
+
+  // It must NOT fall through to the #109 path and accept an unrelated repository.
+  assert.equal(runSessionCli(["source", foreign], cwd, env).code, 1);
+});
+
+// Why the containment check inside the non-git branch of bindSessionSource is a DEFENSIVE
+// INVARIANT rather than a reachable path, pinned so a future probe change cannot quietly
+// make it reachable. Entering that branch means the FSM cwd is not inside ANY repository.
+// A source root that CONTAINS the FSM cwd necessarily puts that cwd inside the source
+// repository, which makes nativeGitIdentity non-null and routes the call to the `native`
+// linked-worktree branch instead. So the ancestor is refused -- just not by the message
+// the non-git branch would emit. This test documents the real behaviour instead of
+// asserting a string that never appears.
+test("#109: a source root containing the FSM cwd is refused by the native branch", t => {
+  const f = splitFixture(t);
+  // Before: the FSM cwd is not inside any repository.
+  assert.throws(() => execFileSync("git", ["rev-parse", "--git-dir"], { cwd: f.cwd, stdio: "pipe" }));
+  // Making the ancestor a repository also makes the FSM cwd a git cwd.
+  execFileSync("git", ["init", "-q"], { cwd: f.root, stdio: "pipe" });
+  assert.doesNotThrow(() => execFileSync("git", ["rev-parse", "--git-dir"], { cwd: f.cwd, stdio: "pipe" }));
+  const anc = runSessionCli(["source", f.root], f.cwd, f.env);
+  assert.equal(anc.code, 1);
+  assert.match(anc.output, /linked worktree root/);
+});


### PR DESCRIPTION
Layer **L6**, the top of the Windows issue sweep stack. Base is **L5** (`codex/windows-landmine-sweep`). `enforce-target` will flag the non-`dev` base; expected for a manual chain.

Closes #109.

## The issue's own diagnosis is inverted

#109 says `--cwd` applies to the FSM but git reads the process cwd. The code is the opposite: `--cwd` reaches git through `captureSessionSourceIdentity(args.cwd)` → `resolveSessionSource` → `captureSourceIdentity(sourceCwd)`. With no binding, `resolveSessionSource` returns `cwd` unchanged, so **`--cwd` *is* the git cwd**. That is exactly why git fails — the FSM directory is not a repository. Propagating `--cwd` harder changes nothing.

The real gap: the one mechanism designed to separate them refused this shape. `bindSessionSource` called `gitIdentity(cwd)`, which **throws** for a non-git native cwd, and then demanded `source.commonDir === native.commonDir` — a linked worktree of the *same* repository. A non-git parent holding a nested repo can never satisfy either.

## What changed

`bindSessionSource` accepts a non-git native cwd. `source.root !== sourceRoot` stays unconditional, so a subdirectory can still never be bound; the linked-worktree rule is unchanged when the native cwd *is* a repository.

`resolveSessionSource` makes **one** clause conditional. The three source-side clauses (`root`, `commonDir`, `gitDir`) stay unconditional — they are what detect a moved or re-pointed source. An earlier draft dropped `source.commonDir` along with the native clause, which an audit caught: it would have stopped detecting a re-pointed source on a non-git native cwd.

## The probe does not swallow every git failure

A bare `catch` around `gitIdentity` would treat a **corrupt or unreadable** repository as "not a repository" and then permit binding an unrelated repo — quietly relaxing the linked-worktree guard for a reason unrelated to #109.

So it discriminates: `git rev-parse --git-dir` succeeds inside any repository, so a failure there is the canonical "not a repository" signal, and anything else is **rethrown**. A bare repository is the precise case that separates the two — `--git-dir` succeeds, `--show-toplevel` fails — and there is a test for exactly that.

## What is deliberately NOT changed

`check-gate.ts`, `receipt-cli.ts` and `compareSource` are untouched. `unavailable` still refuses; `unavailable` vs `unavailable` is still never `same`. The binding stays immutable, session-owned, and un-creatable after B. `GIT_*` sanitisation is untouched and the new probe inherits it.

This layer makes a real git identity **reachable**. It never makes an absent one acceptable. An independent reviewer confirmed there is no CHECK-BINDING-01 bypass.

A per-command `--source-cwd` flag was considered and **rejected**: it would let the B baseline and the C check name different trees while `compareSource` reported `same`. That is worse than the bug — today the cycle cannot close, which is safe.

## Composition with L4

L4 refuses a bound cycle whose **source identity is unavailable** — never on a missing `.git`. So once this layer lets a non-git cwd bind a git source, the same call returns `resolved` and L4's gate switches itself off. The two layers compose; neither undoes the other. The positive-path test asserts exactly that ordering: bind, then `loop init --session` succeeds where L4 alone refuses it.

## Verification

```
split-cwd-cycle.test.ts:                4 tests, 4 passed
worktree-source-integration.test.ts:   23 tests, 23 passed
pabcd-state suite:                   1234 tests, 1232 passed, 0 failed, 2 skipped
npm run build: 181 files compiled    npm run gate: OK
inventory --check --tests 3065: OK
```

**c-8 is about the receipt's content, not its existence.** The positive path asserts the written receipt's `sourceIdentity.kind` is not `unavailable` and its `commitSha` **equals `git -C <fsm>/src rev-parse HEAD`**, with `sourceRoot` pointing at the bound tree while the receipt file itself stays in the native cwd. A receipt that merely exists would prove nothing about the evidence chain.

### Two negative controls, each on its real gate

An earlier draft used one control and aimed it at the wrong message. `changed the source while running` fires only when the command mutates the tree **during its own run**; a mutation made *before* `receipt test` starts leaves its before/after snapshots equal and passes.

- **During-run mutation** → `receipt test` refuses with `changed the source while running`.
- **After-check mutation** → `C → D` refuses with `source changed after the check ran`, and the phase stays at `C`.

Between them they show the split-cwd separation did not cost staleness detection.

## One honest note: a defensive invariant that is currently unreachable

The non-git branch contains a check rejecting a source root that *contains* the FSM cwd. Writing a test for it proved it **cannot fire today**: entering that branch means the cwd is not inside any repository, and a source root containing the cwd would put it inside the source repository, which makes the probe non-null and routes the call to the `native` branch instead.

It is kept, commented as an invariant rather than a branch, because the consequence of it ever firing is bad and silent — `captureSourceIdentity` excludes only `.codexclaw/`, so an ancestor binding would sweep the session's siblings into the certified tree — and because a future change to the probe's definition of "non-git" could make it reachable unnoticed. The test asserts the *real* behaviour (refused by the native branch) instead of a string that never appears.

Plan: `devlog/_plan/260911_windows_issue_sweep/045_wp8_split_cwd_source.md`.
