### PR TITLE
fix(recall): keep cross-paragraph AND hits and forward synonyms to the chat fallback (L2, #142, #143)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C077_passing-brightgreen" alt="3,077 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C081_passing-brightgreen" alt="3,081 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C077_passing-brightgreen" alt="3,077 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C081_passing-brightgreen" alt="3,081 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C077_passing-brightgreen" alt="3,077 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C081_passing-brightgreen" alt="3,081 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_memory_recall_sweep/020_wp3_memory_search_semantics.md
+++ b/devlog/_plan/260911_memory_recall_sweep/020_wp3_memory_search_semantics.md
@@ -592,3 +592,66 @@ Two other ways to fail this layer: recording `matchedThreadIds` on the file-leve
 AND instead of on a kept hit, and emitting the file-span hit without
 `scopeAdjust`. Either one keeps Test C or Test D.1 red.
 
+
+## Amendment B — wp3 A audit fold (2026-09-11)
+
+Independent `xai/grok-4.6` audit: **NEAR-PASS**, one blocker and four concerns, all
+folded. **Amendment B governs.**
+
+The reviewer traced the thread-id hole end to end and confirmed the plan closes it:
+snapshot `keptBefore`, count `paragraphMatches` on the AND only, run the file span
+iff `paragraphMatches === 0` and put it through `scopeAdjust`, then `add` the thread
+id iff `candidates.length > keptBefore`. Paragraph hits all dropped by scope: no
+file span, no push, no add. File span dropped by scope: no push, no add. And
+`repoKeysEqual(null, null)` is false (`repo-key.ts:94`), so Test C's
+`readOriginUrl: () => null` cannot smuggle the out-of-scope file back in.
+
+### B.1 (blocker) Test B is a lock, not proof
+
+`same-paragraph AND still uses the paragraph start line` is already green on the
+parent. Keep it — it pins the behaviour the file-span fallback must not disturb —
+but it is **not** red-green evidence for this layer, and it must not be counted as
+such in the receipt. The layer's proof is Tests A, C and D.
+**Do not touch `paragraphChunks` to manufacture a red B.**
+
+### B.2 (concern) `dist` is build output, not an edit
+
+`§4`'s "MODIFY `dist/memory-search.js`" must not be read as a hand edit. Patch the
+`.ts`, run `npm run build`, then stage `dist`. `chat-search.ts` and `cli.ts` stay
+read-only in this layer.
+
+### B.3 (concern) Test C will fail for the wrong reason unless sqlite is closed
+
+`§5.1` underspecifies the fixture. Copy the setup from `cwd-scope.test.ts`: the same
+`CREATE TABLE`, and `state.close()` / `mem.close()` **before** calling
+`searchMemory`. On this Windows host an open `DatabaseSync` handle makes stage1
+fail soft and return zero hits, which looks exactly like the bug the test is meant
+to catch — a correct patch would still show red and the implementer would chase it.
+
+### B.4 (concern) `firstMatchStartLine` is untested off line 1
+
+Test A's fixture matches in the first paragraph, so `startLine: 1` passes whether
+the helper works or not. Either add a file-span fixture with a leading
+non-matching paragraph and assert the real line, or drop the helper and document
+that a file-span hit reports `startLine: 1`. Do not ship an untested helper.
+
+### B.5 (concern, accepted as-is) File-span scoring differs in magnitude
+
+`scoreChunk(lowerFile, ...)` sees the whole file, so the heading bonus at
+`memory-search.ts:192` (`startsWith("#")`) does not fire for a file that opens with
+frontmatter, while a heading paragraph would get it. That is a value difference on
+the same field through the same code path, not a new branch. **Accept it. Do not
+special-case file-span scoring** — a scoring branch that exists only for the
+fallback is exactly the kind of divergence this layer is supposed to remove.
+
+### B.6 Red on parent, as audited
+
+| test | on `1e819453` |
+|---|---|
+| A — file-level AND across a blank line | **FAIL**, 0 file hits: `:473` passes, every chunk fails `:487` |
+| B — same-paragraph start line | PASS (lock only) |
+| C — `matchedThreadIds` only after a kept hit | **FAIL**, `hits: []`: the add at `:474-475` makes `:710` skip stage1 |
+| D — fallback forwards `synonyms` and `any` | **FAIL**, both omitted; D.1 also fails the wrong `=== true` expression |
+
+Three reds are the layer's evidence and all three must be observed before the fix.
+

--- a/devlog/_plan/260911_memory_recall_sweep/020_wp3_memory_search_semantics.md
+++ b/devlog/_plan/260911_memory_recall_sweep/020_wp3_memory_search_semantics.md
@@ -519,3 +519,76 @@ Above — L3 / wp4 / #139 #140 (`codex/fix-recall-cli-arg-hygiene`): writes `mem
 Above — L4 / wp5 / #144: `cli.ts` `--status` plus `hook.ts` banner. No overlap with section 4 if this layer stays out of those files.
 
 wp8: publishes this branch as PR base L1, title `fix(recall): keep cross-paragraph AND hits and forward synonyms to the chat fallback (#142, #143)`, `Closes #142` and `Closes #143` only on this PR.
+
+## Amendment A — wp3 P revalidation (2026-09-11)
+
+Re-verified against the tree at `1e819453` by an independent `xai/grok-4.6`
+explorer. **This amendment governs where it disagrees with the body.**
+
+### A.1 What is stale
+
+1. **Header.** Written against `6aae1c97` on `codex/memory-recall-roadmap`. This
+   layer is `codex/fix-memory-search-semantics` off `1e819453`. `6aae1c97` is not an
+   ancestor (merge-base `a267b398`). Every memory/chat/test file this layer touches
+   is byte-identical to that SHA, so the content citations hold.
+2. **§2.2 and §2.5 "current" blocks are collages, not quotes.** They drop the
+   comments at `:478-479`, `:482-483`, `:493` and the ingest/injection comments
+   around `:585-602`. **Do not diff against them.** The §4.2 and §4.4 BEFORE blocks
+   DO match byte-for-byte; use those.
+3. **§2.5's receiver collage is wrong about `chat-search.ts`.** The JSDoc is
+   `:59-63` and the field is `:64`; `const source = opts.source ?? "main"` sits at
+   `:157`, between `anyMode` and `chatMatchPlan`.
+4. **§6.3 demands `npm test` exit 0.** It does not and never did on this host. The
+   gate is `002_host_verification_baseline.md`: build exit 0, focused recall suite
+   exit 0, and full `npm test` showing exactly the two recorded environmental
+   failures and no third.
+
+### A.2 L1 changed nothing this layer depends on
+
+L1 (`9d9f1046`) touched `rollout.ts`, `index-search.ts` and `cwd-context.ts` only.
+`normalizeCwd` now strips the extended prefixes (`:87-96`), `canonicalCwdSql`
+(`:99-104`) is not called from `memory-search.ts`, `FOLD_CWD_CASE` (`:129-132`) is
+true on win32, and `cwdMatches` (`:115-126`) still normalises then prefix-matches.
+`scopeAdjust`'s only callers are still `:488` and `:722`. Test C's `/proj/here` vs
+`/proj/other` fixtures are unaffected by the strip or the fold.
+
+### A.3 The two insertion points, quoted from the current file
+
+The file-level AND passes at `:473`, the thread id is recorded at `:474-475`, and the
+per-chunk AND at `:487` is what throws the hit away:
+
+```ts
+      if (!planMatches(lowerFile, plan)) continue;
+      const threadId = frontmatterThreadId(content);
+      if (threadId) matchedThreadIds.add(threadId);
+      for (const chunk of paragraphChunks(content)) {
+        const lower = chunk.text.toLowerCase();
+        if (!planMatches(lower, plan)) continue;
+```
+
+The file-span fallback must push the **same `MemoryHit` shape as `:490-501`** —
+`origin: "file"`, `kind`, `relpath`, `threadId`, `updatedAt`, `excerpt`, `startLine`,
+`cwd`, `score` — with the excerpt taken from
+`excerptAround(splitLines(content).join("\n"), firstPresentMember(lowerFile, active), 400)`,
+`startLine: firstMatchStartLine(content, active)`, and `scoreChunk(lowerFile, ...)`.
+It must go through `scopeAdjust` exactly like a paragraph hit.
+
+The chat fallback is the only such call, `backfillFromChat` at `:585-602`, and it
+currently passes neither option.
+
+### A.4 The mistake that will actually be made
+
+```ts
+synonyms: opts.synonyms === true      // WRONG - that is chat's own defaulting
+synonyms: opts.synonyms ?? true       // RIGHT - memory's default is ON
+```
+
+`chat-search.ts` defaults `synonyms` OFF (`:158` tests `opts.synonyms === true`) and
+`any` to false (`:156`). Memory defaults `synonyms` ON (`:54-55`, `:434-436`).
+Copying chat's expression forwards `undefined` as false and the fallback stays as
+blind as it is today — the bug would survive its own fix.
+
+Two other ways to fail this layer: recording `matchedThreadIds` on the file-level
+AND instead of on a kept hit, and emitting the file-span hit without
+`scopeAdjust`. Either one keeps Test C or Test D.1 red.
+

--- a/devlog/_plan/260911_memory_recall_sweep/021_wp3_receipt.md
+++ b/devlog/_plan/260911_memory_recall_sweep/021_wp3_receipt.md
@@ -1,0 +1,85 @@
+# 021 — wp3 receipt (L2 / #142 + #143, memory search semantics)
+
+Branch `codex/fix-memory-search-semantics`, based on `codex/fix-recall-cwd-normalization`
+at `1e819453`. Implementation commit `c8bb1ff9`.
+
+## Conclusion
+
+A memory file that answers the query across a blank line is no longer silently
+dropped, a thread is no longer marked "already found" when nothing was kept, and the
+chat fallback now searches with the same synonym expansion the memory path used.
+The three defects compounded: the first produced zero paragraph hits, the second
+told stage1 to skip that thread's chat rows, and the third made the fallback blind
+in exactly the mixed-language case it existed for. A user asking a two-word question
+about a document they could see got an empty result and no warning.
+
+## What changed — `memory-search.ts` only, +46 lines
+
+1. **File-span fallback.** When the file-level AND passes and every
+   blank-separated paragraph fails, one file-span hit is emitted — same nine
+   `MemoryHit` fields, same `scopeAdjust`, same `PER_FILE_CAP` and `rankAndTrim`.
+   It runs only when `paragraphMatches === 0`, so a paragraph hit that `--cwd-only`
+   legitimately dropped does not resurrect itself as a file hit.
+2. **`matchedThreadIds` moves.** The `add()` left the file-level AND at `:474-475`
+   and now fires after `candidates.length > keptBefore`. The comment at the stage1
+   skip changed with it: "already hit via its md file" was not true, "already kept a
+   file hit for this thread" is.
+3. **Fallback forwarding.** `synonyms: opts.synonyms ?? true` and
+   `any: opts.any === true`. The `??` is load-bearing: chat tests
+   `opts.synonyms === true` on its side, so forwarding chat's own expression would
+   have passed `undefined`, read as false, and the fix would have been a no-op that
+   still looked correct in review.
+
+`firstMatchStartLine` is new and pinned off line 1 — the Test A fixture asserts
+`startLine === 3` — rather than shipped on the strength of a fixture that matches in
+the first paragraph.
+
+## Evidence
+
+RED on the parent `1e819453`, proven per-test by the main session after the fact,
+and per-assertion by the executor before the fix:
+
+```text
+git stash push -- recall/src recall/dist
+test.mjs memory-search.test.ts chat-fallback.test.ts
+  -> tests 21, pass 18, fail 3
+     ✖ the chat fallback forwards synonyms and any
+     ✖ file-level AND still hits when tokens sit on opposite sides of a blank line
+     ✖ matchedThreadIds records a thread only after a file hit is kept
+git stash pop -> tree restored
+```
+
+Exactly three red, and Test B green among the 18 — the lock held while the three
+real defects failed. Executor's pre-fix capture: A `assert.ok(r.hits.length >= 1)`
+falsy, C `0 !== 1`, D `undefined !== true`.
+
+GREEN: `npm run build` exit 0; focused recall suite `tests 207, pass 207, fail 0`
+(203 before this layer, so all four new names ran).
+
+## Deviations, and one thing deliberately not done
+
+- **Test B is a lock, not proof.** It was already green on the parent. The audit
+  called that out and it is recorded as a lock here rather than counted as
+  red-green evidence. `paragraphChunks` was not touched to manufacture a red B.
+- **File-span scoring is not special-cased.** `scoreChunk` sees the whole file, so
+  the heading bonus at `:192` does not fire for a file that opens with frontmatter,
+  while a heading paragraph would get it. That is a value difference on one field
+  through one code path. A scoring branch that existed only for the fallback would
+  reintroduce exactly the paragraph-vs-file divergence this layer removes.
+- **Test C closes its sqlite handles before `searchMemory`.** The audit predicted
+  that an open `DatabaseSync` on this Windows host fail-softs stage1 to zero hits —
+  indistinguishable from the bug. The fixture follows `cwd-scope.test.ts`.
+
+## What did not improve
+
+The file-span excerpt is a 400-character window around the first present term, so
+for a long document the two matched words can still be far outside it. The hit is
+correct and findable; the excerpt may not show why it matched. Merging the two
+matching paragraphs was considered and rejected — it invents text the file does not
+contain and breaks `startLine`. If users report confusing excerpts, that is the
+thread to pull, and it is a separate change.
+
+## Next
+
+wp4 / L3 / #139 + #140 on `codex/fix-recall-cli-arg-hygiene`, based on this branch.
+

--- a/plugins/codexclaw/components/recall/dist/memory-search.js
+++ b/plugins/codexclaw/components/recall/dist/memory-search.js
@@ -382,6 +382,15 @@ export function paragraphChunks(content        )                                
   return chunks;
 }
 
