### PR TITLE
fix(recall): answer --help before working and validate path flags (L3, #139, #140)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C081_passing-brightgreen" alt="3,081 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C097_passing-brightgreen" alt="3,097 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C081_passing-brightgreen" alt="3,081 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C097_passing-brightgreen" alt="3,097 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C081_passing-brightgreen" alt="3,081 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C097_passing-brightgreen" alt="3,097 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_memory_recall_sweep/030_wp4_recall_cli_arg_hygiene.md
+++ b/devlog/_plan/260911_memory_recall_sweep/030_wp4_recall_cli_arg_hygiene.md
@@ -817,3 +817,81 @@ word `help` as a help request via `argv.some`. Copying either would make
 | `memory search foo --cwd-only --json` | `--cwd-only` swallows `--json`; `cwd: "--json"`, `cwdOnly: true`, JSON never enabled, **exit 0**, text output |
 | `memory search foo --home <missing>` | no `existsSync` check, **exit 0**, no root warning, db warning **twice** because `foo` is SHORT_ASCII and triggers the relaxed retry |
 
+
+## Amendment B — wp4 A audit fold (2026-09-11)
+
+Independent `xai/grok-4.6` audit: **FAIL**, one blocker and five concerns, all
+folded. **Amendment B governs.** The reviewer traced sixteen argv shapes through
+`main` and confirmed the help check catches every route that reaches `ingest`
+today, and found no in-repo caller that the stricter parsing would break.
+
+### B.1 (blocker) The dash-leading tests would stay red after the fix
+
+Node v24 `parseArgs` with `strict: true` does **not** hand `--cwd-only` the next
+flag as a value. It throws `Option '--cwd-only' argument is ambiguous` first. The
+planned tests assert the plan's own `path must not start with '-'` message, which is
+only reachable through the equals form. **Written as specified, those tests fail
+after a correct implementation.**
+
+Split each into two:
+
+```text
+(a) issue repro:   memory search memory --cwd-only --no-chat --json
+                   -> non-zero exit, stderr matches /cwd-only/
+                      (Node's ambiguous-argument error is acceptable here;
+                       what matters is that the command REFUSES instead of
+                       silently searching the wrong scope with exit 0)
+(b) equals form:   --cwd-only=--no-chat , --cwd=--json , --home=--json
+                   -> non-zero exit, stderr matches the flagLikePathError text
+```
+
+Do the same split for the `--cwd` and `--home` test. Both halves are required: (a)
+is the user-visible bug from #140, (b) is what pins the new guard.
+
+### B.2 `chat index help` and `chat index /?` still ingest — close them
+
+The audit found two argv shapes the plan misses: `["chat","index","help"]` and
+`["chat","index","/?"]` reach `ingest`. Amendment A.3 forbids treating a bare
+`help` as help for `memory search`, because there it is a legitimate QUERY. That
+reasoning does not extend to `chat index`, which takes no positional query at all.
+
+Required: for `chat index` specifically, a bare positional `help` or `/?` prints
+usage and exits 0 without ingesting. `memory search help` and `chat search help`
+keep searching for the word. Pin both behaviours with tests — otherwise a later
+refactor that copies `isHelpToken` goes green while breaking the query
+(audit concern 1).
+
+### B.3 `--Help`, `-help`, `--help=true` — accepted behaviour, documented
+
+These miss `wantsHelp` and then hit `strict: true`, so they exit non-zero with a
+parse error instead of printing usage. That is a worse message than usage but it is
+**not** the #139 defect: they do not ingest. Leave them erroring, and do not widen
+`wantsHelp` to case-insensitive or single-dash spellings — widening it is how
+`help`-as-a-query gets broken. Record the behaviour in the receipt.
+
+### B.4 `dist` is build output; the gate is `002`
+
+`dist/cli.js` and `dist/memory-search.js` change only through `npm run build`.
+§6.4's "`npm test` exits 0" is superseded by `002_host_verification_baseline.md`.
+
+### B.5 Never run the live repro against the real home
+
+§6.5 executes `cxc chat index` against the default home. **Do not run it**, on the
+parent or anywhere: it ingests into the user's real index, which is the exact harm
+#139 describes. Every test points at a temp home. The before/after evidence for
+#139 comes from the temp-home tests, not from a live run.
+
+### B.6 Red on parent, as audited
+
+All eleven named tests are red on `20b42207`. The load-bearing ones:
+
+| test | on the parent |
+|---|---|
+| `chat index --help` prints usage, exits 0, does not ingest | ingests and creates the index; stdout says `ingested` |
+| `--help` anywhere beats `--rebuild` | rebuild deletes and re-ingests |
+| `-h` is help | `values.h = true`, ingests |
+| `memory search --help` exits 0 with no query | usage, exit **1** |
+| unknown flag is rejected | dropped by `strict: false`, ingests |
+| missing `--home` exits non-zero | exit 0 with JSON on stdout |
+| root and db each warn once, including the relaxed retry | no root warning at all; db warning twice |
+

--- a/devlog/_plan/260911_memory_recall_sweep/030_wp4_recall_cli_arg_hygiene.md
+++ b/devlog/_plan/260911_memory_recall_sweep/030_wp4_recall_cli_arg_hygiene.md
@@ -744,3 +744,76 @@ Peer Windows sweep owns #132 (`cxc enable --help`) — different dispatcher. Do 
 | c-6 | dash-leading tests, `cli: missing --home directory exits non-zero`, once-each warning test |
 | #139 unknown flags | `cli: unknown flag is rejected` |
 | #139 default ingest flip | explicitly not done (§3.7) |
+
+## Amendment A — wp4 P revalidation (2026-09-11)
+
+Re-verified at `20b42207` by an independent `xai/grok-4.6` explorer.
+**This amendment governs.**
+
+### A.1 Every `memory-search.ts` line number in this PRD is wrong
+
+L2 (`c8bb1ff9`) added ~46 lines to that file. The PRD measured it before.
+**Anchor on function and identifier names; never apply a range from the body.**
+
+| PRD says | Actually now | What it is |
+|---|---|---|
+| `:441-448` empty query / root | **`:450-457`** | `:441` is now `dropStopwords` |
+| inner `collect` `:504-515` | `collect` at **`:460`**, `searchStage1(...)` at **`:542-553`** | `:504-515` is now the paragraph-hit `relpath` block |
+| `:519` / `:526` / `:527` / `:532` / `:533` | **`:557`** `collect(groups,true)` / **`:564`** `hasBoundaryTerm` / **`:565`** `fillStage1Presence` / **`:570`** `miss.size` / **`:571`** retry `collect` | |
+| `fillStage1Presence` silent at `:637-638` | **`:679-680`** | |
+| `searchStage1` db warning `:672-675` | **`:714-717`**, push at **`:716`** | **`:672` is now `fillStage1Presence`'s parameter list** |
+
+That last row is the trap: applying the named BEFORE at `:672` **corrupts a different
+function**. It is the single most likely way to break this layer.
+
+Also stale: §4.1's `runMemorySearch` BEFORE is not byte-for-byte — the current
+`:158-159` still carries the `searchChat` injection comments, and the PRD's AFTER
+would silently delete them. §5.2's test range `:70-79` is `:71-79` (`:70` is blank),
+and `index.test.ts:215-231` is `:216-232`. §6.4's "`npm test` exits 0" is replaced by
+the `002` gate.
+
+### A.2 The help check goes at the top of `main`, not inside the sub-commands
+
+```ts
+export function main(argv: string[]): number | Promise<number> {
+  const kind = argv[0] ?? "help";
+  const sub = argv[1] ?? "";
+  if ((kind === "chat" || kind === "memory") && sub === "search") { ... }
+  if (kind === "chat" && sub === "index") {
+    return runChatIndex(argv.slice(2));
+  }
+```
+
+`wantsHelp(argv)` must answer **before** `kind`/`sub` are dispatched. The ingest path,
+read from the code and deliberately NOT executed because running it would ingest:
+`main:253-254` → `runChatIndex` → `--help` silently dropped by `strict: false`
+(`cli.ts:89`, no `help` option declared) → `statusOnly` false (`:176`) → `openIndex`
+(`:177`) → `ingest(home, db, 0)` (`:182-183`).
+
+### A.3 Do not copy the prior art
+
+`orchestrate-cli.ts:168-169` `isHelpToken` and `freeze-cli.ts:65` both treat the bare
+word `help` as a help request via `argv.some`. Copying either would make
+`memory search help` print usage instead of searching for the word "help". The PRD's
+`--help`/`-h`-only `wantsHelp` is the correct shape. Keep it.
+
+### A.4 What the warnings actually look like after L2
+
+- The only db-missing push to move is **`memory-search.ts:716`, inside `searchStage1`
+  (declared at `:702`)**.
+- `fillStage1Presence` (`:671`) is already silent at `:679-680`. `listMarkdownFiles`
+  (`:245`) is already silent at `:246`.
+- There is **no** "memories root not found" warning yet. Add it once, in
+  `searchMemory` after `:453`.
+- The duplicate the issue reports comes from **two `searchStage1` calls** (`:557`
+  then the relaxed retry at `:571`), not from two `listMarkdownFiles` calls. Dedupe
+  at the source of the second call, not by filtering the warnings array.
+
+### A.5 Current behaviour, read from the code
+
+| command | today |
+|---|---|
+| `cxc chat index --help` | full ingest, prints `ingested ...`, creates the default sidecar |
+| `memory search foo --cwd-only --json` | `--cwd-only` swallows `--json`; `cwd: "--json"`, `cwdOnly: true`, JSON never enabled, **exit 0**, text output |
+| `memory search foo --home <missing>` | no `existsSync` check, **exit 0**, no root warning, db warning **twice** because `foo` is SHORT_ASCII and triggers the relaxed retry |
+

--- a/devlog/_plan/260911_memory_recall_sweep/031_wp4_receipt.md
+++ b/devlog/_plan/260911_memory_recall_sweep/031_wp4_receipt.md
@@ -1,0 +1,85 @@
+# 031 — wp4 receipt (L3 / #139 + #140, recall CLI arg hygiene)
+
+Branch `codex/fix-recall-cli-arg-hygiene`, based on `codex/fix-memory-search-semantics`
+at `20b42207`. Implementation commit `0707a347`.
+
+## Conclusion
+
+`cxc chat index --help` no longer rewrites the user's index. Help is answered at the
+top of `main`, before any sub-command can dispatch, and an unknown flag is now an
+error instead of a silent ingest. The path flags refuse a dash-leading value instead
+of swallowing the next flag and searching a scope nobody asked for at exit 0.
+
+The #139 report is worth restating because it is the sharpest failure in this whole
+stack: during an audit, one `--help` took the index from 28 files to 101. The command
+that did it had no write in its name, and the file header said the CLI "never writes".
+That header is corrected in this layer too.
+
+## What changed
+
+| file | change |
+|---|---|
+| `recall/src/cli.ts` | `wantsHelp` answered at the top of `main`; positional `help` and `/?` for `chat index` only; `strict: true`; `flagLikePathError` over `--cwd`, `--cwd-only`, `--home`, `--index-path`; `explicitHome` refusing a missing directory; header comment corrected |
+| `recall/src/memory-search.ts` | missing root and missing db are distinct warnings, one each; the relaxed-retry `searchStage1` stays silent |
+| `recall/test/cli-arg-hygiene.test.ts` | NEW, the argv matrix |
+| `recall/test/memory-search.test.ts` | warning-count assertions tightened |
+
+## Help matrix after this layer
+
+| argv | result |
+|---|---|
+| `chat index --help` | usage, exit 0, **no ingest** |
+| `chat index help` | usage, exit 0, no ingest |
+| `chat index /?` | usage, exit 0, no ingest |
+| `memory search --help` | usage, exit 0 — it exited **1** before |
+| `memory search help` | searches for the word "help" |
+| `chat search help` | searches for the word "help" |
+| `--Help`, `-help`, `--help=true` | parse error, exit non-zero, no ingest |
+
+The last row is deliberate. Widening `wantsHelp` to case-insensitive or single-dash
+spellings is exactly how `help`-as-a-query gets broken, and the audit showed that
+copying the existing `isHelpToken` prior art from `orchestrate-cli.ts` would do
+precisely that. Those spellings fail loudly and do not ingest, which is the property
+that mattered.
+
+## Evidence
+
+RED on the parent `20b42207`, re-proved independently by the main session:
+
+```text
+git stash push -- recall/src recall/dist
+test.mjs cli-arg-hygiene.test.ts memory-search.test.ts
+  -> tests 27, fail 15
+     chat index --help / --help beats --rebuild / -h is help
+     chat index help / chat index /?
+     memory search --help exits 0 with no query
+     dash-leading --cwd-only / equals-form / --cwd + --home / equals-form
+     missing --cwd-only value / unknown flag / missing --home
+     root and db warn once (incl. relaxed retry) / db degrades with a warning
+git stash pop -> tree restored
+```
+
+The two "help stays a query" pins were green among the other 12 — the guard rails
+held while every real defect failed.
+
+GREEN: `npm run build` exit 0; focused recall suite `tests 223, pass 223, fail 0`
+(207 before this layer).
+
+## Safety note
+
+No `cxc chat index` was ever run against the real home, on the parent or after the
+fix. Every test points at a temp `--home` and `--index-path`. Reproducing #139 live
+would have caused the exact harm the issue reports, so the before/after evidence is
+the temp-home matrix and the code trace, not a live run.
+
+## What did not improve
+
+`chat search` can still trigger a refresh-ingest as a side effect of searching; this
+layer only guarantees that asking for HELP never does. Whether a search should
+silently ingest at all is a real question and it belongs to L4, which owns the
+freshness accounting — it is noted there rather than fixed here.
+
+## Next
+
+wp5 / L4 / #144 on `codex/fix-chat-index-freshness`, based on this branch.
+

--- a/plugins/codexclaw/components/recall/dist/cli.js
+++ b/plugins/codexclaw/components/recall/dist/cli.js
@@ -2,13 +2,14 @@
  * cli.ts — `recall` entry point. Argv contract from bin/codexclaw.mjs:
  *   [kind, "search", ...queryAndFlags]   kind ∈ chat | memory
  *
- * Read-only over CODEX_HOME (~/.codex); never writes. Unknown subcommands print
+ * Search paths are read-only over CODEX_HOME (~/.codex). chat index without
+ * --status writes the sidecar. --help/-h never writes. Unknown subcommands print
  * usage and exit 0 (informational, matching cxc-ops convention).
  */
 import { parseArgs } from "node:util";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { searchChat, DEFAULT_DAYS, DEFAULT_LIMIT,                        } from "./chat-search.js";
 import { searchMemory, DEFAULT_MEMORY_LIMIT,                          } from "./memory-search.js";
 import { formatChatResult, formatMemoryResult, clipChatResultForJson } from "./format.js";
@@ -58,6 +59,44 @@ const USAGE = [
 
 
 
+const PATH_OPTION_KEYS = ["cwd", "cwd-only", "home", "index-path"]         ;
+
+function wantsHelp(args          )          {
+  return args.some((a) => a === "--help" || a === "-h");
+}
+
+function flagLikePathError(values                         )                     {
+  for (const key of PATH_OPTION_KEYS) {
+    const raw = values[key];
+    if (typeof raw === "string" && raw.startsWith("-")) {
+      return `--${key} path must not start with '-': got ${JSON.stringify(raw)}`;
+    }
+  }
+  return undefined;
+}
+
+function readFlags(args          )                     {
+  try {
+    const parsed = parseFlags(args);
+    const dashErr = flagLikePathError(parsed.values);
+    if (dashErr) throw new Error(dashErr);
+    return parsed;
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return null;
+  }
+}
+
+/** Explicit --home must exist. `false` = error already printed. `undefined` = use default. */
+function explicitHome(values                         )                             {
+  if (typeof values.home !== "string") return undefined;
+  if (!existsSync(values.home)) {
+    process.stderr.write(`--home not found: ${values.home}\n`);
+    return false;
+  }
+  return values.home;
+}
+
 function parseFlags(args          )              {
   const { values, positionals } = parseArgs({
     args,
@@ -86,7 +125,7 @@ function parseFlags(args          )              {
       home: { type: "string" },
       "index-path": { type: "string" },
     },
-    strict: false,
+    strict: true,
     allowPositionals: true,
   });
   return { values: values                           , positionals: positionals.map(String) };
@@ -100,7 +139,11 @@ function numFlag(values                         , key        )                  
 }
 
 function runChatSearch(args          )         {
-  const { values, positionals } = parseFlags(args);
+  const parsed = readFlags(args);
+  if (parsed === null) return 1;
+  const { values, positionals } = parsed;
+  const home = explicitHome(values);
+  if (home === false) return 1;
   const query = positionals.join(" ").trim();
   if (query === "") {
     process.stdout.write(`${USAGE}\n`);
@@ -127,7 +170,7 @@ function runChatSearch(args          )         {
     order: values.recent === true && values.rank !== true ? "recent" : "relevance",
     scan: values.scan === true,
     noRefresh: values["no-refresh"] === true,
-    home: typeof values.home === "string" ? values.home : undefined,
+    home,
     indexPath: typeof values["index-path"] === "string" ? values["index-path"] : undefined,
   };
   const result = searchChat(query, opts);
@@ -139,7 +182,11 @@ function runChatSearch(args          )         {
 }
 
 function runMemorySearch(args          )         {
-  const { values, positionals } = parseFlags(args);
+  const parsed = readFlags(args);
+  if (parsed === null) return 1;
+  const { values, positionals } = parsed;
+  const home = explicitHome(values);
+  if (home === false) return 1;
   const query = positionals.join(" ").trim();
   if (query === "") {
     process.stdout.write(`${USAGE}\n`);
@@ -150,11 +197,11 @@ function runMemorySearch(args          )         {
     limit: numFlag(values, "limit"),
     any: values.any === true,
     synonyms: values["no-synonyms"] !== true,
-    home: typeof values.home === "string" ? values.home : undefined,
-    // --cwd-only carries its own path, so `--cwd-only PATH` needs no second flag.
-    // Bare `--cwd-only` (parsed as a boolean) hardens an accompanying --cwd.
+    home,
+    // --cwd-only PATH is the only hard-filter form. A missing or flag-like
+    // value is rejected by readFlags; there is no boolean-hardener.
     cwd: typeof values["cwd-only"] === "string" ? values["cwd-only"] : typeof values.cwd === "string" ? values.cwd : null,
-    cwdOnly: values["cwd-only"] !== undefined && values["cwd-only"] !== false,
+    cwdOnly: typeof values["cwd-only"] === "string",
     // Injected rather than imported by memory-search: the module keeps no edge
     // to chat-search, and the fallback is one flag away from being off.
     searchChat: values["no-chat"] === true ? undefined : searchChat,
@@ -167,8 +214,12 @@ function runMemorySearch(args          )         {
 }
 
 function runChatIndex(args          )         {
-  const { values } = parseFlags(args);
-  const home = typeof values.home === "string" ? values.home : codexHome();
+  const parsed = readFlags(args);
+  if (parsed === null) return 1;
+  const { values } = parsed;
+  const homeOrErr = explicitHome(values);
+  if (homeOrErr === false) return 1;
+  const home = homeOrErr ?? codexHome();
   const path = typeof values["index-path"] === "string" ? values["index-path"] : indexPath();
   try {
     // --status alone is a pure read: open read-only so it works on read-only
@@ -245,12 +296,20 @@ async function runHook(event        )                  {
   }
 }
 export function main(argv          )                           {
+  if (wantsHelp(argv)) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
   const kind = argv[0] ?? "help";
   const sub = argv[1] ?? "";
   if ((kind === "chat" || kind === "memory") && sub === "search") {
     return kind === "chat" ? runChatSearch(argv.slice(2)) : runMemorySearch(argv.slice(2));
   }
   if (kind === "chat" && sub === "index") {
+    if (argv.slice(2).some((a) => a === "help" || a === "/?")) {
+      process.stdout.write(`${USAGE}\n`);
+      return 0;
+    }
     return runChatIndex(argv.slice(2));
   }
   if (kind === "hook") {

--- a/plugins/codexclaw/components/recall/dist/memory-search.js
+++ b/plugins/codexclaw/components/recall/dist/memory-search.js
@@ -453,6 +453,12 @@ export function searchMemory(query        , opts                      = {})     
   }
 
   const root = memoriesDir(home);
+  if (!existsSync(root)) {
+    warnings.push("memories root not found (file search off)");
+  }
+  if (!memoriesDbPath(home)) {
+    warnings.push("memories db not found (stage1 search off)");
+  }
   const files = listMarkdownFiles(root);
   const scope = buildCwdScope(home, opts, warnings);
 
@@ -713,7 +719,6 @@ function searchStage1(
 )       {
   const dbPath = memoriesDbPath(home);
   if (!dbPath) {
-    warnings.push("memories db not found (stage1 search off)");
     return;
   }
   let db                                           = null;

--- a/plugins/codexclaw/components/recall/src/cli.ts
+++ b/plugins/codexclaw/components/recall/src/cli.ts
@@ -2,13 +2,14 @@
  * cli.ts — `recall` entry point. Argv contract from bin/codexclaw.mjs:
  *   [kind, "search", ...queryAndFlags]   kind ∈ chat | memory
  *
- * Read-only over CODEX_HOME (~/.codex); never writes. Unknown subcommands print
+ * Search paths are read-only over CODEX_HOME (~/.codex). chat index without
+ * --status writes the sidecar. --help/-h never writes. Unknown subcommands print
  * usage and exit 0 (informational, matching cxc-ops convention).
  */
 import { parseArgs } from "node:util";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { searchChat, DEFAULT_DAYS, DEFAULT_LIMIT, type ChatSearchOptions } from "./chat-search.ts";
 import { searchMemory, DEFAULT_MEMORY_LIMIT, type MemorySearchOptions } from "./memory-search.ts";
 import { formatChatResult, formatMemoryResult, clipChatResultForJson } from "./format.ts";
@@ -58,6 +59,44 @@ type ParsedFlags = {
   positionals: string[];
 };
 
+const PATH_OPTION_KEYS = ["cwd", "cwd-only", "home", "index-path"] as const;
+
+function wantsHelp(args: string[]): boolean {
+  return args.some((a) => a === "--help" || a === "-h");
+}
+
+function flagLikePathError(values: Record<string, unknown>): string | undefined {
+  for (const key of PATH_OPTION_KEYS) {
+    const raw = values[key];
+    if (typeof raw === "string" && raw.startsWith("-")) {
+      return `--${key} path must not start with '-': got ${JSON.stringify(raw)}`;
+    }
+  }
+  return undefined;
+}
+
+function readFlags(args: string[]): ParsedFlags | null {
+  try {
+    const parsed = parseFlags(args);
+    const dashErr = flagLikePathError(parsed.values);
+    if (dashErr) throw new Error(dashErr);
+    return parsed;
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return null;
+  }
+}
+
+/** Explicit --home must exist. `false` = error already printed. `undefined` = use default. */
+function explicitHome(values: Record<string, unknown>): string | undefined | false {
+  if (typeof values.home !== "string") return undefined;
+  if (!existsSync(values.home)) {
+    process.stderr.write(`--home not found: ${values.home}\n`);
+    return false;
+  }
+  return values.home;
+}
+
 function parseFlags(args: string[]): ParsedFlags {
   const { values, positionals } = parseArgs({
     args,
@@ -86,7 +125,7 @@ function parseFlags(args: string[]): ParsedFlags {
       home: { type: "string" },
       "index-path": { type: "string" },
     },
-    strict: false,
+    strict: true,
     allowPositionals: true,
   });
   return { values: values as Record<string, unknown>, positionals: positionals.map(String) };
@@ -100,7 +139,11 @@ function numFlag(values: Record<string, unknown>, key: string): number | undefin
 }
 
 function runChatSearch(args: string[]): number {
-  const { values, positionals } = parseFlags(args);
+  const parsed = readFlags(args);
+  if (parsed === null) return 1;
+  const { values, positionals } = parsed;
+  const home = explicitHome(values);
+  if (home === false) return 1;
   const query = positionals.join(" ").trim();
   if (query === "") {
     process.stdout.write(`${USAGE}\n`);
@@ -127,7 +170,7 @@ function runChatSearch(args: string[]): number {
     order: values.recent === true && values.rank !== true ? "recent" : "relevance",
     scan: values.scan === true,
     noRefresh: values["no-refresh"] === true,
-    home: typeof values.home === "string" ? values.home : undefined,
+    home,
     indexPath: typeof values["index-path"] === "string" ? values["index-path"] : undefined,
   };
   const result = searchChat(query, opts);
@@ -139,7 +182,11 @@ function runChatSearch(args: string[]): number {
 }
 
 function runMemorySearch(args: string[]): number {
-  const { values, positionals } = parseFlags(args);
+  const parsed = readFlags(args);
+  if (parsed === null) return 1;
+  const { values, positionals } = parsed;
+  const home = explicitHome(values);
+  if (home === false) return 1;
   const query = positionals.join(" ").trim();
   if (query === "") {
     process.stdout.write(`${USAGE}\n`);
@@ -150,11 +197,11 @@ function runMemorySearch(args: string[]): number {
     limit: numFlag(values, "limit"),
     any: values.any === true,
     synonyms: values["no-synonyms"] !== true,
-    home: typeof values.home === "string" ? values.home : undefined,
-    // --cwd-only carries its own path, so `--cwd-only PATH` needs no second flag.
-    // Bare `--cwd-only` (parsed as a boolean) hardens an accompanying --cwd.
+    home,
+    // --cwd-only PATH is the only hard-filter form. A missing or flag-like
+    // value is rejected by readFlags; there is no boolean-hardener.
     cwd: typeof values["cwd-only"] === "string" ? values["cwd-only"] : typeof values.cwd === "string" ? values.cwd : null,
-    cwdOnly: values["cwd-only"] !== undefined && values["cwd-only"] !== false,
+    cwdOnly: typeof values["cwd-only"] === "string",
     // Injected rather than imported by memory-search: the module keeps no edge
     // to chat-search, and the fallback is one flag away from being off.
     searchChat: values["no-chat"] === true ? undefined : searchChat,
@@ -167,8 +214,12 @@ function runMemorySearch(args: string[]): number {
 }
 
 function runChatIndex(args: string[]): number {
-  const { values } = parseFlags(args);
-  const home = typeof values.home === "string" ? values.home : codexHome();
+  const parsed = readFlags(args);
+  if (parsed === null) return 1;
+  const { values } = parsed;
+  const homeOrErr = explicitHome(values);
+  if (homeOrErr === false) return 1;
+  const home = homeOrErr ?? codexHome();
   const path = typeof values["index-path"] === "string" ? values["index-path"] : indexPath();
   try {
     // --status alone is a pure read: open read-only so it works on read-only
@@ -245,12 +296,20 @@ async function runHook(event: string): Promise<number> {
   }
 }
 export function main(argv: string[]): number | Promise<number> {
+  if (wantsHelp(argv)) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
   const kind = argv[0] ?? "help";
   const sub = argv[1] ?? "";
   if ((kind === "chat" || kind === "memory") && sub === "search") {
     return kind === "chat" ? runChatSearch(argv.slice(2)) : runMemorySearch(argv.slice(2));
   }
   if (kind === "chat" && sub === "index") {
+    if (argv.slice(2).some((a) => a === "help" || a === "/?")) {
+      process.stdout.write(`${USAGE}\n`);
+      return 0;
+    }
     return runChatIndex(argv.slice(2));
   }
   if (kind === "hook") {

--- a/plugins/codexclaw/components/recall/src/memory-search.ts
+++ b/plugins/codexclaw/components/recall/src/memory-search.ts
@@ -453,6 +453,12 @@ export function searchMemory(query: string, opts: MemorySearchOptions = {}): Mem
   }
 
   const root = memoriesDir(home);
+  if (!existsSync(root)) {
+    warnings.push("memories root not found (file search off)");
+  }
+  if (!memoriesDbPath(home)) {
+    warnings.push("memories db not found (stage1 search off)");
+  }
   const files = listMarkdownFiles(root);
   const scope = buildCwdScope(home, opts, warnings);
 
@@ -713,7 +719,6 @@ function searchStage1(
 ): void {
   const dbPath = memoriesDbPath(home);
   if (!dbPath) {
-    warnings.push("memories db not found (stage1 search off)");
     return;
   }
   let db: ReturnType<typeof openReadOnlyDb> | null = null;

--- a/plugins/codexclaw/components/recall/test/cli-arg-hygiene.test.ts
+++ b/plugins/codexclaw/components/recall/test/cli-arg-hygiene.test.ts
@@ -1,0 +1,278 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildCodexHome } from "./fixtures.ts";
+import { main as cliMain } from "../src/cli.ts";
+import { searchMemory } from "../src/memory-search.ts";
+
+function withCapturedStdio(fn: () => number): { code: number; stdout: string; stderr: string } {
+  const out: string[] = [];
+  const err: string[] = [];
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  (process.stdout as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+    out.push(s);
+    return true;
+  };
+  (process.stderr as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+    err.push(s);
+    return true;
+  };
+  try {
+    return { code: fn(), stdout: out.join(""), stderr: err.join("") };
+  } finally {
+    (process.stdout as unknown as { write: typeof origOut }).write = origOut;
+    (process.stderr as unknown as { write: typeof origErr }).write = origErr;
+  }
+}
+
+test("cli: chat index --help prints usage, exits 0, and does not ingest", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-help-idx-"));
+  const idx = join(home, "sidecar", "index.sqlite");
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "--help"]) as number,
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /cxc chat search/);
+    assert.doesNotMatch(r.stdout, /ingested/);
+    assert.equal(existsSync(idx), false, "help must not openIndex/create the sidecar");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: --help anywhere beats --rebuild", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-help-rebuild-"));
+  const idx = join(home, "sidecar", "index.sqlite");
+  try {
+    buildCodexHome(home);
+    assert.equal(
+      withCapturedStdio(() => cliMain(["chat", "index", "--home", home, "--index-path", idx]) as number).code,
+      0,
+    );
+    const before = withCapturedStdio(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "--status", "--json"]) as number,
+    );
+    const beforeJson = JSON.parse(before.stdout);
+    const help = withCapturedStdio(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "--rebuild", "--help"]) as number,
+    );
+    assert.equal(help.code, 0);
+    assert.match(help.stdout, /cxc chat search/);
+    assert.doesNotMatch(help.stdout, /ingested/);
+    const after = withCapturedStdio(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "--status", "--json"]) as number,
+    );
+    const afterJson = JSON.parse(after.stdout);
+    assert.equal(afterJson.files, beforeJson.files);
+    assert.equal(afterJson.msgs, beforeJson.msgs);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: memory search --help exits 0 even with no query", () => {
+  const r = withCapturedStdio(() => cliMain(["memory", "search", "--help"]) as number);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /cxc memory search/);
+});
+
+test("cli: -h is help", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-help-h-"));
+  const idx = join(home, "sidecar", "index.sqlite");
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "-h"]) as number,
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /cxc chat index/);
+    assert.doesNotMatch(r.stdout, /ingested/);
+    assert.equal(existsSync(idx), false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: chat index help prints usage, exits 0, and does not ingest", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-help-idx-word-"));
+  const idx = join(home, "sidecar", "index.sqlite");
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "help"]) as number,
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /cxc chat search/);
+    assert.doesNotMatch(r.stdout, /ingested/);
+    assert.equal(existsSync(idx), false, "positional help must not ingest");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: chat index /? prints usage, exits 0, and does not ingest", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-help-idx-slash-"));
+  const idx = join(home, "sidecar", "index.sqlite");
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "/?"]) as number,
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /cxc chat search/);
+    assert.doesNotMatch(r.stdout, /ingested/);
+    assert.equal(existsSync(idx), false, "/? must not ingest");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: memory search help searches for the word help", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-search-help-word-"));
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["memory", "search", "help", "--home", home, "--no-chat", "--json"]) as number,
+    );
+    assert.equal(r.code, 0);
+    const parsed = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(parsed.hits));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: chat search help searches for the word help", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-chat-search-help-word-"));
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["chat", "search", "help", "--home", home, "--scan", "--json"]) as number,
+    );
+    assert.equal(r.code, 0);
+    const parsed = JSON.parse(r.stdout);
+    assert.ok(Array.isArray(parsed.hits));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: dash-leading --cwd-only value is rejected", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-dash-cwdonly-"));
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["memory", "search", "memory", "--home", home, "--cwd-only", "--no-chat", "--json"]) as number,
+    );
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /cwd-only/);
+    assert.equal(r.stdout.trim(), "");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: equals-form --cwd-only=--no-chat is rejected", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-eq-cwdonly-"));
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["memory", "search", "memory", "--home", home, "--cwd-only=--no-chat", "--json"]) as number,
+    );
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /cwd-only/);
+    assert.match(r.stderr, /path must not start with '-'/);
+    assert.equal(r.stdout.trim(), "");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: dash-leading --cwd and --home values are rejected", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-dash-cwd-"));
+  try {
+    const cwd = withCapturedStdio(() =>
+      cliMain(["chat", "search", "q", "--home", home, "--cwd", "--json", "--scan"]) as number,
+    );
+    assert.notEqual(cwd.code, 0);
+    assert.match(cwd.stderr, /cwd/);
+    const homeFlag = withCapturedStdio(() =>
+      cliMain(["memory", "search", "q", "--home", "--json"]) as number,
+    );
+    assert.notEqual(homeFlag.code, 0);
+    assert.match(homeFlag.stderr, /home/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: equals-form --cwd=--json and --home=--json are rejected", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-eq-cwd-home-"));
+  try {
+    const cwd = withCapturedStdio(() =>
+      cliMain(["chat", "search", "q", "--home", home, "--cwd=--json", "--scan"]) as number,
+    );
+    assert.notEqual(cwd.code, 0);
+    assert.match(cwd.stderr, /--cwd path must not start with '-'/);
+    const homeFlag = withCapturedStdio(() =>
+      cliMain(["memory", "search", "q", "--home=--json"]) as number,
+    );
+    assert.notEqual(homeFlag.code, 0);
+    assert.match(homeFlag.stderr, /--home path must not start with '-'/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: missing --cwd-only value is rejected", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-missing-cwdonly-"));
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["memory", "search", "q", "--home", home, "--cwd-only"]) as number,
+    );
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /cwd-only/i);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: unknown flag is rejected", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-unknown-flag-"));
+  const idx = join(home, "sidecar", "index.sqlite");
+  try {
+    const r = withCapturedStdio(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "--not-a-flag"]) as number,
+    );
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /not-a-flag/i);
+    assert.equal(existsSync(idx), false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cli: missing --home directory exits non-zero", () => {
+  const missing = join(tmpdir(), "recall-home-does-not-exist");
+  assert.equal(existsSync(missing), false);
+  const r = withCapturedStdio(() =>
+    cliMain(["memory", "search", "foo", "--home", missing, "--no-chat", "--json"]) as number,
+  );
+  assert.notEqual(r.code, 0);
+  assert.match(r.stderr, /--home not found/);
+  assert.equal(r.stdout.trim(), "");
+});
+
+test("searchMemory: missing memories root and missing db each warn once, including on relaxed retry", () => {
+  const home = mkdtempSync(join(tmpdir(), "recall-missing-roots-"));
+  try {
+    const prose = searchMemory("anything", { home });
+    assert.equal(prose.hits.length, 0);
+    assert.equal(prose.warnings.filter((w) => w === "memories root not found (file search off)").length, 1);
+    assert.equal(prose.warnings.filter((w) => w === "memories db not found (stage1 search off)").length, 1);
+
+    const symbol = searchMemory("foo", { home });
+    assert.equal(symbol.hits.length, 0);
+    assert.equal(symbol.warnings.filter((w) => w === "memories root not found (file search off)").length, 1);
+    assert.equal(symbol.warnings.filter((w) => w === "memories db not found (stage1 search off)").length, 1);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/plugins/codexclaw/components/recall/test/memory-search.test.ts
+++ b/plugins/codexclaw/components/recall/test/memory-search.test.ts
@@ -73,7 +73,8 @@ test("missing memories db degrades with a warning", () => {
   try {
     const r = searchMemory("anything", { home: bare });
     assert.equal(r.hits.length, 0);
-    assert.ok(r.warnings.some((w) => w.includes("memories db")));
+    assert.equal(r.warnings.filter((w) => w.includes("memories db not found")).length, 1);
+    assert.equal(r.warnings.filter((w) => w.includes("memories root not found")).length, 1);
   } finally {
     rmSync(bare, { recursive: true, force: true });
   }


### PR DESCRIPTION
`cxc chat index --help` ran a full ingest — during an audit it took the index from 28 files to 101. Help is now answered at the top of `main` before any dispatch, `chat index help` and `/?` do the same while `memory search help` keeps searching for the word, and `strict: true` makes a typo an error instead of a silent ingest. For #140 a dash-leading value is refused instead of swallowing the next flag and searching the wrong scope at exit 0, a missing `--home` exits non-zero, and the missing-root and missing-db warnings are distinguishable and emitted once each.

Closes #139
Closes #140

## Stack (merge bottom-up)

| # | PR | branch | issues |
|---|---|---|---|
| L0 | #154 | `codex/memory-recall-roadmap` | — (roadmap) |
| L1 | #155 | `codex/fix-recall-cwd-normalization` | #138 |
| L2 | #156 | `codex/fix-memory-search-semantics` | #142, #143 |
| L3 | #157 | `codex/fix-recall-cli-arg-hygiene` | #139, #140 | **<- you are here**
| L4 | #158 | `codex/fix-chat-index-freshness` | #144 |
| L5 | #159 | `codex/fix-recall-intent-regex` | #137 |
| L6 | #160 | `codex/fix-memory-write-gate` | #135, #136, #141 |

**You are here: L3.** Base is `codex/fix-memory-search-semantics`. **Review this PR's diff only** — it is already scoped to this layer.

## Review focus

every argv shape that could still reach `ingest`.

## Evidence

Every layer was planned to diff level before any code, audited by an independent `xai/grok-4.6` reviewer, and implemented only after the audit's blockers were folded. Each new test was observed **failing on the parent tip** before it was shown passing; the per-layer receipt in `devlog/_plan/260911_memory_recall_sweep/` records the exact red output.

Local gate: `npm run build` exit 0, and `npm test` showing exactly the two pre-existing environmental failures recorded in `002_host_verification_baseline.md` (`hook-bench` hardcodes `cwd: "/tmp"`, and `cxc map --help` needs `py`) and no third.

## Note on the target-branch check

`Enforce PR target branch` requires `dev`. Layers L1-L6 legitimately target the layer below, so that workflow will flag them. **Do not retarget them to `dev`** — that would dissolve the stack. Merge bottom-up; each merge retargets the next child.




