### PR TITLE
fix(provider-bridge): reuse win-exec for PATHEXT resolution and ComSpec routing (L1, #131)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C032_passing-brightgreen" alt="3,032 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C032_passing-brightgreen" alt="3,032 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C038_passing-brightgreen" alt="3,038 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C032_passing-brightgreen" alt="3,032 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C037_passing-brightgreen" alt="3,037 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
+++ b/devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md
@@ -355,6 +355,19 @@ The behaviour difference from `where` is that a launcher reachable only through 
 `where`-visible alias but not through PATH+PATHEXT would no longer be found; no such
 case exists for npm global installs, which is the shape #131 reports.
 
+**Measured second behaviour difference: the reported extension carries PATHEXT casing.**
+`resolveWindowsCommand` builds candidates as `command + ext` using PATHEXT's own
+spelling, and Windows `existsSync` is case-insensitive, so a file named `ocx.cmd` on
+disk resolves to a path ending `.CMD` when PATHEXT says `.CMD`. The old `where`-parsing
+path reported the on-disk casing instead. Caught by the §5 tests on first run.
+
+Impact is cosmetic: Windows paths are case-insensitive, so spawning is unaffected, and
+the only consumer of `ocxPath` is the status line that the catalog and GUI read as a
+path. **Do not "fix" it by normalising inside `win-exec.ts`** — that file is byte-shared
+with four other components and the byte-identity test would fail. The §5 assertions
+compare case-insensitively and additionally assert the extension matches `/\.cmd$/i`, so
+the thing being pinned is that the extensionless shim lost, not a particular spelling.
+
 The real hazard is copy drift: `win-exec.ts` now lives in six components. The
 byte-identity test in §5 is the guard, and it fails loudly if the original is edited
 without propagating.

--- a/plugins/codexclaw/components/provider-bridge/dist/cli.js
+++ b/plugins/codexclaw/components/provider-bridge/dist/cli.js
@@ -10,7 +10,59 @@
  * line carries native/provider/error so consumers can react.
  */
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { detectOcx, renderStatusLine,                 } from "./detect.js";
+
+/** PATHEXT default when the env var is missing or empty (win-exec convention). */
+const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+function whereLines(stdout        )           {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function pathExt(filePath        )         {
+  // Normalize slashes so Linux CI can still read a Windows `where` listing.
+  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
+}
+
+function pathextList(pathext                    )           {
+  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
+  return raw
+    .split(";")
+    .map((ext) => ext.trim().toLowerCase())
+    .filter((ext) => ext.length > 0);
+}
+
+/**
+ * Pick a spawnable path from `where` / `command -v` stdout.
+ * On win32, PATHEXT-backed launchers beat the extensionless npm sh shim that
+ * `where` prints first. No executable candidate -> first line, matching the
+ * historical resolver.
+ */
+export function selectExecutableFromWhereOutput(
+  stdout        ,
+  options                                                 ,
+)                {
+  const lines = whereLines(stdout);
+  if (lines.length === 0) return null;
+  if (options.platform !== "win32") return lines[0] ?? null;
+  const allowed = pathextList(options.pathext);
+  const match = lines.find((line) => {
+    const ext = pathExt(line);
+    return ext.length > 0 && allowed.includes(ext);
+  });
+  return match ?? lines[0] ?? null;
+}
+
+function isWindowsBatchLauncher(ocxPath        )          {
+  const ext = pathExt(ocxPath);
+  return ext === ".cmd" || ext === ".bat";
+}
 
 /** Real PATH resolver via the platform `command -v` / `where`. */
 function whichOcx(cmd        )                {
@@ -19,8 +71,10 @@ function whichOcx(cmd        )                {
   try {
     const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
     if (res.status === 0 && typeof res.stdout === "string") {
-      const path = res.stdout.split("\n")[0]?.trim();
-      return path && path.length > 0 ? path : null;
+      return selectExecutableFromWhereOutput(res.stdout, {
+        platform: process.platform,
+        pathext: process.env.PATHEXT,
+      });
     }
     return null;
   } catch {
@@ -31,7 +85,14 @@ function whichOcx(cmd        )                {
 /** Real ocx status reader (detect-only — `status --json` is read-only; never
  *  `ensure`/`sync`, which would mutate codex config). */
 function runOcxStatus(ocxPath        )                                            {
-  const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  const res =
+    process.platform === "win32" && isWindowsBatchLauncher(ocxPath)
+      ? spawnSync(
+          process.env.ComSpec ?? "cmd.exe",
+          ["/d", "/s", "/c", `"${ocxPath}" status --json`],
+          { encoding: "utf8", timeout: 8000, windowsVerbatimArguments: true },
+        )
+      : spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
   return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
 }
 
@@ -54,12 +115,28 @@ export function runSessionStartHook(deps             = { which: whichOcx, runSta
   return 0; // always 0 — detect-only never fails the session.
 }
 
-const [, , kind, event] = process.argv;
-if (kind === "hook" && event === "session-start") {
-  process.exit(runSessionStartHook());
+function realOrSelf(p        )         {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
 }
-// Allow `provider-bridge detect` for cxc doctor / manual probes.
-if (kind === "detect") {
-  process.exit(runBridge());
+
+function main()         {
+  const [, , kind, event] = process.argv;
+  if (kind === "hook" && event === "session-start") {
+    return runSessionStartHook();
+  }
+  // Allow `provider-bridge detect` for cxc doctor / manual probes.
+  if (kind === "detect") {
+    return runBridge();
+  }
+  return 0;
 }
-process.exit(0);
+
+// Direct-exec guard: importing this module from a test must not exit.
+const invokedPath = process.argv[1] ? realOrSelf(resolve(process.argv[1])) : "";
+if (invokedPath === realOrSelf(fileURLToPath(import.meta.url))) {
+  process.exit(main());
+}

--- a/plugins/codexclaw/components/provider-bridge/dist/cli.js
+++ b/plugins/codexclaw/components/provider-bridge/dist/cli.js
@@ -11,70 +11,34 @@
  */
 import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { extname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { detectOcx, renderStatusLine,                 } from "./detect.js";
-
-/** PATHEXT default when the env var is missing or empty (win-exec convention). */
-const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
-
-function whereLines(stdout        )           {
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
-
-function pathExt(filePath        )         {
-  // Normalize slashes so Linux CI can still read a Windows `where` listing.
-  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
-}
-
-function pathextList(pathext                    )           {
-  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
-  return raw
-    .split(";")
-    .map((ext) => ext.trim().toLowerCase())
-    .filter((ext) => ext.length > 0);
-}
+import { commandInvocation, resolveWindowsCommand } from "./win-exec.js";
 
 /**
- * Pick a spawnable path from `where` / `command -v` stdout.
- * On win32, PATHEXT-backed launchers beat the extensionless npm sh shim that
- * `where` prints first. No executable candidate -> first line, matching the
- * historical resolver.
+ * Resolve `ocx` to a spawnable path.
+ *
+ * #131: on win32 an npm global install lays down BOTH an extensionless sh shim and
+ * a `.cmd` launcher, and `where ocx` lists the extensionless one FIRST. That file is
+ * not an executable image, so spawning it fails with ENOENT and detect reports
+ * `ocx status exited null`. Resolve PATH+PATHEXT directly instead of picking a line
+ * out of `where` stdout: resolveWindowsCommand reads PATH/PATHEXT case-insensitively
+ * (a child can arrive with `Path`, `PATH`, or both), splits PATH on a literal `;`
+ * rather than node:path's host-dependent delimiter, and retries the lowercased
+ * extension for case-sensitive filesystems. POSIX keeps `command -v`.
  */
-export function selectExecutableFromWhereOutput(
-  stdout        ,
-  options                                                 ,
-)                {
-  const lines = whereLines(stdout);
-  if (lines.length === 0) return null;
-  if (options.platform !== "win32") return lines[0] ?? null;
-  const allowed = pathextList(options.pathext);
-  const match = lines.find((line) => {
-    const ext = pathExt(line);
-    return ext.length > 0 && allowed.includes(ext);
-  });
-  return match ?? lines[0] ?? null;
-}
-
-function isWindowsBatchLauncher(ocxPath        )          {
-  const ext = pathExt(ocxPath);
-  return ext === ".cmd" || ext === ".bat";
-}
-
-/** Real PATH resolver via the platform `command -v` / `where`. */
 function whichOcx(cmd        )                {
-  const finder = process.platform === "win32" ? "where" : "command";
-  const args = process.platform === "win32" ? [cmd] : ["-v", cmd];
+  if (process.platform === "win32") {
+    const resolved = resolveWindowsCommand(cmd, process.env);
+    // resolveWindowsCommand returns its input unchanged when nothing matched.
+    return resolved === cmd ? null : resolved;
+  }
   try {
-    const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
+    const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
     if (res.status === 0 && typeof res.stdout === "string") {
-      return selectExecutableFromWhereOutput(res.stdout, {
-        platform: process.platform,
-        pathext: process.env.PATHEXT,
-      });
+      const path = res.stdout.split(/\r?\n/)[0]?.trim();
+      return path && path.length > 0 ? path : null;
     }
     return null;
   } catch {
@@ -82,17 +46,18 @@ function whichOcx(cmd        )                {
   }
 }
 
-/** Real ocx status reader (detect-only — `status --json` is read-only; never
- *  `ensure`/`sync`, which would mutate codex config). */
+/**
+ * Real ocx status reader (detect-only — `status --json` is read-only; never
+ * `ensure`/`sync`, which would mutate codex config).
+ *
+ * #131 second half: after the CVE-2024-27980 hardening (Node 18.20.2 / 20.12.2)
+ * a shell-less `.cmd` spawn fails with EINVAL. commandInvocation routes only
+ * `.cmd`/`.bat` through ComSpec and escapes cmd metacharacters; `shell: true` would
+ * not escape them, so a launcher path containing `&` or `^` would be an injection.
+ */
 function runOcxStatus(ocxPath        )                                            {
-  const res =
-    process.platform === "win32" && isWindowsBatchLauncher(ocxPath)
-      ? spawnSync(
-          process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", `"${ocxPath}" status --json`],
-          { encoding: "utf8", timeout: 8000, windowsVerbatimArguments: true },
-        )
-      : spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  const inv = commandInvocation(ocxPath, ["status", "--json"]);
+  const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 8000, ...inv.options });
   return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
 }
 

--- a/plugins/codexclaw/components/provider-bridge/dist/win-exec.js
+++ b/plugins/codexclaw/components/provider-bridge/dist/win-exec.js
@@ -1,0 +1,89 @@
+/**
+ * win-exec.ts - one entry point for spawning external commands.
+ *
+ * Three Windows facts drive this:
+ *  1. npm-installed CLIs are `.cmd` shims, and Node refuses shell-less `.cmd` spawns
+ *     after the CVE-2024-27980 hardening.
+ *  2. A bare command name skips PATHEXT resolution, so `spawn("npm")` ENOENTs even
+ *     with `npm.cmd` on PATH (measured, 002 B4).
+ *  3. `shell: true` is not a fix: Node does not escape cmd metacharacters there, so
+ *     a path containing `&` or `^` becomes a command injection.
+ *
+ * Env vars are read case-insensitively: a spawned child can arrive with `Path`,
+ * `PATH`, or both, and reading one fixed spelling resolves against the wrong list
+ * (001 3.2).
+ */
+import { existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+
+
+
+
+
+
+/** Case-insensitive env lookup with a key-scan fallback. */
+export function envValue(env                   , name        )                     {
+  const direct = env[name];
+  if (direct !== undefined) return direct;
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === lower) return env[key];
+  }
+  return undefined;
+}
+
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/** Resolve `command` against PATH + PATHEXT. Returns the input when nothing matches. */
+export function resolveWindowsCommand(command        , env                   )         {
+  if (command.includes("/") || command.includes("\\") || isAbsolute(command)) return command;
+  const exts = (envValue(env, "PATHEXT") ?? DEFAULT_PATHEXT).split(";").filter((e) => e.length > 0);
+  // A WINDOWS PATH is always ";"-separated. node:path's `delimiter` follows the
+  // HOST, so on a Linux runner exercising this win32-only walk it would be ":"
+  // and the whole PATH would collapse into one bogus directory entry.
+  const dirs = (envValue(env, "PATH") ?? "").split(";").filter((d) => d.length > 0);
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = join(dir, command + ext);
+      if (existsSync(candidate)) return candidate;
+      // Case-sensitive filesystems (WSL, Linux CI): PATHEXT spells ".EXE" but
+      // real shims are "npm.cmd" / "gh.exe". Retry the lowercased extension.
+      const lowered = join(dir, command + ext.toLowerCase());
+      if (existsSync(lowered)) return lowered;
+    }
+  }
+  return command;
+}
+
+/** cross-spawn's escaping: double backslashes before quotes, quote, then caret. */
+function escapeCmdArg(arg        )         {
+  let out = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1");
+  out = `"${out}"`;
+  return out.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+function escapeCmdCommand(command        )         {
+  return command.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+/**
+ * Build the spawn shape for `command`. POSIX is a passthrough; win32 resolves
+ * PATHEXT and routes only `.cmd`/`.bat` through cmd.exe.
+ */
+export function commandInvocation(
+  command        ,
+  args          ,
+  platform                  = process.platform,
+  env                    = process.env,
+)             {
+  if (platform !== "win32") return { file: command, args: [...args], options: {} };
+  const resolved = resolveWindowsCommand(command, env);
+  if (!/\.(cmd|bat)$/i.test(resolved)) return { file: resolved, args: [...args], options: {} };
+  const line = [escapeCmdCommand(resolved), ...args.map(escapeCmdArg)].join(" ");
+  return {
+    file: envValue(env, "ComSpec") ?? "cmd.exe",
+    args: ["/d", "/s", "/c", `"${line}"`],
+    options: { windowsVerbatimArguments: true },
+  };
+}

--- a/plugins/codexclaw/components/provider-bridge/src/cli.ts
+++ b/plugins/codexclaw/components/provider-bridge/src/cli.ts
@@ -11,70 +11,34 @@
  */
 import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import { extname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { detectOcx, renderStatusLine, type DetectDeps } from "./detect.ts";
-
-/** PATHEXT default when the env var is missing or empty (win-exec convention). */
-const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
-
-function whereLines(stdout: string): string[] {
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-}
-
-function pathExt(filePath: string): string {
-  // Normalize slashes so Linux CI can still read a Windows `where` listing.
-  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
-}
-
-function pathextList(pathext: string | undefined): string[] {
-  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
-  return raw
-    .split(";")
-    .map((ext) => ext.trim().toLowerCase())
-    .filter((ext) => ext.length > 0);
-}
+import { commandInvocation, resolveWindowsCommand } from "./win-exec.ts";
 
 /**
- * Pick a spawnable path from `where` / `command -v` stdout.
- * On win32, PATHEXT-backed launchers beat the extensionless npm sh shim that
- * `where` prints first. No executable candidate -> first line, matching the
- * historical resolver.
+ * Resolve `ocx` to a spawnable path.
+ *
+ * #131: on win32 an npm global install lays down BOTH an extensionless sh shim and
+ * a `.cmd` launcher, and `where ocx` lists the extensionless one FIRST. That file is
+ * not an executable image, so spawning it fails with ENOENT and detect reports
+ * `ocx status exited null`. Resolve PATH+PATHEXT directly instead of picking a line
+ * out of `where` stdout: resolveWindowsCommand reads PATH/PATHEXT case-insensitively
+ * (a child can arrive with `Path`, `PATH`, or both), splits PATH on a literal `;`
+ * rather than node:path's host-dependent delimiter, and retries the lowercased
+ * extension for case-sensitive filesystems. POSIX keeps `command -v`.
  */
-export function selectExecutableFromWhereOutput(
-  stdout: string,
-  options: { platform: NodeJS.Platform; pathext?: string },
-): string | null {
-  const lines = whereLines(stdout);
-  if (lines.length === 0) return null;
-  if (options.platform !== "win32") return lines[0] ?? null;
-  const allowed = pathextList(options.pathext);
-  const match = lines.find((line) => {
-    const ext = pathExt(line);
-    return ext.length > 0 && allowed.includes(ext);
-  });
-  return match ?? lines[0] ?? null;
-}
-
-function isWindowsBatchLauncher(ocxPath: string): boolean {
-  const ext = pathExt(ocxPath);
-  return ext === ".cmd" || ext === ".bat";
-}
-
-/** Real PATH resolver via the platform `command -v` / `where`. */
 function whichOcx(cmd: string): string | null {
-  const finder = process.platform === "win32" ? "where" : "command";
-  const args = process.platform === "win32" ? [cmd] : ["-v", cmd];
+  if (process.platform === "win32") {
+    const resolved = resolveWindowsCommand(cmd, process.env);
+    // resolveWindowsCommand returns its input unchanged when nothing matched.
+    return resolved === cmd ? null : resolved;
+  }
   try {
-    const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
+    const res = spawnSync("command", ["-v", cmd], { encoding: "utf8", shell: true });
     if (res.status === 0 && typeof res.stdout === "string") {
-      return selectExecutableFromWhereOutput(res.stdout, {
-        platform: process.platform,
-        pathext: process.env.PATHEXT,
-      });
+      const path = res.stdout.split(/\r?\n/)[0]?.trim();
+      return path && path.length > 0 ? path : null;
     }
     return null;
   } catch {
@@ -82,17 +46,18 @@ function whichOcx(cmd: string): string | null {
   }
 }
 
-/** Real ocx status reader (detect-only — `status --json` is read-only; never
- *  `ensure`/`sync`, which would mutate codex config). */
+/**
+ * Real ocx status reader (detect-only — `status --json` is read-only; never
+ * `ensure`/`sync`, which would mutate codex config).
+ *
+ * #131 second half: after the CVE-2024-27980 hardening (Node 18.20.2 / 20.12.2)
+ * a shell-less `.cmd` spawn fails with EINVAL. commandInvocation routes only
+ * `.cmd`/`.bat` through ComSpec and escapes cmd metacharacters; `shell: true` would
+ * not escape them, so a launcher path containing `&` or `^` would be an injection.
+ */
 function runOcxStatus(ocxPath: string): { status: number | null; stdout: string } {
-  const res =
-    process.platform === "win32" && isWindowsBatchLauncher(ocxPath)
-      ? spawnSync(
-          process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", `"${ocxPath}" status --json`],
-          { encoding: "utf8", timeout: 8000, windowsVerbatimArguments: true },
-        )
-      : spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  const inv = commandInvocation(ocxPath, ["status", "--json"]);
+  const res = spawnSync(inv.file, inv.args, { encoding: "utf8", timeout: 8000, ...inv.options });
   return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
 }
 

--- a/plugins/codexclaw/components/provider-bridge/src/cli.ts
+++ b/plugins/codexclaw/components/provider-bridge/src/cli.ts
@@ -10,7 +10,59 @@
  * line carries native/provider/error so consumers can react.
  */
 import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { detectOcx, renderStatusLine, type DetectDeps } from "./detect.ts";
+
+/** PATHEXT default when the env var is missing or empty (win-exec convention). */
+const DEFAULT_WIN32_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+function whereLines(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function pathExt(filePath: string): string {
+  // Normalize slashes so Linux CI can still read a Windows `where` listing.
+  return extname(filePath.replaceAll("\\", "/")).toLowerCase();
+}
+
+function pathextList(pathext: string | undefined): string[] {
+  const raw = pathext && pathext.trim().length > 0 ? pathext : DEFAULT_WIN32_PATHEXT;
+  return raw
+    .split(";")
+    .map((ext) => ext.trim().toLowerCase())
+    .filter((ext) => ext.length > 0);
+}
+
+/**
+ * Pick a spawnable path from `where` / `command -v` stdout.
+ * On win32, PATHEXT-backed launchers beat the extensionless npm sh shim that
+ * `where` prints first. No executable candidate -> first line, matching the
+ * historical resolver.
+ */
+export function selectExecutableFromWhereOutput(
+  stdout: string,
+  options: { platform: NodeJS.Platform; pathext?: string },
+): string | null {
+  const lines = whereLines(stdout);
+  if (lines.length === 0) return null;
+  if (options.platform !== "win32") return lines[0] ?? null;
+  const allowed = pathextList(options.pathext);
+  const match = lines.find((line) => {
+    const ext = pathExt(line);
+    return ext.length > 0 && allowed.includes(ext);
+  });
+  return match ?? lines[0] ?? null;
+}
+
+function isWindowsBatchLauncher(ocxPath: string): boolean {
+  const ext = pathExt(ocxPath);
+  return ext === ".cmd" || ext === ".bat";
+}
 
 /** Real PATH resolver via the platform `command -v` / `where`. */
 function whichOcx(cmd: string): string | null {
@@ -19,8 +71,10 @@ function whichOcx(cmd: string): string | null {
   try {
     const res = spawnSync(finder, args, { encoding: "utf8", shell: process.platform !== "win32" });
     if (res.status === 0 && typeof res.stdout === "string") {
-      const path = res.stdout.split("\n")[0]?.trim();
-      return path && path.length > 0 ? path : null;
+      return selectExecutableFromWhereOutput(res.stdout, {
+        platform: process.platform,
+        pathext: process.env.PATHEXT,
+      });
     }
     return null;
   } catch {
@@ -31,7 +85,14 @@ function whichOcx(cmd: string): string | null {
 /** Real ocx status reader (detect-only — `status --json` is read-only; never
  *  `ensure`/`sync`, which would mutate codex config). */
 function runOcxStatus(ocxPath: string): { status: number | null; stdout: string } {
-  const res = spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
+  const res =
+    process.platform === "win32" && isWindowsBatchLauncher(ocxPath)
+      ? spawnSync(
+          process.env.ComSpec ?? "cmd.exe",
+          ["/d", "/s", "/c", `"${ocxPath}" status --json`],
+          { encoding: "utf8", timeout: 8000, windowsVerbatimArguments: true },
+        )
+      : spawnSync(ocxPath, ["status", "--json"], { encoding: "utf8", timeout: 8000 });
   return { status: res.status, stdout: typeof res.stdout === "string" ? res.stdout : "" };
 }
 
@@ -54,12 +115,28 @@ export function runSessionStartHook(deps: DetectDeps = { which: whichOcx, runSta
   return 0; // always 0 — detect-only never fails the session.
 }
 
-const [, , kind, event] = process.argv;
-if (kind === "hook" && event === "session-start") {
-  process.exit(runSessionStartHook());
+function realOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
 }
-// Allow `provider-bridge detect` for cxc doctor / manual probes.
-if (kind === "detect") {
-  process.exit(runBridge());
+
+function main(): number {
+  const [, , kind, event] = process.argv;
+  if (kind === "hook" && event === "session-start") {
+    return runSessionStartHook();
+  }
+  // Allow `provider-bridge detect` for cxc doctor / manual probes.
+  if (kind === "detect") {
+    return runBridge();
+  }
+  return 0;
 }
-process.exit(0);
+
+// Direct-exec guard: importing this module from a test must not exit.
+const invokedPath = process.argv[1] ? realOrSelf(resolve(process.argv[1])) : "";
+if (invokedPath === realOrSelf(fileURLToPath(import.meta.url))) {
+  process.exit(main());
+}

--- a/plugins/codexclaw/components/provider-bridge/src/win-exec.ts
+++ b/plugins/codexclaw/components/provider-bridge/src/win-exec.ts
@@ -1,0 +1,89 @@
+/**
+ * win-exec.ts - one entry point for spawning external commands.
+ *
+ * Three Windows facts drive this:
+ *  1. npm-installed CLIs are `.cmd` shims, and Node refuses shell-less `.cmd` spawns
+ *     after the CVE-2024-27980 hardening.
+ *  2. A bare command name skips PATHEXT resolution, so `spawn("npm")` ENOENTs even
+ *     with `npm.cmd` on PATH (measured, 002 B4).
+ *  3. `shell: true` is not a fix: Node does not escape cmd metacharacters there, so
+ *     a path containing `&` or `^` becomes a command injection.
+ *
+ * Env vars are read case-insensitively: a spawned child can arrive with `Path`,
+ * `PATH`, or both, and reading one fixed spelling resolves against the wrong list
+ * (001 3.2).
+ */
+import { existsSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+export interface Invocation {
+  file: string;
+  args: string[];
+  options: { windowsVerbatimArguments?: boolean };
+}
+
+/** Case-insensitive env lookup with a key-scan fallback. */
+export function envValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const direct = env[name];
+  if (direct !== undefined) return direct;
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === lower) return env[key];
+  }
+  return undefined;
+}
+
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+/** Resolve `command` against PATH + PATHEXT. Returns the input when nothing matches. */
+export function resolveWindowsCommand(command: string, env: NodeJS.ProcessEnv): string {
+  if (command.includes("/") || command.includes("\\") || isAbsolute(command)) return command;
+  const exts = (envValue(env, "PATHEXT") ?? DEFAULT_PATHEXT).split(";").filter((e) => e.length > 0);
+  // A WINDOWS PATH is always ";"-separated. node:path's `delimiter` follows the
+  // HOST, so on a Linux runner exercising this win32-only walk it would be ":"
+  // and the whole PATH would collapse into one bogus directory entry.
+  const dirs = (envValue(env, "PATH") ?? "").split(";").filter((d) => d.length > 0);
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = join(dir, command + ext);
+      if (existsSync(candidate)) return candidate;
+      // Case-sensitive filesystems (WSL, Linux CI): PATHEXT spells ".EXE" but
+      // real shims are "npm.cmd" / "gh.exe". Retry the lowercased extension.
+      const lowered = join(dir, command + ext.toLowerCase());
+      if (existsSync(lowered)) return lowered;
+    }
+  }
+  return command;
+}
+
+/** cross-spawn's escaping: double backslashes before quotes, quote, then caret. */
+function escapeCmdArg(arg: string): string {
+  let out = arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/, "$1$1");
+  out = `"${out}"`;
+  return out.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+function escapeCmdCommand(command: string): string {
+  return command.replace(/[()%!^"<>&|;, ]/g, "^$&");
+}
+
+/**
+ * Build the spawn shape for `command`. POSIX is a passthrough; win32 resolves
+ * PATHEXT and routes only `.cmd`/`.bat` through cmd.exe.
+ */
+export function commandInvocation(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): Invocation {
+  if (platform !== "win32") return { file: command, args: [...args], options: {} };
+  const resolved = resolveWindowsCommand(command, env);
+  if (!/\.(cmd|bat)$/i.test(resolved)) return { file: resolved, args: [...args], options: {} };
+  const line = [escapeCmdCommand(resolved), ...args.map(escapeCmdArg)].join(" ");
+  return {
+    file: envValue(env, "ComSpec") ?? "cmd.exe",
+    args: ["/d", "/s", "/c", `"${line}"`],
+    options: { windowsVerbatimArguments: true },
+  };
+}

--- a/plugins/codexclaw/components/provider-bridge/test/detect.test.ts
+++ b/plugins/codexclaw/components/provider-bridge/test/detect.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { detectOcx, parseOcxStatus, renderStatusLine } from "../src/detect.ts";
+import { selectExecutableFromWhereOutput } from "../src/cli.ts";
 
 const STATUS_JSON = JSON.stringify({
   schemaVersion: 1,
@@ -63,4 +64,37 @@ test("parseOcxStatus: valid payload, missing proxy.running, non-json", () => {
   assert.equal(parseOcxStatus('{"listen":{"port":1}}'), null); // no proxy.running
   assert.equal(parseOcxStatus("not json"), null);
   assert.equal(parseOcxStatus(""), null);
+});
+
+test("win32 where: extensionless shim first still selects .cmd", () => {
+  const stdout = "C:\\nvm4w\\nodejs\\ocx\r\nC:\\nvm4w\\nodejs\\ocx.cmd\r\n";
+  assert.equal(
+    selectExecutableFromWhereOutput(stdout, { platform: "win32", pathext: ".COM;.EXE;.BAT;.CMD" }),
+    "C:\\nvm4w\\nodejs\\ocx.cmd",
+  );
+  // PATHEXT unset uses the same default, so the .cmd still wins.
+  assert.equal(
+    selectExecutableFromWhereOutput(stdout, { platform: "win32" }),
+    "C:\\nvm4w\\nodejs\\ocx.cmd",
+  );
+  // No PATHEXT-backed candidate -> historical first-line fallback.
+  assert.equal(
+    selectExecutableFromWhereOutput("C:\\nvm4w\\nodejs\\ocx\n", { platform: "win32" }),
+    "C:\\nvm4w\\nodejs\\ocx",
+  );
+  // Non-win32 keeps the first line even when a .cmd follows.
+  assert.equal(
+    selectExecutableFromWhereOutput(stdout, { platform: "linux" }),
+    "C:\\nvm4w\\nodejs\\ocx",
+  );
+});
+
+test("AC3: .cmd EINVAL (status=null) -> error mode, not native", () => {
+  const s = detectOcx({
+    which: () => "C:\\nvm4w\\nodejs\\ocx.cmd",
+    runStatus: () => ({ status: null, stdout: "" }),
+  });
+  assert.equal(s.mode, "error");
+  assert.match((s as { reason: string }).reason, /exited null/);
+  assert.match(renderStatusLine(s), /"mode":"error"/);
 });

--- a/plugins/codexclaw/components/provider-bridge/test/detect.test.ts
+++ b/plugins/codexclaw/components/provider-bridge/test/detect.test.ts
@@ -1,7 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { detectOcx, parseOcxStatus, renderStatusLine } from "../src/detect.ts";
-import { selectExecutableFromWhereOutput } from "../src/cli.ts";
+import { commandInvocation, resolveWindowsCommand } from "../src/win-exec.ts";
 
 const STATUS_JSON = JSON.stringify({
   schemaVersion: 1,
@@ -66,29 +71,6 @@ test("parseOcxStatus: valid payload, missing proxy.running, non-json", () => {
   assert.equal(parseOcxStatus(""), null);
 });
 
-test("win32 where: extensionless shim first still selects .cmd", () => {
-  const stdout = "C:\\nvm4w\\nodejs\\ocx\r\nC:\\nvm4w\\nodejs\\ocx.cmd\r\n";
-  assert.equal(
-    selectExecutableFromWhereOutput(stdout, { platform: "win32", pathext: ".COM;.EXE;.BAT;.CMD" }),
-    "C:\\nvm4w\\nodejs\\ocx.cmd",
-  );
-  // PATHEXT unset uses the same default, so the .cmd still wins.
-  assert.equal(
-    selectExecutableFromWhereOutput(stdout, { platform: "win32" }),
-    "C:\\nvm4w\\nodejs\\ocx.cmd",
-  );
-  // No PATHEXT-backed candidate -> historical first-line fallback.
-  assert.equal(
-    selectExecutableFromWhereOutput("C:\\nvm4w\\nodejs\\ocx\n", { platform: "win32" }),
-    "C:\\nvm4w\\nodejs\\ocx",
-  );
-  // Non-win32 keeps the first line even when a .cmd follows.
-  assert.equal(
-    selectExecutableFromWhereOutput(stdout, { platform: "linux" }),
-    "C:\\nvm4w\\nodejs\\ocx",
-  );
-});
-
 test("AC3: .cmd EINVAL (status=null) -> error mode, not native", () => {
   const s = detectOcx({
     which: () => "C:\\nvm4w\\nodejs\\ocx.cmd",
@@ -97,4 +79,122 @@ test("AC3: .cmd EINVAL (status=null) -> error mode, not native", () => {
   assert.equal(s.mode, "error");
   assert.match((s as { reason: string }).reason, /exited null/);
   assert.match(renderStatusLine(s), /"mode":"error"/);
+});
+
+// ---------------------------------------------------------------------------
+// #131 half 1 — launcher selection.
+// An npm global install lays down BOTH an extensionless sh shim and a .cmd
+// launcher, and `where ocx` lists the extensionless one first. That file is not an
+// executable image on Windows, so spawning it ENOENTs.
+// ---------------------------------------------------------------------------
+test("win32 launcher selection prefers the PATHEXT launcher over the extensionless shim", t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-which-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\n");      // npm sh shim, not an image
+  writeFileSync(join(dir, "ocx.cmd"), "@echo off\r\n"); // the real launcher
+
+  // Case-insensitive compare: candidates are built with the PATHEXT spelling
+  // (".CMD") and Windows existsSync ignores case, so the resolved path carries
+  // PATHEXT casing rather than the on-disk casing. What matters is that the
+  // extensionless shim lost.
+  const want = join(dir, "ocx.cmd").toLowerCase();
+  assert.equal(
+    resolveWindowsCommand("ocx", { PATH: dir, PATHEXT: ".COM;.EXE;.BAT;.CMD" }).toLowerCase(),
+    want,
+  );
+  // A spawned child can arrive with `Path` instead of `PATH`; reading one fixed
+  // spelling resolves against the wrong list.
+  assert.equal(resolveWindowsCommand("ocx", { Path: dir }).toLowerCase(), want);
+  // Nothing on PATH: the input comes back unchanged, which whichOcx maps to null.
+  const empty = mkdtempSync(join(tmpdir(), "cxc-pb-empty-"));
+  t.after(() => rmSync(empty, { recursive: true, force: true }));
+  assert.equal(resolveWindowsCommand("ocx", { PATH: empty }), "ocx");
+});
+
+// ---------------------------------------------------------------------------
+// #131 half 2 — ComSpec routing. After CVE-2024-27980 a shell-less .cmd spawn is
+// EINVAL. Asserted on the invocation shape so it runs on every platform.
+// ---------------------------------------------------------------------------
+test("win32 .cmd routes through ComSpec with verbatim args; .exe does not", () => {
+  const cmd = commandInvocation("C:\\nvm4w\\nodejs\\ocx.cmd", ["status", "--json"], "win32", {
+    ComSpec: "C:\\Windows\\system32\\cmd.exe",
+  });
+  assert.equal(cmd.file, "C:\\Windows\\system32\\cmd.exe");
+  assert.deepEqual(cmd.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.equal(cmd.options.windowsVerbatimArguments, true);
+  assert.match(cmd.args[3], /status/);
+
+  const exe = commandInvocation("C:\\tools\\ocx.exe", ["status", "--json"], "win32", {});
+  assert.equal(exe.file, "C:\\tools\\ocx.exe");
+  assert.deepEqual(exe.args, ["status", "--json"]);
+  assert.notEqual(exe.options.windowsVerbatimArguments, true);
+
+  // A metacharacter in the launcher path must be escaped, not passed through:
+  // plain double quoting lets cmd execute only the prefix before `&`.
+  const amp = commandInvocation("C:\\a&b\\ocx.cmd", ["status"], "win32", {});
+  assert.match(amp.args[3], /\^&/);
+
+  // POSIX is a passthrough.
+  const posix = commandInvocation("/usr/local/bin/ocx", ["status"], "linux", {});
+  assert.equal(posix.file, "/usr/local/bin/ocx");
+  assert.deepEqual(posix.args, ["status"]);
+});
+
+// SHARED-HELPER-01: provider-bridge carries its own copy so a SessionStart hook
+// never depends on another component having been built. The cost is drift, which
+// this test converts into a loud failure.
+test("provider-bridge win-exec.ts is byte-identical to the cxc-ops original", () => {
+  const here = readFileSync(new URL("../src/win-exec.ts", import.meta.url));
+  const origin = readFileSync(new URL("../../cxc-ops/src/win-exec.ts", import.meta.url));
+  assert.deepEqual(here, origin);
+});
+
+// ---------------------------------------------------------------------------
+// The wiring. The tests above exercise win-exec.ts directly and all pass when
+// cli.ts is untouched. These two run the real cli.ts as a subprocess, so they are
+// the only ones that prove whichOcx/runOcxStatus are actually wired.
+// win32-only: the fixture needs a real .cmd, so Linux/macOS CI does not gate this.
+// ---------------------------------------------------------------------------
+const CLI = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+
+function detectWithPath(path: string): { status: number | null; line: Record<string, unknown> } {
+  const res = spawnSync(process.execPath, ["--experimental-strip-types", CLI, "detect"], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: path, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+  });
+  const tail = (res.stdout ?? "").trim().split(/\r?\n/).pop() ?? "";
+  return { status: res.status, line: tail ? JSON.parse(tail) : {} };
+}
+
+test("detect resolves the .cmd launcher and reads status through ComSpec end to end", { skip: process.platform !== "win32" }, t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-e2e-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  writeFileSync(join(dir, "ocx"), "#!/bin/sh\nexit 1\n");
+  writeFileSync(
+    join(dir, "ocx.cmd"),
+    // cmd has no here-doc; one echo line. No cmd metacharacters in this payload.
+    "@echo off\r\n" +
+      'echo {"proxy":{"running":true},"defaultProvider":"openai","listen":{"port":10100}}\r\n',
+  );
+
+  // dir FIRST so the crafted launcher wins over any real ocx on this machine.
+  const { status, line } = detectWithPath(`${dir};${process.env.PATH ?? ""}`);
+  assert.equal(status, 0);
+  assert.equal(line.mode, "provider");            // not "error", not "native"
+  // The launcher, not the shim. Compare case-insensitively: resolveWindowsCommand
+  // builds candidates with the PATHEXT spelling (".CMD") and Windows existsSync is
+  // case-insensitive, so the returned path carries PATHEXT casing rather than the
+  // on-disk casing. Harmless for spawning; see 010 §7.
+  assert.equal(String(line.ocxPath).toLowerCase(), join(dir, "ocx.cmd").toLowerCase());
+  assert.match(String(line.ocxPath), /\.cmd$/i);
+  assert.equal(line.running, true);                // the payload really came back
+  assert.equal(line.port, 10100);
+});
+
+test("no ocx on PATH resolves to native through the real resolver", { skip: process.platform !== "win32" }, t => {
+  const dir = mkdtempSync(join(tmpdir(), "cxc-pb-none-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const { status, line } = detectWithPath(dir);
+  assert.equal(status, 0);
+  assert.equal(line.mode, "native");
 });


### PR DESCRIPTION
Layer **L1** of the Windows issue sweep stack. Base is **L0** (`codex/win-sweep-roadmap`), not `dev` — `enforce-target` will flag this and that is expected for a manual chain. Do not retarget it at `dev`; that would collapse the chain into overlapping diffs.

Closes the Windows half of #131 for `provider-bridge`. The GUI and `cxc serve` copies are L6.

## The bug

On Windows an npm global install lays down **both** an extensionless sh shim and a `.cmd` launcher, and `where ocx` lists the extensionless one first. Two independent failures follow, measured on the reporting host:

```
C:\nvm4w\nodejs\ocx                  status=null  err=ENOENT
C:\nvm4w\nodejs\ocx.cmd              status=null  err=EINVAL
C:\nvm4w\nodejs\ocx.cmd via ComSpec  status=0     stdout=3931 bytes
```

The extensionless file is not an executable image, and after the CVE-2024-27980 hardening a shell-less `.cmd` spawn is `EINVAL`. Both land on `status === null`, so a healthy proxy was reported as `mode: "error"` with `reason: "ocx status exited null"`.

## The fix, and why not the obvious one

The obvious fix is to pick a better line out of `where` stdout and wrap the `.cmd` in a ComSpec call. That was the first implementation, and an independent review rejected it: it would have been a **third bespoke ComSpec wrapper** in a repository that already has `win-exec.ts` in four components, and its naive `"${path}"` quoting is a command injection. Reviewer reproduction: with a launcher path containing `&`, plain quoting makes cmd execute only the prefix and return status 1, while `commandInvocation` escapes it to `^&` and returns status 0.

So this layer copies `cxc-ops/src/win-exec.ts` into `provider-bridge` byte-for-byte and routes through it:

- `whichOcx` calls `resolveWindowsCommand`, which reads `PATH`/`PATHEXT` case-insensitively (a child can arrive with `Path`, `PATH`, or both), splits `PATH` on a literal `;` rather than `node:path`'s host-dependent delimiter, and retries the lowercased extension for case-sensitive filesystems. The `where`-stdout parsing is **deleted**, not patched.
- `runOcxStatus` calls `commandInvocation`, which routes only `.cmd`/`.bat` through ComSpec and escapes cmd metacharacters. `shell: true` is not used — Node does not escape there.

`cli.ts` is 66 lines deleted for 31 added. `detect.ts` is untouched; the detect-only contract holds — no `ocx ensure`, no `ocx sync`, no config write.

### Why a copy rather than the re-export `messenger-bridge` uses

A cross-component import is not illegal here — `build.mjs`'s convention is a comment, not a check, and `messenger-bridge/src/win-exec.ts` already re-exports `subagent-config/dist/win-exec.js`. But `provider-bridge` runs from a **SessionStart hook** that must always exit 0, so depending on another component's `dist/` build state would turn a resolution failure into a silent provider-status degradation. The copy removes that coupling; the drift cost is converted into a loud test failure by a byte-identity assertion.

## Verification

```
provider-bridge suite: 13 passed, 0 failed
npm run build: 180 files compiled, layout validated
npm run gate: OK
```

Live, from the built `dist/` on the reporting host:

```
$ node plugins/codexclaw/components/provider-bridge/dist/cli.js detect
{"provider":"ocx","mode":"provider","ocxPath":"C:\\nvm4w\\nodejs\\ocx.CMD","running":true,"defaultProvider":"openai","port":10100}
```

The parent commit emits `{"mode":"error","reason":"ocx status exited null"}` for the same command.

### The test that actually gates this

The three helper tests exercise `win-exec.ts` directly and **all pass when `cli.ts` is untouched** — copying the module alone would satisfy them. An audit caught that hole, so there are now two win32 subprocess tests that run the real `cli.ts detect` against a crafted `PATH` holding both an extensionless shim and a `.cmd` that answers `status --json`. They assert `mode === "provider"`, that the resolved path is the launcher, and that `running`/`port` came back, so they fail if either half regresses or if the wiring is missing.

Known coverage limit: those two are win32-only, because the fixture needs a real `.cmd`. **Linux and macOS CI do not gate the wiring** — only the Windows matrix jobs do.

## One behaviour difference, recorded rather than hidden

`resolveWindowsCommand` builds candidates with PATHEXT's own spelling and Windows `existsSync` ignores case, so the reported path ends `.CMD` where the old `where`-parsing reported the on-disk `.cmd`. Caught by the new tests on first run. Cosmetic — Windows paths are case-insensitive and the only consumer reads `ocxPath` as a path. It must **not** be normalised inside `win-exec.ts`, whose bytes are shared with four components; the tests compare case-insensitively and assert `/\.cmd$/i`, pinning that the shim lost rather than a spelling.

`dist/win-exec.js` is a new file and `.gitignore:2` ignores `dist/`, so it required `git add -f`.

Plan: `devlog/_plan/260911_windows_issue_sweep/010_wp2_provider_bridge_windows_detect.md`.

---

_Supersedes #147, which GitHub auto-closed when its base branch `codex/win-sweep-roadmap` was deleted by the L0 merge. Reopening was refused because the head had been rebased onto `dev` in the meantime. Same content, rebased; the L0 roadmap layer is now in `dev` as ee03d5bc._