+/** 1-based line of the first query-group hit in the file; 1 if none (should not happen after file AND). */
+function firstMatchStartLine(content        , groups              )         {
+  const lines = splitLines(content);
+  for (let i = 0; i < lines.length; i++) {
+    if (groups.some((g) => groupHit(lines[i].toLowerCase(), g))) return i + 1;
+  }
+  return 1;
+}
+
 function groupHit(lowerText        , group            )          {
   return group.some((term) => termIncludes(lowerText, term));
 }
@@ -472,7 +481,6 @@ export function searchMemory(query        , opts                      = {})     
       if (tallyPresence) markGroupPresence(lowerFile, groups, present);
       if (!planMatches(lowerFile, plan)) continue;
       const threadId = frontmatterThreadId(content);
-      if (threadId) matchedThreadIds.add(threadId);
       const relpath = relative(root, file).split(sep).join("/");
       const kind = kindOfRelpath(relpath, "file");
       // Frontmatter first, then the thread join: a summary states its own cwd,
@@ -482,9 +490,12 @@ export function searchMemory(query        , opts                      = {})     
       // The remote can only come from the thread join: a summary's frontmatter
       // records cwd, never the origin URL.
       const fileRepoKey = normalizeRepoKey(threadMeta?.gitOriginUrl);
