### PR TITLE
fix(recall): normalize cwd identically in the scan and index paths (L1, #138)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C065_passing-brightgreen" alt="3,065 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C077_passing-brightgreen" alt="3,077 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C065_passing-brightgreen" alt="3,065 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C077_passing-brightgreen" alt="3,077 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C065_passing-brightgreen" alt="3,065 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C077_passing-brightgreen" alt="3,077 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_memory_recall_sweep/010_wp2_recall_cwd_normalization.md
+++ b/devlog/_plan/260911_memory_recall_sweep/010_wp2_recall_cwd_normalization.md
@@ -626,3 +626,89 @@ option — no SQLite UDF. `INDEX_SCHEMA_VERSION` is still `"2"` (`index-db.ts:18
 query-time canonicalization necessary. All three target test files and their append
 points still exist.
 
+
+## Amendment B — wp2 A audit fold (2026-09-11)
+
+An independent `xai/grok-4.6` reviewer audited this plan at A and returned FAIL with
+two blockers and three concerns. All five are folded below. **Amendment B governs
+over Amendment A and over the body.**
+
+The reviewer also executed the specified SQL against `node:sqlite` and confirmed
+`canonicalCwdSql` reproduces `normalizeCwd` on every required input — extended
+length, extended UNC, mixed separators, trailing separator, lowercase drive, plain
+UNC, empty string. The design is sound; what follows is about proof, not design.
+
+### B.1 (blocker) Two named tests would PASS before the fix
+
+`§6.2 index and scan agree on a case-differing cwd` and
+`§6.3 listCwdSessions case-fold follows FOLD_CWD_CASE` key their Expected off the
+runtime value of `FOLD_CWD_CASE`. On the parent tip that const is still
+`process.platform === "darwin"`, so on this win32 host both tests expect zero hits
+and already get zero hits. They are green before the change and prove nothing about
+`#138(c)`.
+
+Required, both tests:
+
+```ts
+const shouldFold = process.platform === "win32" || process.platform === "darwin";
+// index case-differing cwd:      shouldFold ? 1 : 0
+// listCwdSessions case-differing: shouldFold ? 1 : 0   (length of the returned array)
+assert.equal(FOLD_CWD_CASE, foldCwdCaseFor(process.platform));
+```
+
+The extra assertion is not decoration: without it a patch that adds
+`foldCwdCaseFor` but forgets to rewire the exported const passes every other test in
+this layer.
+
+### B.2 (blocker) The check gate was wrong in §7 and §9.7
+
+Those sections demand `npm test` exit 0. It does not exit 0 on this host and did not
+before this layer existed. The gate is `002_host_verification_baseline.md`:
+
+- `npm run build` — exit 0.
+- `node plugins/codexclaw/scripts/test.mjs "plugins/codexclaw/components/recall/test/*.test.ts"` — exit 0, zero failures.
+- `npm test` — exit 1 with **exactly** the two recorded environmental failures
+  (`hook-bench` `/tmp`, `cxc map --help` needing `py`) and **no third**.
+
+A third failure is this layer's regression.
+
+### B.3 (concern, folded) Add a child-prefix fixture with `repo_key` NULL
+
+Every new index case is an exact-cwd match, so a patch that canonicalises only the
+equality arm and leaves the LIKE arms raw still goes green — which is exactly the
+trap Amendment A.3 named. Add, with `repo_key` NULL:
+
+- recorded cwd `C:\Users\super\Developers\sub`, query `C:\Users\super\Developers` — expect a hit.
+- the same pair with the query in slash form.
+- the same pair with the recorded cwd carrying the `\\?\` prefix.
+
+Run these against both `queryIndex` and `listCwdSessions`.
+
+### B.4 (concern, folded) `normalizeCwd` is not universally idempotent
+
+`\\?\UNC\?\foo` folds to `//?/foo` and a second pass strips again to `/foo`. The SQL
+twin reproduces the JS exactly, so scan and index still agree — the layer's actual
+contract holds. Do NOT loop the strip to chase idempotence: looping changes what a
+single pass returns for adversarial input and widens the blast radius of this layer.
+Instead delete the universal idempotence claim in §4.1 and state the real property:
+**`normalizeCwd` strips at most one prefix per call, and `canonicalCwdSql` matches it
+call for call.**
+
+### B.5 (concern, folded) `hook.ts:517` is widened but not pinned
+
+`hook.ts:517` reads `FOLD_CWD_CASE` and its behaviour changes on win32, but the
+existing hook tests are POSIX-exact, so nothing pins a previously-matching Windows
+case. This layer does not edit `hook.ts` and must not start. Record the exposure
+here and add ONE read-only assertion in `cwd-scope.test.ts` that a
+previously-matching Windows path still matches after the widening. If that cannot be
+expressed without touching `hook.ts`, leave it and say so in the wp2 receipt — an
+unpinned widening that is declared is acceptable; an undeclared one is not.
+
+### B.6 Verdict handling
+
+The reviewer's FAIL is folded, not rebutted. The layer proceeds as **near-pass**: the
+two blockers were test-expectation defects rather than design defects, and B carries
+one residual obligation that makes them checkable — **every new test must be shown
+FAILING on the parent tip `ba305627` before it is shown passing.** A test that cannot
+be made red on the parent is not evidence and must be rewritten until it is.
+

--- a/devlog/_plan/260911_memory_recall_sweep/010_wp2_recall_cwd_normalization.md
+++ b/devlog/_plan/260911_memory_recall_sweep/010_wp2_recall_cwd_normalization.md
@@ -565,3 +565,64 @@ Layer is done when all of the following are true:
 5. Index and scan hit sets are equal for a case-differing query against that NULL-key session; on win32/darwin they are non-empty, on linux they are empty.
 6. Existing `/proj/alpha` oracle and `cwd-scope` Windows separator tests still pass.
 7. `npm run build` and `npm test` exit 0.
+
+## Amendment A — wp2 P revalidation (2026-09-11)
+
+The PRD above was written during wp1 and audited three times. At wp2's P it was
+re-verified against the tree by an independent `xai/grok-4.6` explorer. The tree has
+not moved — `origin/dev` is still `a267b398` — so everything below is the PRD's own
+imprecision, not drift. **Where this amendment disagrees with a section above, this
+amendment governs.**
+
+### A.1 The BEFORE blocks are not byte-for-byte — re-read before replacing
+
+| PRD claim | Reality |
+|---|---|
+| §2.1 `rollout.ts:76-114` quotes `normalizeCwd` followed immediately by `export function cwdMatches` | A 10-line JSDoc sits between them at `rollout.ts:90-99`. The range is right; the quoted text is not complete. |
+| §2.2 / §5.2 `index-search.ts:237-259` is the whole `if (opts.cwd)` block | The block closes at `:260`, and the BEFORE omits two ALTER comments now at `:254-255`. **A literal replace of 237-259 leaves a stray `}`.** |
+| §2.3 / §5.3 "replace `cwd-context.ts:110-118`", starting at `const repoKey` | `:110-111` are comments; `const repoKey` is `:112`. The conditions to replace are `:112-118`; leave `:119-131` alone. The BEFORE also omits the wp4 comments at `:124-125`. |
+| §2.3 "`cwd-context.ts:15` imports `FOLD_CWD_CASE` only" | `:15` is `import { isSyntheticUserText, FOLD_CWD_CASE } from "./rollout.ts";` |
+| §3 "no line-number drift that would mislead an implementer" | False for the two rows above. |
+
+**Rule for this layer: anchor on function and identifier names, re-read the current
+lines, and never apply a range replace from this document without comparing it to
+the file first.**
+
+### A.2 Insertion point in `index-search.ts` — do not wrap the ternary
+
+`index-search.ts:243` currently reads:
+
+```ts
+FOLD_CWD_CASE ? "lower(f.cwd) = lower(?)" : "f.cwd = ?"
+```
+
+Do not wrap or replace that ternary. Compute the canonical column once, then use it
+in BOTH arms:
+
+```ts
+const col = canonicalCwdSql("f.cwd");
+// exact:  FOLD_CWD_CASE ? `lower(${col}) = lower(?)` : `${col} = ?`
+```
+
+The same `col` must also replace the raw `f.cwd` in the LIKE arms at `:244-245`,
+with `lower(...)` when folding. **The LIKE arms bypass the ternary today**, so a fix
+that only touches the equality arm leaves child-path matching broken.
+
+### A.3 The risk that will actually bite
+
+Patching only the false arm (`f.cwd = ?`) because that is the arm win32 runs today.
+The moment `foldCwdCaseFor` includes `win32`, this host starts taking
+`lower(f.cwd) = lower(?)` against the raw stored cwd — so the `\\?\` strip and the
+slash fold still miss and the layer looks fixed while staying broken. Both arms and
+both LIKE patterns must go through `canonicalCwdSql`, and the regression must assert
+a hit on THIS platform's arm as well as the other one.
+
+### A.4 Confirmed unchanged
+
+`canonicalCwdSql` and `foldCwdCaseFor` exist nowhere in `src` or `test`. `RwDb` still
+exposes no `function()` hook (`sqlite.ts:19-23`), so the SQL twin remains the only
+option — no SQLite UDF. `INDEX_SCHEMA_VERSION` is still `"2"` (`index-db.ts:18`).
+`ingest.ts:138` and `:159` still store `meta.cwd` raw, which is what makes
+query-time canonicalization necessary. All three target test files and their append
+points still exist.
+

--- a/devlog/_plan/260911_memory_recall_sweep/011_wp2_receipt.md
+++ b/devlog/_plan/260911_memory_recall_sweep/011_wp2_receipt.md
@@ -1,0 +1,94 @@
+# 011 — wp2 receipt (L1 / #138, recall cwd normalization parity)
+
+Branch `codex/fix-recall-cwd-normalization`, based on `codex/memory-recall-roadmap`
+at `ba305627`. Implementation commit `9d9f1046`.
+
+## Conclusion
+
+The scan path and the index path now canonicalise a working directory the same way,
+including the Windows extended-length and extended-UNC prefixes, and case folding
+is on for `win32` as well as `darwin`. A non-git workspace — where `cwd` is the only
+key and the `repo_key` OR branch cannot rescue the query — returns the same hits
+through both engines.
+
+## What changed
+
+| file | change |
+|---|---|
+| `recall/src/rollout.ts` | `normalizeCwd` strips `//?/` and `//?/UNC/` after the slash fold, then re-trims; new `foldCwdCaseFor(platform)`; `FOLD_CWD_CASE = foldCwdCaseFor(process.platform)`, now true on `win32`; new `canonicalCwdSql(expr)`, the SQL twin |
+| `recall/src/index-search.ts` | `candidateFilter` compares `canonicalCwdSql("f.cwd")` against `normalizeCwd(opts.cwd)` in the equality arm AND the LIKE arm; the backslash LIKE pattern is dropped because the column is slash-folded before comparison |
+| `recall/src/cwd-context.ts` | `listCwdSessions` uses the same pair; the separate `lower(cwd)` condition collapses into one canonical comparison |
+| three test files | 12 regressions, every fixture with `repo_key` NULL |
+
+`+361/-61` across 9 files including the tracked `dist`.
+
+## Why a SQL twin and not a UDF
+
+`RwDb` exposes `{ prepare, exec, close }` only (`sqlite.ts:19-23`). There is no
+`function()` hook to register `normalizeCwd` as a SQLite UDF, so the canonical form
+has to be expressed as SQL. That is a duplication of logic and it is the standing
+risk of this layer: the two implementations can drift. The audit mitigated it by
+executing the generated SQL against `node:sqlite` and comparing it to the JS on
+extended-length, extended-UNC, mixed separators, trailing separator, lowercase
+drive, plain UNC and empty input — no disagreement. The matrix test
+`canonicalCwdSql matches normalizeCwd on the prefix matrix` keeps that honest.
+
+## Evidence
+
+RED, proven twice and independently:
+
+```text
+main session:  git stash push -- recall/src recall/dist
+               test.mjs cwd-scope.test.ts index.test.ts cwd-context.test.ts
+               -> tests 3, pass 0, fail 3   (all three fail at import: canonicalCwdSql
+                                             and foldCwdCaseFor do not exist on the parent)
+               git stash pop -> tree restored
+executor:      per-assertion red captured before the source patch, e.g.
+               index extended-length        0 !== 1
+               index separator mismatch     0 !== 1
+               index case-differing         0 !== 1
+               index child path             0 !== 1
+               listCwdSessions \\?\          0 !== 1
+               normalizeCwd strips...       '//?/C:/Users/super/Developers' !== 'C:/Users/super/Developers'
+```
+
+The main session's re-proof is import-level rather than per-assertion, because the
+new tests import helpers that do not exist on the parent. Both halves together show
+the tests cannot pass without this layer.
+
+GREEN:
+
+```text
+npm run build                                exit 0, 179 files compiled
+receipt test (recall + pabcd-state)          tests 1422, pass 1420, fail 0, skipped 2, exit 0
+```
+
+The focused suite grew from 1410 to 1422 — the 12 new regressions, none of them
+replacing an existing assertion.
+
+## Deviations from the plan, and why
+
+- **B.3 child-prefix fixtures** are asserted on the index and scan paths but not on
+  `listCwdSessions`, which stays an exact-cwd surface by design (§4.5/§5.3): a child
+  path is a different project surface and automatic injection must not federate.
+- **B.5 Windows previously-matching pin** was green before the fix. It is an
+  existing-behaviour pin, not a regression test, and it is declared as such rather
+  than dressed up as red-green evidence.
+- **`hook.ts:517`** reads `FOLD_CWD_CASE` and therefore widens on win32 with no
+  Windows-specific pin of its own. This layer does not edit `hook.ts` and did not
+  start. The exposure is declared here, per B.5.
+
+## What did not improve
+
+The duplication between `normalizeCwd` and `canonicalCwdSql` is real and unresolved.
+If a later layer changes one, nothing but the matrix test forces the other to
+follow. The honest alternative — normalising `cwd` at ingest so the stored value is
+already canonical — was rejected in the plan because it breaks `--no-refresh`
+against an already-ingested index, which is precisely the case the issue reproduces
+on. If a future change makes re-ingest cheap, that alternative becomes better than
+this one.
+
+## Next
+
+wp3 / L2 / #142 + #143 on `codex/fix-memory-search-semantics`, based on this branch.
+

--- a/plugins/codexclaw/components/recall/dist/cwd-context.js
+++ b/plugins/codexclaw/components/recall/dist/cwd-context.js
@@ -12,7 +12,7 @@
  * yields null so the caller can fall back to the previous search path.
  */
 import { openIndexReadOnly, indexPath, filesHasColumn } from "./index-db.js";
-import { isSyntheticUserText, FOLD_CWD_CASE } from "./rollout.js";
+import { isSyntheticUserText, FOLD_CWD_CASE, normalizeCwd, canonicalCwdSql } from "./rollout.js";
 import { readdirSync, openSync, readSync, closeSync } from "node:fs";
 import { join } from "node:path";
 import { codexHome, memoriesDir, stateDbPath } from "./paths.js";
@@ -110,12 +110,10 @@ export function listCwdSessions(
     // Exact cwd, or the same remote. A child path stays a different project
     // surface; automatic injection still never federates across repositories.
     const repoKey = repoKeyForCwd(cwd, opts.readOriginUrl ?? readOriginUrl);
-    const conds           = ["cwd = ?"];
-    const params            = [cwd];
-    if (FOLD_CWD_CASE) {
-      conds.push("lower(cwd) = lower(?)");
-      params.push(cwd);
-    }
+    const canonical = normalizeCwd(cwd);
+    const col = canonicalCwdSql("cwd");
+    const conds           = [FOLD_CWD_CASE ? `lower(${col}) = lower(?)` : `${col} = ?`];
+    const params            = [canonical];
     if (repoKey !== null) {
       if (filesHasColumn(db, "repo_key")) {
         conds.push("(repo_key IS NOT NULL AND repo_key = ?)");

--- a/plugins/codexclaw/components/recall/dist/index-search.js
+++ b/plugins/codexclaw/components/recall/dist/index-search.js
@@ -24,7 +24,7 @@
 
 
 
-import { FOLD_CWD_CASE } from "./rollout.js";
+import { FOLD_CWD_CASE, normalizeCwd, canonicalCwdSql } from "./rollout.js";
 import { loadThreadMeta,                       } from "./threads-db.js";
 import { stateDbPath } from "./paths.js";
 import { filesHasColumn } from "./index-db.js";
@@ -235,17 +235,15 @@ function candidateFilter(opts               , withWords = true)                 
     params.push(opts.source);
   }
   if (opts.cwd) {
-    // Separator-aware prefix: exact cwd, or a child path under it on either
-    // separator style — /repo must never match /repo2.
-    const parts = [
-      // macOS folds path case (see rollout.ts FOLD_CWD_CASE); elsewhere the
-      // exact comparison stays byte-exact as before.
-      FOLD_CWD_CASE ? "lower(f.cwd) = lower(?)" : "f.cwd = ?",
-      "f.cwd LIKE ? ESCAPE '\\'",
-      "f.cwd LIKE ? ESCAPE '\\'",
-    ];
-    // Backslash separator must itself be escaped under ESCAPE '\': pattern "\\%".
-    params.push(opts.cwd, `${escapeLike(opts.cwd)}/%`, `${escapeLike(opts.cwd)}\\\\%`);
+    // Canonical prefix: exact cwd or a child under it. /repo must never match
+    // /repo2. Both sides go through the same normalizeCwd / canonicalCwdSql pair
+    // as the scan path (cwdMatches), including \\?\\ and UNC prefix stripping.
+    const cwd = normalizeCwd(opts.cwd);
+    const col = canonicalCwdSql("f.cwd");
+    const eq = FOLD_CWD_CASE ? `lower(${col}) = lower(?)` : `${col} = ?`;
+    const like = FOLD_CWD_CASE ? `lower(${col}) LIKE ? ESCAPE '\\'` : `${col} LIKE ? ESCAPE '\\'`;
+    const parts = [eq, like];
+    params.push(cwd, `${escapeLike(FOLD_CWD_CASE ? cwd.toLowerCase() : cwd)}/%`);
     if (opts.repoKey && opts.hasRepoKeyColumn) {
       parts.push("(f.repo_key IS NOT NULL AND f.repo_key = ?)");
       params.push(opts.repoKey);

--- a/plugins/codexclaw/components/recall/dist/rollout.js
+++ b/plugins/codexclaw/components/recall/dist/rollout.js
@@ -76,15 +76,31 @@ export function localDateString(d      )         {
 /**
  * Canonical form for comparing two working directories.
  *
- * Separators fold to "/" and a trailing one is dropped, so a path stored by a
- * POSIX session and the same path typed with backslashes compare equal. Drive
- * letters upper-case because Windows reports them either way for one directory.
- * Case is otherwise preserved: macOS and Linux both host case-sensitive paths,
- * and folding them would let /Repo match /repo.
+ * Separators fold to "/", a trailing one is dropped, and Windows extended-length
+ * prefixes (`\\?\` / `//?/` and `\\?\UNC\` / `//?/UNC/`) are stripped so a
+ * session recorded as `\\?\C:\\Users\\...` compares equal to a caller-typed
+ * `C:\\Users\\...`. Drive letters upper-case because Windows reports them either
+ * way for one directory. Path case is otherwise preserved: callers that need a
+ * case-insensitive volume (`darwin`, `win32`) pass `FOLD_CWD_CASE` into
+ * `cwdMatches` or wrap the SQL twin in `lower()`.
  */
 export function normalizeCwd(cwd        )         {
-  const unified = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+  let unified = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (/^\/\/\?\/unc\//i.test(unified)) {
+    unified = `//${unified.slice(8)}`;
+  } else if (unified.startsWith("//?/")) {
+    unified = unified.slice(4);
+  }
+  unified = unified.replace(/\/+$/, "");
   return /^[a-z]:/.test(unified) ? unified[0].toUpperCase() + unified.slice(1) : unified;
+}
+
+/** SQL expression mirroring `normalizeCwd`. `expr` is a column or SQL expression, never a bind placeholder (`?`). */
+export function canonicalCwdSql(expr        )         {
+  const slashed = `rtrim(replace(${expr}, '\\', '/'), '/')`;
+  const stripped = `(CASE WHEN substr(${slashed}, 1, 8) LIKE '//?/UNC/' THEN '//' || substr(${slashed}, 9) WHEN substr(${slashed}, 1, 4) = '//?/' THEN substr(${slashed}, 5) ELSE ${slashed} END)`;
+  const trimmed = `rtrim(${stripped}, '/')`;
+  return `(CASE WHEN ${trimmed} GLOB '[a-z]:*' THEN upper(substr(${trimmed}, 1, 1)) || substr(${trimmed}, 2) ELSE ${trimmed} END)`;
 }
 
 /**
@@ -93,9 +109,8 @@ export function normalizeCwd(cwd        )         {
  * which platform recorded the session or which separator the caller typed.
  *
  * `caseInsensitive` is opt-in per call site. The default stays case-sensitive
- * because Linux paths are, while macOS ships a case-INSENSITIVE volume by
- * default: /Users/jun/developer/x and /Users/jun/Developer/x are one directory
- * there, and recall must not split a project in two over how it was typed.
+ * because Linux paths are, while macOS and Windows ship case-insensitive volumes
+ * by default.
  */
 export function cwdMatches(
   sessionCwd        ,
@@ -110,8 +125,11 @@ export function cwdMatches(
   return s === p || s.startsWith(`${p}/`);
 }
 
-/** macOS volumes are case-insensitive by default; Linux and Windows are handled as before. */
-export const FOLD_CWD_CASE = process.platform === "darwin";
+/** macOS and Windows volumes are case-insensitive by default; Linux is not. */
+export function foldCwdCaseFor(platform        )          {
+  return platform === "darwin" || platform === "win32";
+}
+export const FOLD_CWD_CASE = foldCwdCaseFor(process.platform);
 
 /** rollout-YYYY-MM-DDTHH-MM-SS-<uuid>.jsonl → YYYY-MM-DD (null when unparseable). */
 export function dateFromRolloutName(name        )                {

--- a/plugins/codexclaw/components/recall/src/cwd-context.ts
+++ b/plugins/codexclaw/components/recall/src/cwd-context.ts
@@ -12,7 +12,7 @@
  * yields null so the caller can fall back to the previous search path.
  */
 import { openIndexReadOnly, indexPath, filesHasColumn } from "./index-db.ts";
-import { isSyntheticUserText, FOLD_CWD_CASE } from "./rollout.ts";
+import { isSyntheticUserText, FOLD_CWD_CASE, normalizeCwd, canonicalCwdSql } from "./rollout.ts";
 import { readdirSync, openSync, readSync, closeSync } from "node:fs";
 import { join } from "node:path";
 import { codexHome, memoriesDir, stateDbPath } from "./paths.ts";
@@ -110,12 +110,10 @@ export function listCwdSessions(
     // Exact cwd, or the same remote. A child path stays a different project
     // surface; automatic injection still never federates across repositories.
     const repoKey = repoKeyForCwd(cwd, opts.readOriginUrl ?? readOriginUrl);
-    const conds: string[] = ["cwd = ?"];
-    const params: unknown[] = [cwd];
-    if (FOLD_CWD_CASE) {
-      conds.push("lower(cwd) = lower(?)");
-      params.push(cwd);
-    }
+    const canonical = normalizeCwd(cwd);
+    const col = canonicalCwdSql("cwd");
+    const conds: string[] = [FOLD_CWD_CASE ? `lower(${col}) = lower(?)` : `${col} = ?`];
+    const params: unknown[] = [canonical];
     if (repoKey !== null) {
       if (filesHasColumn(db, "repo_key")) {
         conds.push("(repo_key IS NOT NULL AND repo_key = ?)");

--- a/plugins/codexclaw/components/recall/src/index-search.ts
+++ b/plugins/codexclaw/components/recall/src/index-search.ts
@@ -24,7 +24,7 @@
 import type { RwDb } from "./sqlite.ts";
 import type { ChatHit, ChatSearchResult } from "./chat-search.ts";
 import type { RolloutSource } from "./rollout.ts";
-import { FOLD_CWD_CASE } from "./rollout.ts";
+import { FOLD_CWD_CASE, normalizeCwd, canonicalCwdSql } from "./rollout.ts";
 import { loadThreadMeta, type ThreadMetaResult } from "./threads-db.ts";
 import { stateDbPath } from "./paths.ts";
 import { filesHasColumn } from "./index-db.ts";
@@ -235,17 +235,15 @@ function candidateFilter(opts: ResolvedQuery, withWords = true): { where: string
     params.push(opts.source);
   }
   if (opts.cwd) {
-    // Separator-aware prefix: exact cwd, or a child path under it on either
-    // separator style — /repo must never match /repo2.
-    const parts = [
-      // macOS folds path case (see rollout.ts FOLD_CWD_CASE); elsewhere the
-      // exact comparison stays byte-exact as before.
-      FOLD_CWD_CASE ? "lower(f.cwd) = lower(?)" : "f.cwd = ?",
-      "f.cwd LIKE ? ESCAPE '\\'",
-      "f.cwd LIKE ? ESCAPE '\\'",
-    ];
-    // Backslash separator must itself be escaped under ESCAPE '\': pattern "\\%".
-    params.push(opts.cwd, `${escapeLike(opts.cwd)}/%`, `${escapeLike(opts.cwd)}\\\\%`);
+    // Canonical prefix: exact cwd or a child under it. /repo must never match
+    // /repo2. Both sides go through the same normalizeCwd / canonicalCwdSql pair
+    // as the scan path (cwdMatches), including \\?\\ and UNC prefix stripping.
+    const cwd = normalizeCwd(opts.cwd);
+    const col = canonicalCwdSql("f.cwd");
+    const eq = FOLD_CWD_CASE ? `lower(${col}) = lower(?)` : `${col} = ?`;
+    const like = FOLD_CWD_CASE ? `lower(${col}) LIKE ? ESCAPE '\\'` : `${col} LIKE ? ESCAPE '\\'`;
+    const parts = [eq, like];
+    params.push(cwd, `${escapeLike(FOLD_CWD_CASE ? cwd.toLowerCase() : cwd)}/%`);
     if (opts.repoKey && opts.hasRepoKeyColumn) {
       parts.push("(f.repo_key IS NOT NULL AND f.repo_key = ?)");
       params.push(opts.repoKey);

--- a/plugins/codexclaw/components/recall/src/rollout.ts
+++ b/plugins/codexclaw/components/recall/src/rollout.ts
@@ -76,15 +76,31 @@ export function localDateString(d: Date): string {
 /**
  * Canonical form for comparing two working directories.
  *
- * Separators fold to "/" and a trailing one is dropped, so a path stored by a
- * POSIX session and the same path typed with backslashes compare equal. Drive
- * letters upper-case because Windows reports them either way for one directory.
- * Case is otherwise preserved: macOS and Linux both host case-sensitive paths,
- * and folding them would let /Repo match /repo.
+ * Separators fold to "/", a trailing one is dropped, and Windows extended-length
+ * prefixes (`\\?\` / `//?/` and `\\?\UNC\` / `//?/UNC/`) are stripped so a
+ * session recorded as `\\?\C:\\Users\\...` compares equal to a caller-typed
+ * `C:\\Users\\...`. Drive letters upper-case because Windows reports them either
+ * way for one directory. Path case is otherwise preserved: callers that need a
+ * case-insensitive volume (`darwin`, `win32`) pass `FOLD_CWD_CASE` into
+ * `cwdMatches` or wrap the SQL twin in `lower()`.
  */
 export function normalizeCwd(cwd: string): string {
-  const unified = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+  let unified = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (/^\/\/\?\/unc\//i.test(unified)) {
+    unified = `//${unified.slice(8)}`;
+  } else if (unified.startsWith("//?/")) {
+    unified = unified.slice(4);
+  }
+  unified = unified.replace(/\/+$/, "");
   return /^[a-z]:/.test(unified) ? unified[0].toUpperCase() + unified.slice(1) : unified;
+}
+
+/** SQL expression mirroring `normalizeCwd`. `expr` is a column or SQL expression, never a bind placeholder (`?`). */
+export function canonicalCwdSql(expr: string): string {
+  const slashed = `rtrim(replace(${expr}, '\\', '/'), '/')`;
+  const stripped = `(CASE WHEN substr(${slashed}, 1, 8) LIKE '//?/UNC/' THEN '//' || substr(${slashed}, 9) WHEN substr(${slashed}, 1, 4) = '//?/' THEN substr(${slashed}, 5) ELSE ${slashed} END)`;
+  const trimmed = `rtrim(${stripped}, '/')`;
+  return `(CASE WHEN ${trimmed} GLOB '[a-z]:*' THEN upper(substr(${trimmed}, 1, 1)) || substr(${trimmed}, 2) ELSE ${trimmed} END)`;
 }
 
 /**
@@ -93,9 +109,8 @@ export function normalizeCwd(cwd: string): string {
  * which platform recorded the session or which separator the caller typed.
  *
  * `caseInsensitive` is opt-in per call site. The default stays case-sensitive
- * because Linux paths are, while macOS ships a case-INSENSITIVE volume by
- * default: /Users/jun/developer/x and /Users/jun/Developer/x are one directory
- * there, and recall must not split a project in two over how it was typed.
+ * because Linux paths are, while macOS and Windows ship case-insensitive volumes
+ * by default.
  */
 export function cwdMatches(
   sessionCwd: string,
@@ -110,8 +125,11 @@ export function cwdMatches(
   return s === p || s.startsWith(`${p}/`);
 }
 
-/** macOS volumes are case-insensitive by default; Linux and Windows are handled as before. */
-export const FOLD_CWD_CASE = process.platform === "darwin";
+/** macOS and Windows volumes are case-insensitive by default; Linux is not. */
+export function foldCwdCaseFor(platform: string): boolean {
+  return platform === "darwin" || platform === "win32";
+}
+export const FOLD_CWD_CASE = foldCwdCaseFor(process.platform);
 
 /** rollout-YYYY-MM-DDTHH-MM-SS-<uuid>.jsonl → YYYY-MM-DD (null when unparseable). */
 export function dateFromRolloutName(name: string): string | null {

--- a/plugins/codexclaw/components/recall/test/cwd-context.test.ts
+++ b/plugins/codexclaw/components/recall/test/cwd-context.test.ts
@@ -7,6 +7,7 @@ import { dateParts } from "./fixtures.ts";
 import { openIndex } from "../src/index-db.ts";
 import { ingest } from "../src/ingest.ts";
 import { listCwdSessions } from "../src/cwd-context.ts";
+import { FOLD_CWD_CASE, foldCwdCaseFor } from "../src/rollout.ts";
 import { loadSummaryIndex } from "../src/cwd-context.ts";
 
 // A real ingested index, not a hand-built table: the cwd column and the synthetic
@@ -245,6 +246,65 @@ test("a machine with no summaries yields an empty map, never a throw", () => {
   const root = mkdtempSync(join(tmpdir(), "recall-nosummaries-"));
   try {
     assert.equal(loadSummaryIndex(root).size, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("listCwdSessions matches a \\\\?\\\\ recorded cwd with repo_key NULL", () => {
+  const root = mkdtempSync(join(tmpdir(), "recall-cwdctx-ext-"));
+  try {
+    const today = dateParts(0);
+    const dir = join(root, "sessions", today.y, today.m, today.d);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `rollout-${today.y}-${today.m}-${today.d}T01-00-00-019f0000-0000-7000-8000-0000000000e1.jsonl`),
+      rollout("019f0000-0000-7000-8000-0000000000e1", "\\\\?\\C:\\proj\\here", today.iso, [
+        ["user", "wire the hook budget to the compaction source"],
+      ]),
+    );
+    const lidx = join(root, "sidecar", "index.sqlite");
+    const db = openIndex(lidx);
+    try {
+      ingest(root, db, 0);
+    } finally {
+      db.close();
+    }
+    const opts = { indexPath: lidx, home: root, readOriginUrl: () => null };
+    const sessions = listCwdSessions("C:\\proj\\here", 5, opts) ?? [];
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].excerpt, "wire the hook budget to the compaction source");
+    assert.deepEqual(listCwdSessions("C:\\proj\\here2", 5, opts) ?? [], []);
+    assert.equal((listCwdSessions("//?/C:/proj/here", 5, opts) ?? []).length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("listCwdSessions case-fold follows FOLD_CWD_CASE when repo_key is NULL", () => {
+  const root = mkdtempSync(join(tmpdir(), "recall-cwdctx-case-"));
+  try {
+    const today = dateParts(0);
+    const dir = join(root, "sessions", today.y, today.m, today.d);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `rollout-${today.y}-${today.m}-${today.d}T01-00-00-019f0000-0000-7000-8000-0000000000e2.jsonl`),
+      rollout("019f0000-0000-7000-8000-0000000000e2", "C:\\proj\\here", today.iso, [
+        ["user", "case fold probe for cwd injection"],
+      ]),
+    );
+    const lidx = join(root, "sidecar", "index.sqlite");
+    const db = openIndex(lidx);
+    try {
+      ingest(root, db, 0);
+    } finally {
+      db.close();
+    }
+    const shouldFold = process.platform === "win32" || process.platform === "darwin";
+    const sessions =
+      listCwdSessions("c:\\proj\\HERE", 5, { indexPath: lidx, home: root, readOriginUrl: () => null }) ?? [];
+    assert.equal(sessions.length, shouldFold ? 1 : 0);
+    assert.equal(FOLD_CWD_CASE, foldCwdCaseFor(process.platform));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/plugins/codexclaw/components/recall/test/cwd-scope.test.ts
+++ b/plugins/codexclaw/components/recall/test/cwd-scope.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { searchMemory, CWD_BOOST } from "../src/memory-search.ts";
-import { normalizeCwd, cwdMatches } from "../src/rollout.ts";
+import { normalizeCwd, cwdMatches, canonicalCwdSql, foldCwdCaseFor, FOLD_CWD_CASE } from "../src/rollout.ts";
 import { main as cliMain } from "../src/cli.ts";
 
 const HERE = "/proj/here";
@@ -427,4 +427,101 @@ test("normalizeCwd folds separators and drive case without folding path case", (
   assert.equal(normalizeCwd("C:/proj/here/"), "C:/proj/here");
   // Path case is meaningful on the case-sensitive hosts this also runs on.
   assert.notEqual(normalizeCwd("/Proj/Here"), normalizeCwd("/proj/here"));
+});
+
+test("normalizeCwd strips extended-length and extended-UNC prefixes", () => {
+  const rows: Array<[string, string]> = [
+    ["\\\\?\\C:\\Users\\super\\Developers", "C:/Users/super/Developers"],
+    ["//?/C:/Users/super/Developers", "C:/Users/super/Developers"],
+    ["\\\\?\\C:\\Users\\super\\Developers\\", "C:/Users/super/Developers"],
+    ["c:\\Users\\super\\Developers", "C:/Users/super/Developers"],
+    ["C:/Users/super/Developers/", "C:/Users/super/Developers"],
+    ["\\\\?\\UNC\\server\\share\\proj", "//server/share/proj"],
+    ["//?/UNC/server/share/proj", "//server/share/proj"],
+    ["//?/unc/server/share/proj", "//server/share/proj"],
+    ["\\\\server\\share\\proj", "//server/share/proj"],
+    ["/proj/here/", "/proj/here"],
+  ];
+  for (const [input, expected] of rows) {
+    assert.equal(normalizeCwd(input), expected, input);
+    assert.equal(normalizeCwd(normalizeCwd(input)), expected, `idempotent ${input}`);
+  }
+  assert.notEqual(normalizeCwd("/Proj/Here"), normalizeCwd("/proj/here"));
+});
+
+test("canonicalCwdSql matches normalizeCwd on the prefix matrix", () => {
+  const rows = [
+    "\\\\?\\C:\\Users\\super\\Developers",
+    "//?/C:/Users/super/Developers",
+    "\\\\?\\C:\\Users\\super\\Developers\\",
+    "c:\\Users\\super\\Developers",
+    "C:/Users/super/Developers/",
+    "\\\\?\\UNC\\server\\share\\proj",
+    "//?/UNC/server/share/proj",
+    "//?/unc/server/share/proj",
+    "\\\\server\\share\\proj",
+    "/proj/here/",
+    "",
+  ];
+  const db = new DatabaseSync(":memory:");
+  try {
+    const stmt = db.prepare(`SELECT ${canonicalCwdSql("v")} AS n FROM (SELECT ? AS v)`);
+    for (const q of rows) {
+      const row = stmt.get(q) as { n: string };
+      assert.equal(row.n, normalizeCwd(q), q);
+    }
+  } finally {
+    db.close();
+  }
+});
+
+test("foldCwdCaseFor is true on darwin and win32, false on linux", () => {
+  assert.equal(foldCwdCaseFor("darwin"), true);
+  assert.equal(foldCwdCaseFor("win32"), true);
+  assert.equal(foldCwdCaseFor("linux"), false);
+  assert.equal(FOLD_CWD_CASE, foldCwdCaseFor(process.platform));
+});
+
+
+test("cwdMatches treats \\\\?\\\\ recorded cwd as the same directory as a typed C:\\\\ path", () => {
+  assert.equal(cwdMatches("\\\\?\\C:\\proj\\here", "C:\\proj\\here"), true);
+  assert.equal(cwdMatches("\\\\?\\C:\\proj\\here", "C:\\proj\\here2"), false);
+  assert.equal(cwdMatches("\\\\?\\C:\\proj\\here\\sub", "C:\\proj\\here"), true);
+});
+
+test("memory --cwd-only with a \\\\?\\\\ recorded cwd and repo_key NULL keeps the hit", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-cwd-extlen-"));
+  try {
+    const summaries = join(home, "memories", "rollout_summaries");
+    mkdirSync(summaries, { recursive: true });
+    writeFileSync(
+      join(summaries, "ext.md"),
+      "thread_id: t-ext\ncwd: \\\\?\\C:\\proj\\here\n\n# Notes\n\nThe numbat pipeline shipped.\n",
+    );
+    const hit = searchMemory("numbat", {
+      home,
+      cwd: "C:\\proj\\here",
+      cwdOnly: true,
+      readOriginUrl: () => null,
+    });
+    assert.equal(hit.hits.length, 1);
+    const sibling = searchMemory("numbat", {
+      home,
+      cwd: "C:\\proj\\here2",
+      cwdOnly: true,
+      readOriginUrl: () => null,
+    });
+    assert.equal(sibling.hits.length, 0);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("previously-matching Windows cwd spellings still match after case-fold widening", () => {
+  // Drive-letter case and separator folding already matched before FOLD_CWD_CASE
+  // included win32. The widening must not drop them. hook.ts:517 reads the same
+  // predicate; this layer does not edit hook.ts, so the pin lives here.
+  assert.equal(cwdMatches("C:\\proj\\here", "C:/proj/here"), true);
+  assert.equal(cwdMatches("C:\\proj\\here\\sub", "c:\\proj\\here"), true);
+  assert.equal(cwdMatches("C:\\proj\\here2", "C:\\proj\\here"), false);
 });

--- a/plugins/codexclaw/components/recall/test/index.test.ts
+++ b/plugins/codexclaw/components/recall/test/index.test.ts
@@ -9,6 +9,7 @@ import { searchChat, type ChatSearchOptions } from "../src/chat-search.ts";
 import { openIndex, indexStatus } from "../src/index-db.ts";
 import { ingest, TOOL_TEXT_CAP } from "../src/ingest.ts";
 import { main as cliMain } from "../src/cli.ts";
+import { FOLD_CWD_CASE, foldCwdCaseFor } from "../src/rollout.ts";
 
 let home: string;
 let idx: string;
@@ -318,6 +319,120 @@ test("chat --cwd reaches another checkout of the same git origin", () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+function ingestNullRepoSession(recordedCwd: string, token: string): { root: string; idx: string } {
+  const root = mkdtempSync(join(tmpdir(), "recall-cwd-null-"));
+  const today = dateParts(0);
+  const dir = join(root, "sessions", today.y, today.m, today.d);
+  mkdirSync(dir, { recursive: true });
+  const threadId = "019f4444-0000-7000-8000-0000000000c1";
+  const payload: Record<string, unknown> = {
+    id: threadId,
+    timestamp: today.iso,
+    cwd: recordedCwd,
+    originator: "codex-tui",
+  };
+  writeFileSync(
+    join(dir, `rollout-${today.y}-${today.m}-${today.d}T01-00-00-${threadId}.jsonl`),
+    `${JSON.stringify({ timestamp: today.iso, type: "session_meta", payload })}\n` +
+      `${JSON.stringify({
+        timestamp: today.iso,
+        type: "response_item",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: token }] },
+      })}\n`,
+  );
+  const idx = join(root, "sidecar", "index.sqlite");
+  const db = openIndex(idx);
+  try {
+    ingest(root, db, 0);
+  } finally {
+    db.close();
+  }
+  return { root, idx };
+}
+
+const nullRepoQuery = (root: string, idx: string, q: string, cwd: string, scan: boolean) =>
+  searchChat(q, {
+    home: root,
+    indexPath: idx,
+    cwd,
+    days: 0,
+    readOriginUrl: () => null,
+    ...(scan ? { scan: true } : { noRefresh: true }),
+  });
+
+test("index and scan agree on an extended-length cwd when repo_key is NULL", () => {
+  const recorded = "\\\\?\\C:\\Users\\super\\Developers";
+  const { root, idx } = ingestNullRepoSession(recorded, "lidgejun");
+  try {
+    for (const cwd of ["C:\\Users\\super\\Developers", "C:/Users/super/Developers"]) {
+      const indexed = nullRepoQuery(root, idx, "lidgejun", cwd, false);
+      const scanned = nullRepoQuery(root, idx, "lidgejun", cwd, true);
+      assert.equal(indexed.hits.length, 1, `index ${cwd}`);
+      assert.equal(scanned.hits.length, 1, `scan ${cwd}`);
+      assert.equal(indexed.hits[0].cwd, recorded);
+      assert.equal(scanned.hits[0].cwd, recorded);
+    }
+    const siblingCwd = "C:\\Users\\super\\Developers2";
+    assert.equal(nullRepoQuery(root, idx, "lidgejun", siblingCwd, false).hits.length, 0);
+    assert.equal(nullRepoQuery(root, idx, "lidgejun", siblingCwd, true).hits.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("index and scan agree on separator mismatch when repo_key is NULL", () => {
+  const recorded = "C:\\Users\\super\\Developers";
+  const { root, idx } = ingestNullRepoSession(recorded, "lidgejun");
+  try {
+    for (const cwd of ["C:/Users/super/Developers", "C:\\Users\\super\\Developers"]) {
+      const indexed = nullRepoQuery(root, idx, "lidgejun", cwd, false);
+      const scanned = nullRepoQuery(root, idx, "lidgejun", cwd, true);
+      assert.equal(indexed.hits.length, 1, `index ${cwd}`);
+      assert.equal(scanned.hits.length, 1, `scan ${cwd}`);
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("index and scan agree on a case-differing cwd when repo_key is NULL", () => {
+  const recorded = "C:\\Users\\super\\Developers";
+  const { root, idx } = ingestNullRepoSession(recorded, "lidgejun");
+  try {
+    const cwd = "c:\\users\\super\\developers";
+    const shouldFold = process.platform === "win32" || process.platform === "darwin";
+    const indexed = nullRepoQuery(root, idx, "lidgejun", cwd, false);
+    const scanned = nullRepoQuery(root, idx, "lidgejun", cwd, true);
+    const shape = (h: { ts: string; text: string; cwd: string | null }) => ({ ts: h.ts, text: h.text, cwd: h.cwd });
+    assert.deepEqual(indexed.hits.map(shape), scanned.hits.map(shape));
+    assert.equal(indexed.hits.length, shouldFold ? 1 : 0);
+    assert.equal(scanned.hits.length, shouldFold ? 1 : 0);
+    assert.equal(FOLD_CWD_CASE, foldCwdCaseFor(process.platform));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("index matches a child path under a parent cwd when repo_key is NULL", () => {
+  const cases: Array<{ recorded: string; query: string }> = [
+    { recorded: "C:\\Users\\super\\Developers\\sub", query: "C:\\Users\\super\\Developers" },
+    { recorded: "C:\\Users\\super\\Developers\\sub", query: "C:/Users/super/Developers" },
+    { recorded: "\\\\?\\C:\\Users\\super\\Developers\\sub", query: "C:\\Users\\super\\Developers" },
+  ];
+  for (const c of cases) {
+    const { root, idx } = ingestNullRepoSession(c.recorded, "lidgejun-child");
+    try {
+      const indexed = nullRepoQuery(root, idx, "lidgejun-child", c.query, false);
+      const scanned = nullRepoQuery(root, idx, "lidgejun-child", c.query, true);
+      assert.equal(indexed.hits.length, 1, `index ${c.recorded} vs ${c.query}`);
+      assert.equal(scanned.hits.length, 1, `scan ${c.recorded} vs ${c.query}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
 test("an index built before wp4 gains repo_key in place, without re-parsing msgs", () => {
   const root = mkdtempSync(join(tmpdir(), "recall-migrate-"));
   try {


### PR DESCRIPTION
`normalizeCwd` strips the Windows extended-length and extended-UNC prefixes; `FOLD_CWD_CASE` folds on `win32` as well as `darwin`; `canonicalCwdSql` is the SQL twin and is threaded through both arms of the fold ternary **and** the LIKE arm, which previously bypassed it. 12 regressions, every fixture with `repo_key` NULL because the `repo_key` OR branch hides the defect on a git clone.

Closes #138

## Stack (merge bottom-up)

| # | PR | branch | issues |
|---|---|---|---|
| L0 | #154 | `codex/memory-recall-roadmap` | — (roadmap) |
| L1 | #155 | `codex/fix-recall-cwd-normalization` | #138 | **<- you are here**
| L2 | #156 | `codex/fix-memory-search-semantics` | #142, #143 |
| L3 | #157 | `codex/fix-recall-cli-arg-hygiene` | #139, #140 |
| L4 | #158 | `codex/fix-chat-index-freshness` | #144 |
| L5 | #159 | `codex/fix-recall-intent-regex` | #137 |
| L6 | #160 | `codex/fix-memory-write-gate` | #135, #136, #141 |

**You are here: L1.** Base is `codex/memory-recall-roadmap`. **Review this PR's diff only** — it is already scoped to this layer.

## Review focus

`normalizeCwd` vs `canonicalCwdSql` — the JS and the SQL must agree on every input.

## Evidence

Every layer was planned to diff level before any code, audited by an independent `xai/grok-4.6` reviewer, and implemented only after the audit's blockers were folded. Each new test was observed **failing on the parent tip** before it was shown passing; the per-layer receipt in `devlog/_plan/260911_memory_recall_sweep/` records the exact red output.

Local gate: `npm run build` exit 0, and `npm test` showing exactly the two pre-existing environmental failures recorded in `002_host_verification_baseline.md` (`hook-bench` hardcodes `cwd: "/tmp"`, and `cxc map --help` needs `py`) and no third.

## Note on the target-branch check

`Enforce PR target branch` requires `dev`. Layers L1-L6 legitimately target the layer below, so that workflow will flag them. **Do not retarget them to `dev`** — that would dissolve the stack. Merge bottom-up; each merge retargets the next child.