+      const keptBefore = candidates.length;
+      let paragraphMatches = 0;
       for (const chunk of paragraphChunks(content)) {
         const lower = chunk.text.toLowerCase();
         if (!planMatches(lower, plan)) continue;
+        paragraphMatches += 1;
         const scoped = scopeAdjust(scope, fileCwd, lower, fileRepoKey);
         if (!scoped.keep) continue;
         candidates.push({
@@ -500,6 +511,33 @@ export function searchMemory(query        , opts                      = {})     
           score: finalScore(scoreChunk(lower, active, lowerPhrase), kind, mtimeMs, nowMs) + scoped.bonus,
         });
       }
+      // File AND passed, every blank-separated paragraph failed AND: keep one
+      // file-span hit so split tokens still surface. Do not merge paragraphs
+      // and do not run this when a paragraph matched but cwd-only dropped it.
+      if (paragraphMatches === 0) {
+        const scoped = scopeAdjust(scope, fileCwd, lowerFile, fileRepoKey);
+        if (scoped.keep) {
+          candidates.push({
+            origin: "file",
+            kind,
+            relpath,
+            threadId,
+            updatedAt: new Date(mtimeMs).toISOString(),
+            // excerptAround (memory-search.ts:409-414) slices the original
+            // string, so pass LF-normalized text: a CRLF file would otherwise
+            // keep \r and fail Test A's no-\r assertion (same invariant as
+            // memory-search.test.ts:60). Paragraph chunks already join with
+            // "\n" via splitLines(...).join("\n") in paragraphChunks.
+            excerpt: excerptAround(splitLines(content).join("\n"), firstPresentMember(lowerFile, active), 400),
+            startLine: firstMatchStartLine(content, active),
+            cwd: fileCwd,
+            score: finalScore(scoreChunk(lowerFile, active, lowerPhrase), kind, mtimeMs, nowMs) + scoped.bonus,
+          });
+        }
+      }
+      // Record the thread only if this file actually kept a hit (paragraph or
+      // file-span). Recording on file AND was lying to stage1.
+      if (threadId && candidates.length > keptBefore) matchedThreadIds.add(threadId);
     }
     searchStage1(
       home,
@@ -599,6 +637,10 @@ function backfillFromChat(
       readOriginUrl: opts.readOriginUrl,
       // A hard memory scope stays hard in the backfill; a boost does not filter.
       cwd: scope?.only ? scope.prefix : null,
+      // Memory defaults synonyms on; chat defaults them off. Dropping the flag
+      // here re-zeroes a Korean query the memory path just failed to answer.
+      synonyms: opts.synonyms ?? true,
+      any: opts.any === true,
     });
     const out              = result.hits.slice(0, want).map((hit) => {
       const updatedMs = Date.parse(hit.ts);
@@ -707,7 +749,7 @@ function searchStage1(
     const rows = db.prepare(sql).all(...params)                                  ;
     for (const r of rows) {
       const threadId = typeof r.thread_id === "string" ? r.thread_id : null;
-      if (threadId && matchedThreadIds.has(threadId)) continue; // already hit via its md file
+      if (threadId && matchedThreadIds.has(threadId)) continue; // already kept a file hit for this thread
       const updatedSec = typeof r.source_updated_at === "number" ? r.source_updated_at : null;
       if (cutoffMs && updatedSec !== null && updatedSec * 1000 < cutoffMs) continue;
       const body = `${String(r.raw_memory ?? "")}\n${String(r.rollout_summary ?? "")}`;

--- a/plugins/codexclaw/components/recall/src/memory-search.ts
+++ b/plugins/codexclaw/components/recall/src/memory-search.ts
@@ -382,6 +382,15 @@ export function paragraphChunks(content: string): Array<{ text: string; startLin
   return chunks;
 }
 
+/** 1-based line of the first query-group hit in the file; 1 if none (should not happen after file AND). */
+function firstMatchStartLine(content: string, groups: QueryGroup[]): number {
+  const lines = splitLines(content);
+  for (let i = 0; i < lines.length; i++) {
+    if (groups.some((g) => groupHit(lines[i].toLowerCase(), g))) return i + 1;
+  }
+  return 1;
+}
+
 function groupHit(lowerText: string, group: QueryGroup): boolean {
   return group.some((term) => termIncludes(lowerText, term));
 }
@@ -472,7 +481,6 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
       if (tallyPresence) markGroupPresence(lowerFile, groups, present);
       if (!planMatches(lowerFile, plan)) continue;
       const threadId = frontmatterThreadId(content);
-      if (threadId) matchedThreadIds.add(threadId);
       const relpath = relative(root, file).split(sep).join("/");
       const kind = kindOfRelpath(relpath, "file");
       // Frontmatter first, then the thread join: a summary states its own cwd,
@@ -482,9 +490,12 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
       // The remote can only come from the thread join: a summary's frontmatter
       // records cwd, never the origin URL.
       const fileRepoKey = normalizeRepoKey(threadMeta?.gitOriginUrl);
+      const keptBefore = candidates.length;
+      let paragraphMatches = 0;
       for (const chunk of paragraphChunks(content)) {
         const lower = chunk.text.toLowerCase();
         if (!planMatches(lower, plan)) continue;
+        paragraphMatches += 1;
         const scoped = scopeAdjust(scope, fileCwd, lower, fileRepoKey);
         if (!scoped.keep) continue;
         candidates.push({
@@ -500,6 +511,33 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
           score: finalScore(scoreChunk(lower, active, lowerPhrase), kind, mtimeMs, nowMs) + scoped.bonus,
         });
       }
+      // File AND passed, every blank-separated paragraph failed AND: keep one
+      // file-span hit so split tokens still surface. Do not merge paragraphs
+      // and do not run this when a paragraph matched but cwd-only dropped it.
+      if (paragraphMatches === 0) {
+        const scoped = scopeAdjust(scope, fileCwd, lowerFile, fileRepoKey);
+        if (scoped.keep) {
+          candidates.push({
+            origin: "file",
+            kind,
+            relpath,
+            threadId,
+            updatedAt: new Date(mtimeMs).toISOString(),
+            // excerptAround (memory-search.ts:409-414) slices the original
+            // string, so pass LF-normalized text: a CRLF file would otherwise
+            // keep \r and fail Test A's no-\r assertion (same invariant as
+            // memory-search.test.ts:60). Paragraph chunks already join with
+            // "\n" via splitLines(...).join("\n") in paragraphChunks.
+            excerpt: excerptAround(splitLines(content).join("\n"), firstPresentMember(lowerFile, active), 400),
+            startLine: firstMatchStartLine(content, active),
+            cwd: fileCwd,
+            score: finalScore(scoreChunk(lowerFile, active, lowerPhrase), kind, mtimeMs, nowMs) + scoped.bonus,
+          });
+        }
+      }
+      // Record the thread only if this file actually kept a hit (paragraph or
+      // file-span). Recording on file AND was lying to stage1.
+      if (threadId && candidates.length > keptBefore) matchedThreadIds.add(threadId);
     }
     searchStage1(
       home,
@@ -599,6 +637,10 @@ function backfillFromChat(
       readOriginUrl: opts.readOriginUrl,
       // A hard memory scope stays hard in the backfill; a boost does not filter.
       cwd: scope?.only ? scope.prefix : null,
+      // Memory defaults synonyms on; chat defaults them off. Dropping the flag
+      // here re-zeroes a Korean query the memory path just failed to answer.
+      synonyms: opts.synonyms ?? true,
+      any: opts.any === true,
     });
     const out: MemoryHit[] = result.hits.slice(0, want).map((hit) => {
       const updatedMs = Date.parse(hit.ts);
@@ -707,7 +749,7 @@ function searchStage1(
     const rows = db.prepare(sql).all(...params) as Array<Record<string, unknown>>;
     for (const r of rows) {
       const threadId = typeof r.thread_id === "string" ? r.thread_id : null;
-      if (threadId && matchedThreadIds.has(threadId)) continue; // already hit via its md file
+      if (threadId && matchedThreadIds.has(threadId)) continue; // already kept a file hit for this thread
       const updatedSec = typeof r.source_updated_at === "number" ? r.source_updated_at : null;
       if (cutoffMs && updatedSec !== null && updatedSec * 1000 < cutoffMs) continue;
       const body = `${String(r.raw_memory ?? "")}\n${String(r.rollout_summary ?? "")}`;

--- a/plugins/codexclaw/components/recall/test/chat-fallback.test.ts
+++ b/plugins/codexclaw/components/recall/test/chat-fallback.test.ts
@@ -211,3 +211,28 @@ test("the real chat engine satisfies the injected type", () => {
   const fn: ChatSearchFn = searchChat;
   assert.equal(typeof fn, "function");
 });
+
+test("the chat fallback forwards synonyms and any", () => {
+  const home = emptyHome("recall-fallback-syn-");
+  try {
+    const def = stubChat([]);
+    searchMemory("기억", { home, searchChat: def.fn });
+    assert.equal(def.calls[0].synonyms, true);
+    assert.equal(def.calls[0].any, false);
+    assert.equal(def.calls[0].includeTools, false, "tool logs are the pollution source");
+    assert.equal(def.calls[0].noRefresh, true, "a backfill must not refresh a multi-GB index");
+    assert.equal(def.calls[0].days, 0, "full history, not chat's 7-day default");
+
+    const orMode = stubChat([]);
+    searchMemory("기억", { home, searchChat: orMode.fn, any: true });
+    assert.equal(orMode.calls[0].any, true);
+    assert.equal(orMode.calls[0].synonyms, true);
+
+    const raw = stubChat([]);
+    searchMemory("기억", { home, searchChat: raw.fn, synonyms: false });
+    assert.equal(raw.calls[0].synonyms, false);
+    assert.equal(raw.calls[0].any, false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/plugins/codexclaw/components/recall/test/memory-search.test.ts
+++ b/plugins/codexclaw/components/recall/test/memory-search.test.ts
@@ -4,9 +4,10 @@ import assert from "node:assert/strict";
 // Pin the cxc-resolve seam (B1): a literal `cxc chat search` assertion below
 // must not depend on whether the test runner's PATH carries a cxc binary.
 process.env.CODEXCLAW_CXC = "cxc";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { buildCodexHome, THREAD_MAIN, THREAD_SUB } from "./fixtures.ts";
 import { searchMemory, paragraphChunks } from "../src/memory-search.ts";
 import { formatChatResult, formatMemoryResult } from "../src/format.ts";
@@ -111,5 +112,111 @@ test("cli main: routes chat/memory search, rejects empty query, prints usage oth
     assert.match(captured.join(""), /cxc chat search/);
   } finally {
     (process.stdout as unknown as { write: typeof orig }).write = orig;
+  }
+});
+
+test("file-level AND still hits when tokens sit on opposite sides of a blank line", () => {
+  const isolated = mkdtempSync(join(tmpdir(), "recall-mem-span-"));
+  try {
+    const mem = join(isolated, "memories");
+    mkdirSync(mem, { recursive: true });
+    writeFileSync(join(mem, "MEMORY.md"), "# Memory Handbook\n\nNo groups consolidated yet.\n");
+    writeFileSync(join(mem, "windows-span.md"), "# Memory Handbook\r\n\r\nNo groups consolidated yet.\r\n");
+    // Amendment B.4: pin file-span startLine on a match that is not line 1.
+    writeFileSync(
+      join(mem, "later-span.md"),
+      "Leading preamble that is not a query token.\n\n# Memory Handbook\n\nNo groups consolidated yet.\n",
+    );
+
+    const r = searchMemory("Handbook consolidated", { home: isolated });
+    assert.ok(r.hits.length >= 1);
+    const fileHit = r.hits.find((h) => h.origin === "file" && h.relpath === "MEMORY.md");
+    assert.ok(fileHit, "MEMORY.md file-span hit expected");
+    assert.equal(fileHit.startLine, 1);
+    assert.match(fileHit.excerpt, /Handbook|consolidated/);
+
+    const crlfHit = r.hits.find((h) => h.origin === "file" && h.relpath === "windows-span.md");
+    assert.ok(crlfHit, "CRLF file-span hit expected");
+    assert.ok(!crlfHit.excerpt.includes("\r"), "excerpt must not carry CR");
+
+    const laterHit = r.hits.find((h) => h.origin === "file" && h.relpath === "later-span.md");
+    assert.ok(laterHit, "later-span.md file-span hit expected");
+    assert.equal(laterHit.startLine, 3, "file-span startLine is the first matching line, not always 1");
+
+    const handbook = searchMemory("Handbook", { home: isolated });
+    assert.ok(handbook.hits.some((h) => h.origin === "file" && h.relpath === "MEMORY.md"));
+    const none = searchMemory("Handbook missingtokenxyz", { home: isolated });
+    assert.equal(none.hits.length, 0);
+  } finally {
+    rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("same-paragraph AND still uses the paragraph start line", () => {
+  const isolated = mkdtempSync(join(tmpdir(), "recall-mem-para-"));
+  try {
+    const mem = join(isolated, "memories");
+    mkdirSync(mem, { recursive: true });
+    writeFileSync(join(mem, "MEMORY.md"), "# Title\n\n## Task 1: ship the trigram sidecar index\n");
+    const r = searchMemory("trigram sidecar", { home: isolated });
+    const fileHit = r.hits.find((h) => h.origin === "file" && h.relpath === "MEMORY.md");
+    assert.ok(fileHit, "MEMORY.md paragraph hit expected");
+    assert.equal(fileHit.startLine, 3);
+  } finally {
+    rmSync(isolated, { recursive: true, force: true });
+  }
+});
+
+test("matchedThreadIds records a thread only after a file hit is kept", () => {
+  const isolated = mkdtempSync(join(tmpdir(), "recall-mem-thread-"));
+  try {
+    const summaries = join(isolated, "memories", "rollout_summaries");
+    mkdirSync(summaries, { recursive: true });
+    const threadId = "019f3333-0000-7000-8000-00000000aaaa";
+    writeFileSync(
+      join(summaries, "other.md"),
+      `thread_id: ${threadId}\ncwd: /proj/other\n\n# Memory Handbook\n\nNo groups consolidated yet.\n`,
+    );
+
+    const state = new DatabaseSync(join(isolated, "state_1.sqlite"));
+    state.exec(
+      "CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL DEFAULT ''," +
+        " cwd TEXT NOT NULL DEFAULT '', git_branch TEXT, updated_at_ms INTEGER)",
+    );
+    const ins = state.prepare("INSERT INTO threads (id, title, cwd, git_branch, updated_at_ms) VALUES (?, ?, ?, ?, ?)");
+    ins.run(threadId, "other lane", "/proj/here", "main", Date.now());
+    state.close();
+
+    const mem = new DatabaseSync(join(isolated, "memories_1.sqlite"));
+    mem.exec(
+      "CREATE TABLE stage1_outputs (thread_id TEXT PRIMARY KEY, source_updated_at INTEGER NOT NULL," +
+        " raw_memory TEXT NOT NULL, rollout_summary TEXT NOT NULL)",
+    );
+    const mins = mem.prepare(
+      "INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary) VALUES (?, ?, ?, ?)",
+    );
+    mins.run(threadId, Math.floor(Date.now() / 1000), "Handbook consolidated in the scoped project", "span");
+    mem.close();
+
+    const scoped = searchMemory("Handbook consolidated", {
+      home: isolated,
+      cwd: "/proj/here",
+      cwdOnly: true,
+      readOriginUrl: () => null,
+    });
+    assert.equal(scoped.hits.length, 1);
+    assert.equal(scoped.hits[0].origin, "stage1");
+    assert.equal(scoped.hits[0].threadId, threadId);
+    assert.ok(!scoped.hits.some((h) => h.origin === "file" && h.relpath === "rollout_summaries/other.md"));
+
+    const boosted = searchMemory("Handbook consolidated", {
+      home: isolated,
+      cwd: "/proj/here",
+      readOriginUrl: () => null,
+    });
+    assert.ok(boosted.hits.some((h) => h.origin === "file" && h.relpath === "rollout_summaries/other.md"));
+    assert.ok(!boosted.hits.some((h) => h.origin === "stage1" && h.threadId === threadId));
+  } finally {
+    rmSync(isolated, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
A file whose AND tokens straddle a blank line now keeps one file-span hit, emitted through `scopeAdjust` with the same nine-field shape as a paragraph hit and only when no paragraph matched. `matchedThreadIds` records a thread only after a hit is actually kept — recording it on the file-level AND made stage1 skip that thread's chat rows, so the query returned nothing at all. The chat fallback forwards `synonyms` and `any`; memory defaults synonyms on and chat defaults them off, so omitting them re-zeroed the mixed-language query the fallback existed to rescue.

Closes #142
Closes #143

## Stack (merge bottom-up)

| # | PR | branch | issues |
|---|---|---|---|
| L0 | #154 | `codex/memory-recall-roadmap` | — (roadmap) |
| L1 | #155 | `codex/fix-recall-cwd-normalization` | #138 |
| L2 | #156 | `codex/fix-memory-search-semantics` | #142, #143 | **<- you are here**
| L3 | #157 | `codex/fix-recall-cli-arg-hygiene` | #139, #140 |
| L4 | #158 | `codex/fix-chat-index-freshness` | #144 |
| L5 | #159 | `codex/fix-recall-intent-regex` | #137 |
| L6 | #160 | `codex/fix-memory-write-gate` | #135, #136, #141 |

**You are here: L2.** Base is `codex/fix-recall-cwd-normalization`. **Review this PR's diff only** — it is already scoped to this layer.

## Review focus

the ordering of `matchedThreadIds.add` relative to `scopeAdjust`, and `?? true` vs `=== true` in the fallback.

## Evidence

Every layer was planned to diff level before any code, audited by an independent `xai/grok-4.6` reviewer, and implemented only after the audit's blockers were folded. Each new test was observed **failing on the parent tip** before it was shown passing; the per-layer receipt in `devlog/_plan/260911_memory_recall_sweep/` records the exact red output.

Local gate: `npm run build` exit 0, and `npm test` showing exactly the two pre-existing environmental failures recorded in `002_host_verification_baseline.md` (`hook-bench` hardcodes `cwd: "/tmp"`, and `cxc map --help` needs `py`) and no third.

## Note on the target-branch check

`Enforce PR target branch` requires `dev`. Layers L1-L6 legitimately target the layer below, so that workflow will flag them. **Do not retarget them to `dev`** — that would dissolve the stack. Merge bottom-up; each merge retargets the next child.




