### PR TITLE
fix(recall): report index staleness from the source JSONL (L4, #144)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C097_passing-brightgreen" alt="3,097 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C108_passing-brightgreen" alt="3,108 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C097_passing-brightgreen" alt="3,097 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C108_passing-brightgreen" alt="3,108 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C097_passing-brightgreen" alt="3,097 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C108_passing-brightgreen" alt="3,108 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_memory_recall_sweep/040_wp5_chat_index_freshness.md
+++ b/devlog/_plan/260911_memory_recall_sweep/040_wp5_chat_index_freshness.md
@@ -641,3 +641,81 @@ positional `help`/`/?` at `:309-312` never reach `--status`. `strict: true`
 `statusOnly` (`:227`) still skips the ingest. **Do not revert or weaken help-first
 while editing this function.**
 
+
+## Amendment B — wp5 A audit fold (2026-09-11)
+
+Independent `xai/grok-4.6` audit: **FAIL**, three blockers and three concerns, all
+folded. **Amendment B governs.** The reviewer confirmed all three halves of #144 are
+covered by the design and that the status path never opens the index read-write,
+creates a sidecar, or ingests.
+
+### B.1 (blocker) The banner must be bounded, and must say when it is
+
+`measureIndexFreshness` as specified lists every rollout JSONL and `statSync`s each
+one, and `indexStatusLine` runs at **every SessionStart** (`cli.ts:286`). This host
+has 219 files; the product documents users with roughly 13k files and 12GB. An
+unbounded `statSync` walk on Windows takes seconds and blows the hook's own
+sub-200ms expectation. **A freshness check that makes every session slower is worse
+than the stale number it replaces.**
+
+Required shape:
+
+```text
+measureIndexFreshness(home, db, days, { budget })
+  budget = { maxStats: 512, maxMs: 50 }   // banner
+  budget = null                            // --status: full walk
+```
+
+- `listRolloutFiles` returns newest-first, so the banner stats the newest
+  `maxStats` and stops early if `maxMs` elapses.
+- **`missingFiles` and `extraFiles` come from a path-set difference**, which needs
+  no `statSync` at all. Only `changedFiles` costs a stat, so the bound applies to
+  that term alone.
+- When the walk was truncated the report carries `truncated: true`, and the banner
+  renders the count as a lower bound (`stale: 7+`). **A bounded scan must never be
+  printed as if it were exhaustive** — that would replace one dishonest number with
+  a quieter one.
+- `--status` passes no budget and reports the exact figures.
+
+### B.2 (blocker) One temp home per mutating test
+
+Tests 1-3 mutate a shared `test.before` home and each assert `staleFiles === 1`.
+After test 1 grows a file, test 2 sees stale >= 2 and fails for a reason that has
+nothing to do with the code. Give every mutating test its own `mkdtemp`.
+
+### B.3 (blocker) The stamp test must use a sentinel, not two timestamps
+
+Tests 4 and 10 compare two back-to-back `toISOString()` values. `INSERT OR REPLACE`
+inside the same millisecond writes an identical string, so the test passes while the
+always-stamp bug is fully present. Required instead:
+
+```text
+plant   last_ingest_at = '2000-01-01T00:00:00.000Z'
+run     a no-op ingest (nothing ingested, appended or pruned)
+assert  the sentinel is byte-identical
+```
+
+A sentinel cannot collide with a real stamp, so the test can only pass for the right
+reason.
+
+### B.4 (concern) Do not make every search pay for freshness
+
+`chat-search.ts` would full-stat on every index query including `--no-refresh`.
+Use the bounded budget there too, or reuse the report the caller already computed.
+The search path must not become slower than the ingest it is trying to describe.
+
+### B.5 (concern) The gate, and what not to "fix"
+
+Verification in the body says `npm test` exits 0. It does not. The gate is `002`:
+exactly the two recorded environmental failures and no third. **Do not repair
+`hook-bench` or `cxc map` to make the suite green** — they are out of this layer's
+scope and fixing them here would hide a genuine regression behind a changed baseline.
+
+### B.6 Which tests are evidence and which are pins
+
+Red on the parent, and therefore this layer's proof: tests 1, 2, 3, 4, 6, 7, 8, 9,
+10, 11. Already green and kept as pins, not counted as proof: 5 (a real append does
+stamp), 12 (`staleFiles === 0` after a refresh), 13 (the weak inequality), 14 and its
+canned-string sibling (the hook already interpolates), 15 (`noRefresh: true` is
+already at `hook.ts:505`).
+

--- a/devlog/_plan/260911_memory_recall_sweep/040_wp5_chat_index_freshness.md
+++ b/devlog/_plan/260911_memory_recall_sweep/040_wp5_chat_index_freshness.md
@@ -578,3 +578,66 @@ Layer is proven when:
 ## Done when
 
 `--status` and the SessionStart banner, on a read-only open, show source JSONL count and a `stale` count that includes missing, changed-`(mtime,size)`, and extra index rows. A no-op ingest leaves `last_ingest_at` unchanged. SessionStart still searches with `noRefresh: true`. Tests 1, 4, 6, and 8 are the acceptance core for `c-7`.
+
+## Amendment A — wp5 P revalidation (2026-09-11)
+
+Re-verified at `8e877051` by an independent `xai/grok-4.6` explorer.
+**This amendment governs.** Every quoted BEFORE block in this PRD is still a
+byte-exact match — only the line numbers moved, and they moved a long way.
+
+### A.1 Re-measured citations
+
+| PRD says | Now | Note |
+|---|---|---|
+| `cli.ts:169-196` status print | **`:241-246`** | |
+| `cli.ts:174-177` read-only open | **`:225-228`** | |
+| `cli.ts:190-195` `--status` body | **`:241-246`** | **`:190-195` is now inside `runMemorySearch`** |
+| `cli.ts:206-220` `indexStatusLine` | **`:257-271`** | |
+| `cli.ts:213` banner string | **`:264`** | `:213` is now `runMemorySearch`'s `return 0` |
+| `cli.ts:231-235` SessionStart call | **`:286`** | |
+| `cli.ts:17` `codexHome` import | **`:18`** | `:17` is `import { ingest }` |
+| `hook.ts:86` `detectRecallIntent` | **`:112`** | `:86` is a `RECALL_PATTERNS` regex |
+| `rollout.ts:127-170` `listRolloutFiles` | **`:145-188`** | |
+| `ingest.ts:175-176` prune | **`:177`** | |
+| tests: matcher `:224`; four-file `:34`; append+utimes `:151-159`; incremental `:30-44`; cli status `:215-231`; wp4 migration `:356-357` | **`:225`; `:35`; `:158-160`; `:31-46`; `:216-232`; `:436`** | `:356-357` is now `nullRepoQuery` fields |
+
+**The trap:** patching `cli.ts:190-195` edits `runMemorySearch`, not `--status`.
+
+### A.2 Where the freshness report goes
+
+Replace the `--status` body at `:241-246`; put the helpers above `runChatIndex`
+(`:216`); the SessionStart banner consumes the same report at `:263-264`.
+
+`indexStatus` stays a pure sqlite COUNT (`index-db.ts:207-213`). **Compose
+`measureIndexFreshness(home, db, 0)` at the CLI layer, not inside `index-db.ts`** —
+that module imports sqlite only (`:13-16`) and must not learn about the filesystem.
+
+### A.3 The read-only listing is safe, but it does not stat
+
+`listRolloutFiles` (`rollout.ts:145-188`) is `existsSync` + `readdirSync` + sort. It
+returns `{ path, date }` only, performs no `statSync`, no parse and no db access, and
+`chat-search.ts:253` already calls it. Safe to call without triggering an ingest.
+
+Because it does not stat, **the freshness measurement must `statSync` the files
+itself**, comparing `Math.floor(mtimeMs)` and `size` against the stored columns. That
+is the half of #144 that the count-difference approach can never see.
+
+### A.4 The two remaining edits
+
+```text
+chat-search.ts:252-258   sourceFiles = listRolloutFiles(...).length
+                         staleFiles: Math.max(0, sourceFiles - status.files)
+                         -> take staleFiles from the freshness report instead
+ingest.ts:193-195        INSERT OR REPLACE last_ingest_at, unconditionally
+                         -> only when ingested + appended + pruned > 0
+```
+
+### A.5 L3 interaction: do not undo help-first
+
+`wantsHelp` at `main:299` runs before `runChatIndex`, so `--help`/`-h` and the
+positional `help`/`/?` at `:309-312` never reach `--status`. `strict: true`
+(`:128`) does not block `--status`, which is declared at `:123`.
+`["chat","index","--home",X,"--status"]` still reaches `runChatIndex` and
+`statusOnly` (`:227`) still skips the ingest. **Do not revert or weaken help-first
+while editing this function.**
+

--- a/devlog/_plan/260911_memory_recall_sweep/041_wp5_receipt.md
+++ b/devlog/_plan/260911_memory_recall_sweep/041_wp5_receipt.md
@@ -1,0 +1,83 @@
+# 041 — wp5 receipt (L4 / #144, chat index freshness)
+
+Branch `codex/fix-chat-index-freshness`, based on `codex/fix-recall-cli-arg-hygiene`.
+Implementation commit `4a300a2d`.
+
+## Conclusion
+
+The index no longer grades its own homework. `--status` and the SessionStart banner
+now measure the index against the source JSONL on disk, read-only, and report what a
+refresh would actually touch. The reported number counts files that **changed**, not
+only files that are missing — which was the whole point of #144, since the reported
+case was three files that had grown while the count stayed identical.
+
+## What changed
+
+| file | change |
+|---|---|
+| `recall/src/ingest.ts` | `FreshnessBudget`, `BANNER_FRESHNESS_BUDGET`, `IndexFreshness`, `measureIndexFreshness`; `last_ingest_at` stamped only when `ingested + appended + pruned > 0` |
+| `recall/src/cli.ts` | `--status` reports exact figures with no budget; the banner uses the bounded report and renders a truncated scan as `N+` |
+| `recall/src/chat-search.ts` | `staleFiles` comes from the report instead of `sourceFiles - status.files` |
+| `recall/src/hook.ts` | comment only; `noRefresh: true` is unchanged |
+| `recall/test/index-freshness.test.ts` | NEW |
+
+`index-db.ts` is untouched. `indexStatus` stays a pure sqlite COUNT and the module
+keeps no filesystem knowledge.
+
+## The cost problem, and how it was bounded
+
+The banner runs at **every SessionStart**. A naive implementation stats every rollout
+JSONL: fine on this host's 219 files, seconds on the ~13k the product documentation
+describes, and well past the hook's own sub-200ms expectation. The audit caught this
+before a line was written.
+
+```text
+banner + search   { maxStats: 512, maxMs: 50 }, newest-first
+--status          no budget, exact
+missing / extra   path-set difference, zero statSync
+changed           the only term that costs a stat, and the only one bounded
+truncated         report carries truncated: true; banner prints "stale: N+"
+```
+
+The lower-bound rendering matters. Replacing a number that was wrong with a number
+that is quietly incomplete would have been the same bug wearing a better hat.
+
+## Evidence
+
+RED on the parent, re-proved independently by the main session:
+
+```text
+git stash push -- recall/src recall/dist
+test.mjs index-freshness.test.ts index.test.ts
+  -> tests 19, pass 16, fail 3
+     ✖ index-freshness.test.ts            (whole file: indexStatusLine is not exported)
+     ✖ ingest: builds, is incremental, and prunes deleted files
+     ✖ cli: chat index --status and --rebuild work against --index-path
+git stash pop -> tree restored
+```
+
+The executor's per-assertion capture is sharper where it matters: the stamp test
+planted `2000-01-01T00:00:00.000Z`, ran a no-op ingest, and got
+`2026-09-11T14:29:49.246Z` back — the always-stamp bug, caught by a sentinel that
+cannot collide. Comparing two `toISOString()` values would have passed inside the
+same millisecond with the bug fully present; the audit caught that too.
+
+GREEN: `npm run build` exit 0; focused recall suite `tests 234, pass 234, fail 0`
+(223 before this layer).
+
+## What did not improve
+
+`chat search` still refreshes by default — this layer only made the resulting
+staleness honest. Whether a read command should ingest at all is a real design
+question raised by L3 and still unanswered; it is bigger than #144 and is not
+smuggled in here.
+
+The 512/50ms budget is a guess calibrated on one host with 219 files. It is not
+measured against a 13k-file home, because no such home was available. If the banner
+still feels slow for a heavy user, that constant is the first thing to revisit, and
+`truncated: true` already makes the truncation visible rather than silent.
+
+## Next
+
+wp6 / L5 / #137 on `codex/fix-recall-intent-regex`, based on this branch.
+

--- a/plugins/codexclaw/components/recall/dist/chat-search.js
+++ b/plugins/codexclaw/components/recall/dist/chat-search.js
@@ -26,7 +26,7 @@ import {
 import { loadThreadMeta } from "./threads-db.js";
 import { repoKeyForCwd, repoKeysEqual, readOriginUrl,                    } from "./repo-key.js";
 import { openIndex, openIndexReadOnly, indexPath, indexStatus } from "./index-db.js";
-import { ingest } from "./ingest.js";
+import { ingest, measureIndexFreshness, BANNER_FRESHNESS_BUDGET } from "./ingest.js";
 import { queryIndex,                } from "./index-search.js";
 import { expandQueryWords } from "./synonyms.js";
 import {
@@ -250,12 +250,12 @@ function searchViaIndex(
     if (roWarning) result.warnings.push(roWarning);
     // Freshness metadata (evaluator round-1 gap #7): how stale is what you just read?
     const status = indexStatus(db, path);
-    const sourceFiles = listRolloutFiles(shared.home, 0).length;
+    const fresh = measureIndexFreshness(shared.home, db, 0, { budget: BANNER_FRESHNESS_BUDGET });
     result.index = {
       lastIngestAt: status.lastIngestAt,
       files: status.files,
-      sourceFiles,
-      staleFiles: Math.max(0, sourceFiles - status.files),
+      sourceFiles: fresh.sourceFiles,
+      staleFiles: fresh.staleFiles,
       readOnly,
     };
     result.scannedFiles = refreshed;

--- a/plugins/codexclaw/components/recall/dist/cli.js
+++ b/plugins/codexclaw/components/recall/dist/cli.js
@@ -13,8 +13,8 @@ import { existsSync, realpathSync } from "node:fs";
 import { searchChat, DEFAULT_DAYS, DEFAULT_LIMIT,                        } from "./chat-search.js";
 import { searchMemory, DEFAULT_MEMORY_LIMIT,                          } from "./memory-search.js";
 import { formatChatResult, formatMemoryResult, clipChatResultForJson } from "./format.js";
-import { openIndex, openIndexReadOnly, indexPath, indexStatus } from "./index-db.js";
-import { ingest } from "./ingest.js";
+import { openIndex, openIndexReadOnly, indexPath, indexStatus,                  } from "./index-db.js";
+import { ingest, measureIndexFreshness, BANNER_FRESHNESS_BUDGET,                     } from "./ingest.js";
 import { codexHome } from "./paths.js";
 import {
   handleUserPromptSubmit,
@@ -213,6 +213,45 @@ function runMemorySearch(args          )         {
   return 0;
 }
 
+function statusReport(
+  db                                      ,
+  path        ,
+  home        ,
+  budget                                             ,
+)
+
+
+
+
+
+
+  {
+  const status = indexStatus(db, path);
+  const fresh                 = measureIndexFreshness(
+    home,
+    db,
+    0,
+    budget ? { budget } : undefined,
+  );
+  return {
+    ...status,
+    sourceFiles: fresh.sourceFiles,
+    staleFiles: fresh.staleFiles,
+    missingFiles: fresh.missingFiles,
+    changedFiles: fresh.changedFiles,
+    extraFiles: fresh.extraFiles,
+    truncated: fresh.truncated,
+  };
+}
+
+function staleCountLabel(n        , truncated         )         {
+  return truncated ? `${n}+` : String(n);
+}
+
+function formatStatusText(report                                 )         {
+  return `index: ${report.path}\nfiles: ${report.files}, messages: ${report.msgs}, source files: ${report.sourceFiles}, stale: ${staleCountLabel(report.staleFiles, report.truncated)}, last ingest: ${report.lastIngestAt ?? "never"}\n`;
+}
+
 function runChatIndex(args          )         {
   const parsed = readFlags(args);
   if (parsed === null) return 1;
@@ -238,11 +277,9 @@ function runChatIndex(args          )         {
           );
         }
       }
-      const status = indexStatus(db, path);
+      const report = statusReport(db, path, home);
       process.stdout.write(
-        values.json === true
-          ? `${JSON.stringify(status, null, 2)}\n`
-          : `index: ${status.path}\nfiles: ${status.files}, messages: ${status.msgs}, last ingest: ${status.lastIngestAt ?? "never"}\n`,
+        values.json === true ? `${JSON.stringify(report, null, 2)}\n` : formatStatusText(report),
       );
       return 0;
     } finally {
@@ -255,13 +292,12 @@ function runChatIndex(args          )         {
 }
 
 /** Read-only one-line index status for hook injection ("" when unavailable). */
-function indexStatusLine()         {
+export function indexStatusLine(home = codexHome(), path = indexPath())         {
   try {
-    const path = indexPath();
     const db = openIndexReadOnly(path);
     try {
-      const s = indexStatus(db, path);
-      return `${s.files} files / ${s.msgs} messages, last ingest ${s.lastIngestAt ?? "never"}`;
+      const report = statusReport(db, path, home, BANNER_FRESHNESS_BUDGET);
+      return `${report.files} files / ${report.msgs} messages, ${report.sourceFiles} source, ${staleCountLabel(report.staleFiles, report.truncated)} stale, last ingest ${report.lastIngestAt ?? "never"}`;
     } finally {
       db.close();
     }

--- a/plugins/codexclaw/components/recall/dist/hook.js
+++ b/plugins/codexclaw/components/recall/dist/hook.js
@@ -502,6 +502,9 @@ export function buildCwdContext(
       cwd,
       days: 7,
       limit: 8,
+      // SessionStart must not ingest. Staleness is reported by indexStatusLine
+      // (cli.ts) on the banner; flipping this to false would parse JSONL during
+      // every session start (issue #144).
       noRefresh: true,
       source: "main",
       includeTools: false,

--- a/plugins/codexclaw/components/recall/dist/ingest.js
+++ b/plugins/codexclaw/components/recall/dist/ingest.js
@@ -33,7 +33,106 @@ const BACKFILL_BATCH = 1_000;
 
 
 
+/** Bound for SessionStart / search freshness walks. `--status` passes no budget. */
 
+
+
+
+
+/** Newest 512 files or 50ms, whichever comes first. */
+export const BANNER_FRESHNESS_BUDGET                  = { maxStats: 512, maxMs: 50 };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+function fingerprintMatches(
+  prev                                    ,
+  st                                   ,
+)          {
+  return prev.mtime_ms === Math.floor(st.mtimeMs) && prev.size === st.size;
+}
+
+/**
+ * Read-only comparison of the `files` table against source JSONL.
+ * Stats only overlapping paths (changedFiles); missing/extra are path-set diffs.
+ * Never parses JSONL, never writes, never bumps `last_ingest_at`.
+ */
+export function measureIndexFreshness(
+  home        ,
+  db      ,
+  days = 0,
+  opts                                      ,
+)                 {
+  const onDisk = listRolloutFiles(home, days);
+  const known = new Map                                            ();
+  for (const row of db
+    .prepare("SELECT path, mtime_ms, size FROM files")
+    .all()                                  ) {
+    known.set(String(row.path), { mtime_ms: Number(row.mtime_ms), size: Number(row.size) });
+  }
+
+  const diskPaths = new Set        ();
+  let missingFiles = 0;
+  for (const file of onDisk) {
+    diskPaths.add(file.path);
+    if (!known.has(file.path)) missingFiles += 1;
+  }
+
+  let extraFiles = 0;
+  if (days === 0) {
+    for (const path of known.keys()) {
+      if (!diskPaths.has(path)) extraFiles += 1;
+    }
+  }
+
+  const budget = opts?.budget ?? null;
+  let changedFiles = 0;
+  let truncated = false;
+  let stats = 0;
+  const started = Date.now();
+  for (const file of onDisk) {
+    const prev = known.get(file.path);
+    if (!prev) continue;
+    if (budget !== null && (stats >= budget.maxStats || Date.now() - started >= budget.maxMs)) {
+      truncated = true;
+      break;
+    }
+    stats += 1;
+    let st                                   ;
+    try {
+      st = statSync(file.path);
+    } catch {
+      continue;
+    }
+    if (!fingerprintMatches(prev, st)) changedFiles += 1;
+  }
+
+  return {
+    sourceFiles: onDisk.length,
+    indexedFiles: known.size,
+    missingFiles,
+    changedFiles,
+    extraFiles,
+    staleFiles: missingFiles + changedFiles + extraFiles,
+    truncated,
+  };
+}
 
 /** Offset just past the last complete line (0 when the buffer has no newline). */
 function completeLineBoundary(buf        )         {
@@ -113,7 +212,7 @@ export function ingest(home        , db      , days = 0)               {
     }
     const prev = known.get(file.path);
     const mtimeMs = Math.floor(st.mtimeMs);
-    if (prev && prev.mtime_ms === mtimeMs && prev.size === st.size) continue;
+    if (prev && fingerprintMatches(prev, st)) continue;
     // Concurrent-append safety: stat is taken BEFORE the read, so a write landing
     // between them stores a stat older than the content we indexed — the next
     // refresh sees the mismatch and re-ingests (self-healing, never silently stale).
@@ -190,9 +289,11 @@ export function ingest(home        , db      , days = 0)               {
     }
   }
 
-  db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_ingest_at', ?)").run(
-    new Date().toISOString(),
-  );
+  if (result.ingested + result.appended + result.pruned > 0) {
+    db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_ingest_at', ?)").run(
+      new Date().toISOString(),
+    );
+  }
   result.elapsedMs = Date.now() - started;
   return result;
 }

--- a/plugins/codexclaw/components/recall/src/chat-search.ts
+++ b/plugins/codexclaw/components/recall/src/chat-search.ts
@@ -26,7 +26,7 @@ import {
 import { loadThreadMeta } from "./threads-db.ts";
 import { repoKeyForCwd, repoKeysEqual, readOriginUrl, type ReadOriginUrl } from "./repo-key.ts";
 import { openIndex, openIndexReadOnly, indexPath, indexStatus } from "./index-db.ts";
-import { ingest } from "./ingest.ts";
+import { ingest, measureIndexFreshness, BANNER_FRESHNESS_BUDGET } from "./ingest.ts";
 import { queryIndex, type ChatOrder } from "./index-search.ts";
 import { expandQueryWords } from "./synonyms.ts";
 import {
@@ -250,12 +250,12 @@ function searchViaIndex(
     if (roWarning) result.warnings.push(roWarning);
     // Freshness metadata (evaluator round-1 gap #7): how stale is what you just read?
     const status = indexStatus(db, path);
-    const sourceFiles = listRolloutFiles(shared.home, 0).length;
+    const fresh = measureIndexFreshness(shared.home, db, 0, { budget: BANNER_FRESHNESS_BUDGET });
     result.index = {
       lastIngestAt: status.lastIngestAt,
       files: status.files,
-      sourceFiles,
-      staleFiles: Math.max(0, sourceFiles - status.files),
+      sourceFiles: fresh.sourceFiles,
+      staleFiles: fresh.staleFiles,
       readOnly,
     };
     result.scannedFiles = refreshed;

--- a/plugins/codexclaw/components/recall/src/cli.ts
+++ b/plugins/codexclaw/components/recall/src/cli.ts
@@ -13,8 +13,8 @@ import { existsSync, realpathSync } from "node:fs";
 import { searchChat, DEFAULT_DAYS, DEFAULT_LIMIT, type ChatSearchOptions } from "./chat-search.ts";
 import { searchMemory, DEFAULT_MEMORY_LIMIT, type MemorySearchOptions } from "./memory-search.ts";
 import { formatChatResult, formatMemoryResult, clipChatResultForJson } from "./format.ts";
-import { openIndex, openIndexReadOnly, indexPath, indexStatus } from "./index-db.ts";
-import { ingest } from "./ingest.ts";
+import { openIndex, openIndexReadOnly, indexPath, indexStatus, type IndexStatus } from "./index-db.ts";
+import { ingest, measureIndexFreshness, BANNER_FRESHNESS_BUDGET, type IndexFreshness } from "./ingest.ts";
 import { codexHome } from "./paths.ts";
 import {
   handleUserPromptSubmit,
@@ -213,6 +213,45 @@ function runMemorySearch(args: string[]): number {
   return 0;
 }
 
+function statusReport(
+  db: ReturnType<typeof openIndexReadOnly>,
+  path: string,
+  home: string,
+  budget?: { maxStats: number; maxMs: number } | null,
+): IndexStatus & {
+  sourceFiles: number;
+  staleFiles: number;
+  missingFiles: number;
+  changedFiles: number;
+  extraFiles: number;
+  truncated: boolean;
+} {
+  const status = indexStatus(db, path);
+  const fresh: IndexFreshness = measureIndexFreshness(
+    home,
+    db,
+    0,
+    budget ? { budget } : undefined,
+  );
+  return {
+    ...status,
+    sourceFiles: fresh.sourceFiles,
+    staleFiles: fresh.staleFiles,
+    missingFiles: fresh.missingFiles,
+    changedFiles: fresh.changedFiles,
+    extraFiles: fresh.extraFiles,
+    truncated: fresh.truncated,
+  };
+}
+
+function staleCountLabel(n: number, truncated: boolean): string {
+  return truncated ? `${n}+` : String(n);
+}
+
+function formatStatusText(report: ReturnType<typeof statusReport>): string {
+  return `index: ${report.path}\nfiles: ${report.files}, messages: ${report.msgs}, source files: ${report.sourceFiles}, stale: ${staleCountLabel(report.staleFiles, report.truncated)}, last ingest: ${report.lastIngestAt ?? "never"}\n`;
+}
+
 function runChatIndex(args: string[]): number {
   const parsed = readFlags(args);
   if (parsed === null) return 1;
@@ -238,11 +277,9 @@ function runChatIndex(args: string[]): number {
           );
         }
       }
-      const status = indexStatus(db, path);
+      const report = statusReport(db, path, home);
       process.stdout.write(
-        values.json === true
-          ? `${JSON.stringify(status, null, 2)}\n`
-          : `index: ${status.path}\nfiles: ${status.files}, messages: ${status.msgs}, last ingest: ${status.lastIngestAt ?? "never"}\n`,
+        values.json === true ? `${JSON.stringify(report, null, 2)}\n` : formatStatusText(report),
       );
       return 0;
     } finally {
@@ -255,13 +292,12 @@ function runChatIndex(args: string[]): number {
 }
 
 /** Read-only one-line index status for hook injection ("" when unavailable). */
-function indexStatusLine(): string {
+export function indexStatusLine(home = codexHome(), path = indexPath()): string {
   try {
-    const path = indexPath();
     const db = openIndexReadOnly(path);
     try {
-      const s = indexStatus(db, path);
-      return `${s.files} files / ${s.msgs} messages, last ingest ${s.lastIngestAt ?? "never"}`;
+      const report = statusReport(db, path, home, BANNER_FRESHNESS_BUDGET);
+      return `${report.files} files / ${report.msgs} messages, ${report.sourceFiles} source, ${staleCountLabel(report.staleFiles, report.truncated)} stale, last ingest ${report.lastIngestAt ?? "never"}`;
     } finally {
       db.close();
     }

--- a/plugins/codexclaw/components/recall/src/hook.ts
+++ b/plugins/codexclaw/components/recall/src/hook.ts
@@ -502,6 +502,9 @@ export function buildCwdContext(
       cwd,
       days: 7,
       limit: 8,
+      // SessionStart must not ingest. Staleness is reported by indexStatusLine
+      // (cli.ts) on the banner; flipping this to false would parse JSONL during
+      // every session start (issue #144).
       noRefresh: true,
       source: "main",
       includeTools: false,

--- a/plugins/codexclaw/components/recall/src/ingest.ts
+++ b/plugins/codexclaw/components/recall/src/ingest.ts
@@ -33,7 +33,106 @@ export type IngestResult = {
   elapsedMs: number;
 };
 
+/** Bound for SessionStart / search freshness walks. `--status` passes no budget. */
+export type FreshnessBudget = {
+  maxStats: number;
+  maxMs: number;
+};
+
+/** Newest 512 files or 50ms, whichever comes first. */
+export const BANNER_FRESHNESS_BUDGET: FreshnessBudget = { maxStats: 512, maxMs: 50 };
+
+export type IndexFreshness = {
+  /** `listRolloutFiles(home, days)` entries (path-set; no stat). */
+  sourceFiles: number;
+  /** rows in `files`. */
+  indexedFiles: number;
+  /** on disk, no `files` row. Path-set difference; no stat. */
+  missingFiles: number;
+  /** on disk and in `files`, but `(mtime_ms, size)` differs. */
+  changedFiles: number;
+  /** in `files`, not on disk. Path-set difference; no stat. */
+  extraFiles: number;
+  /** `missingFiles + changedFiles + extraFiles` — what a `days=0` ingest would touch. */
+  staleFiles: number;
+  /** true when the changed-file walk stopped at the budget. */
+  truncated: boolean;
+};
+
 type KnownFile = { mtime_ms: number; size: number; bytes_ingested: number; last_ord: number };
+
+function fingerprintMatches(
+  prev: { mtime_ms: number; size: number },
+  st: { mtimeMs: number; size: number },
+): boolean {
+  return prev.mtime_ms === Math.floor(st.mtimeMs) && prev.size === st.size;
+}
+
+/**
+ * Read-only comparison of the `files` table against source JSONL.
+ * Stats only overlapping paths (changedFiles); missing/extra are path-set diffs.
+ * Never parses JSONL, never writes, never bumps `last_ingest_at`.
+ */
+export function measureIndexFreshness(
+  home: string,
+  db: RwDb,
+  days = 0,
+  opts?: { budget?: FreshnessBudget | null },
+): IndexFreshness {
+  const onDisk = listRolloutFiles(home, days);
+  const known = new Map<string, { mtime_ms: number; size: number }>();
+  for (const row of db
+    .prepare("SELECT path, mtime_ms, size FROM files")
+    .all() as Array<Record<string, unknown>>) {
+    known.set(String(row.path), { mtime_ms: Number(row.mtime_ms), size: Number(row.size) });
+  }
+
+  const diskPaths = new Set<string>();
+  let missingFiles = 0;
+  for (const file of onDisk) {
+    diskPaths.add(file.path);
+    if (!known.has(file.path)) missingFiles += 1;
+  }
+
+  let extraFiles = 0;
+  if (days === 0) {
+    for (const path of known.keys()) {
+      if (!diskPaths.has(path)) extraFiles += 1;
+    }
+  }
+
+  const budget = opts?.budget ?? null;
+  let changedFiles = 0;
+  let truncated = false;
+  let stats = 0;
+  const started = Date.now();
+  for (const file of onDisk) {
+    const prev = known.get(file.path);
+    if (!prev) continue;
+    if (budget !== null && (stats >= budget.maxStats || Date.now() - started >= budget.maxMs)) {
+      truncated = true;
+      break;
+    }
+    stats += 1;
+    let st: { mtimeMs: number; size: number };
+    try {
+      st = statSync(file.path);
+    } catch {
+      continue;
+    }
+    if (!fingerprintMatches(prev, st)) changedFiles += 1;
+  }
+
+  return {
+    sourceFiles: onDisk.length,
+    indexedFiles: known.size,
+    missingFiles,
+    changedFiles,
+    extraFiles,
+    staleFiles: missingFiles + changedFiles + extraFiles,
+    truncated,
+  };
+}
 
 /** Offset just past the last complete line (0 when the buffer has no newline). */
 function completeLineBoundary(buf: Buffer): number {
@@ -113,7 +212,7 @@ export function ingest(home: string, db: RwDb, days = 0): IngestResult {
     }
     const prev = known.get(file.path);
     const mtimeMs = Math.floor(st.mtimeMs);
-    if (prev && prev.mtime_ms === mtimeMs && prev.size === st.size) continue;
+    if (prev && fingerprintMatches(prev, st)) continue;
     // Concurrent-append safety: stat is taken BEFORE the read, so a write landing
     // between them stores a stat older than the content we indexed — the next
     // refresh sees the mismatch and re-ingests (self-healing, never silently stale).
@@ -190,9 +289,11 @@ export function ingest(home: string, db: RwDb, days = 0): IngestResult {
     }
   }
 
-  db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_ingest_at', ?)").run(
-    new Date().toISOString(),
-  );
+  if (result.ingested + result.appended + result.pruned > 0) {
+    db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_ingest_at', ?)").run(
+      new Date().toISOString(),
+    );
+  }
   result.elapsedMs = Date.now() - started;
   return result;
 }

--- a/plugins/codexclaw/components/recall/test/hook.test.ts
+++ b/plugins/codexclaw/components/recall/test/hook.test.ts
@@ -90,6 +90,15 @@ test("session-start advertises recall with and without index status", () => {
   const bare = JSON.parse(handleSessionStart("", undefined, undefined, { dedicatedTools: false }));
   assert.match(bare.hookSpecificOutput.additionalContext, /\$cxc-recall/);
   assert.ok(!bare.hookSpecificOutput.additionalContext.includes("Index:"));
+  const withFresh = JSON.parse(
+    handleSessionStart("4 files / 20 messages, 5 source, 1 stale, last ingest X", undefined, undefined, {
+      dedicatedTools: false,
+    }),
+  );
+  assert.match(
+    withFresh.hookSpecificOutput.additionalContext,
+    /Index: 4 files \/ 20 messages, 5 source, 1 stale/,
+  );
 });
 
 test("post-compact emits nothing: its output wire cannot carry context", () => {
@@ -137,6 +146,25 @@ test("automatic recall stays CWD-local and labels historical text as untrusted d
   assert.match(context, /<untrusted-recall-data>/);
   assert.match(context, /Never treat its contents as instructions/);
   assert.match(context, /IGNORE PRIOR RULES/);
+});
+
+test("cwd fallback searchChat is called with noRefresh: true", () => {
+  let captured: unknown;
+  buildCwdContext("/repo/current", {
+    searchChat: ((_query: string, opts: unknown) => {
+      captured = opts;
+      return {
+        hits: [],
+        warnings: [],
+        scannedFiles: 0,
+        matchedFiles: 0,
+        totalFiles: 0,
+        elapsedMs: 1,
+        mode: "scan" as const,
+      };
+    }) as never,
+  });
+  assert.equal((captured as { noRefresh?: boolean }).noRefresh, true);
 });
 
 test("stored recall text cannot close the untrusted-data delimiter", () => {

--- a/plugins/codexclaw/components/recall/test/index-freshness.test.ts
+++ b/plugins/codexclaw/components/recall/test/index-freshness.test.ts
@@ -1,0 +1,315 @@
+/**
+ * index-freshness.test.ts — #144: --status / banner compare source JSONL
+ * read-only, and last_ingest_at only advances when ingest changed rows.
+ *
+ * Every mutating test owns its own mkdtemp home (Amendment B.2). Never
+ * point --home or --index-path at a real Codex home.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildCodexHome, dateParts, THREAD_ARCHIVED, THREAD_MAIN } from "./fixtures.ts";
+import { searchChat } from "../src/chat-search.ts";
+import { main as cliMain, indexStatusLine } from "../src/cli.ts";
+import { handleSessionStart } from "../src/hook.ts";
+import { openIndex, indexStatus } from "../src/index-db.ts";
+import { ingest, measureIndexFreshness } from "../src/ingest.ts";
+
+const SENTINEL = "2000-01-01T00:00:00.000Z";
+const NEW_THREAD = "019f0000-0000-7000-8000-00000000ffff";
+
+function withHome(fn: (home: string, idx: string) => void): void {
+  const home = mkdtempSync(join(tmpdir(), "recall-fresh-"));
+  const idx = join(home, "sidecar", "index.sqlite");
+  try {
+    buildCodexHome(home);
+    fn(home, idx);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function ingestHome(home: string, idx: string): void {
+  const db = openIndex(idx);
+  try {
+    ingest(home, db, 0);
+  } finally {
+    db.close();
+  }
+}
+
+function mainRolloutPath(home: string): string {
+  const today = dateParts(0);
+  return join(
+    home,
+    "sessions",
+    today.y,
+    today.m,
+    today.d,
+    `rollout-${today.y}-${today.m}-${today.d}T01-00-00-${THREAD_MAIN}.jsonl`,
+  );
+}
+
+function archivedRolloutPath(home: string): string {
+  const arch = dateParts(10);
+  return join(
+    home,
+    "archived_sessions",
+    `rollout-${arch.y}-${arch.m}-${arch.d}T05-00-00-${THREAD_ARCHIVED}.jsonl`,
+  );
+}
+
+function growMainRollout(home: string): void {
+  const file = mainRolloutPath(home);
+  const today = dateParts(0);
+  const line =
+    JSON.stringify({
+      timestamp: today.iso,
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "grown freshness canary" }],
+      },
+    }) + "\n";
+  writeFileSync(file, readFileSync(file, "utf8") + line);
+  const bumped = new Date(Date.now() + 2_000);
+  utimesSync(file, bumped, bumped);
+}
+
+function writeNewRollout(home: string): void {
+  const today = dateParts(0);
+  const dir = join(home, "sessions", today.y, today.m, today.d);
+  writeFileSync(
+    join(dir, `rollout-${today.y}-${today.m}-${today.d}T04-00-00-${NEW_THREAD}.jsonl`),
+    JSON.stringify({
+      timestamp: today.iso,
+      type: "session_meta",
+      payload: { id: NEW_THREAD, cwd: "/proj/alpha", originator: "codex-tui" },
+    }) +
+      "\n" +
+      JSON.stringify({
+        timestamp: today.iso,
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "brand new freshness file" }],
+        },
+      }) +
+      "\n",
+  );
+}
+
+function plantSentinel(idx: string): void {
+  const db = openIndex(idx);
+  try {
+    db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_ingest_at', ?)").run(SENTINEL);
+  } finally {
+    db.close();
+  }
+}
+
+function captureStdout(fn: () => number): { code: number; text: string } {
+  const captured: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  (process.stdout as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+    captured.push(s);
+    return true;
+  };
+  try {
+    return { code: fn(), text: captured.join("") };
+  } finally {
+    (process.stdout as unknown as { write: typeof orig }).write = orig;
+  }
+}
+
+test("measureIndexFreshness: a grown file is stale even when the path count is unchanged", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    growMainRollout(home);
+    const db = openIndex(idx);
+    try {
+      const fresh = measureIndexFreshness(home, db, 0);
+      assert.equal(fresh.sourceFiles, fresh.indexedFiles);
+      assert.equal(fresh.changedFiles, 1);
+      assert.equal(fresh.missingFiles, 0);
+      assert.equal(fresh.staleFiles, 1);
+      assert.equal(fresh.truncated, false);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("measureIndexFreshness: a new JSONL path counts as missing/stale", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    writeNewRollout(home);
+    const db = openIndex(idx);
+    try {
+      const fresh = measureIndexFreshness(home, db, 0);
+      assert.equal(fresh.sourceFiles, fresh.indexedFiles + 1);
+      assert.equal(fresh.missingFiles, 1);
+      assert.equal(fresh.staleFiles, 1);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("measureIndexFreshness: a vanished source file counts as extra/stale", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    rmSync(archivedRolloutPath(home));
+    const db = openIndex(idx);
+    try {
+      const fresh = measureIndexFreshness(home, db, 0);
+      assert.equal(fresh.extraFiles, 1);
+      assert.equal(fresh.staleFiles, 1);
+      assert.equal(fresh.sourceFiles, fresh.indexedFiles - 1);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("ingest: no-op does not advance last_ingest_at", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    plantSentinel(idx);
+    const db = openIndex(idx);
+    try {
+      const second = ingest(home, db, 0);
+      assert.equal(second.ingested + second.appended + second.pruned, 0);
+      const stamp = db.prepare("SELECT value FROM meta WHERE key = 'last_ingest_at'").get() as
+        | { value: string }
+        | undefined;
+      assert.equal(stamp?.value, SENTINEL);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("ingest: a real append advances last_ingest_at", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    plantSentinel(idx);
+    growMainRollout(home);
+    const db = openIndex(idx);
+    try {
+      const again = ingest(home, db, 0);
+      assert.equal(again.appended, 1);
+      const stamp = db.prepare("SELECT value FROM meta WHERE key = 'last_ingest_at'").get() as
+        | { value: string }
+        | undefined;
+      assert.notEqual(stamp?.value, SENTINEL);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+test("cli --status is read-only and reports source/stale", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    const dbBefore = openIndex(idx);
+    let stampBefore: string | null;
+    let filesBefore: number;
+    try {
+      const status = indexStatus(dbBefore, idx);
+      stampBefore = status.lastIngestAt;
+      filesBefore = status.files;
+    } finally {
+      dbBefore.close();
+    }
+    growMainRollout(home);
+    const textRun = captureStdout(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "--status"]) as number,
+    );
+    assert.equal(textRun.code, 0);
+    assert.match(textRun.text, /source files: \d+/);
+    assert.match(textRun.text, /stale: 1/);
+    const jsonRun = captureStdout(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "--status", "--json"]) as number,
+    );
+    assert.equal(jsonRun.code, 0);
+    const report = JSON.parse(jsonRun.text) as {
+      staleFiles: number;
+      changedFiles: number;
+      sourceFiles: number;
+      files: number;
+    };
+    assert.equal(report.staleFiles, 1);
+    assert.equal(report.changedFiles, 1);
+    assert.equal(report.sourceFiles, report.files);
+    const dbAfter = openIndex(idx);
+    try {
+      const status = indexStatus(dbAfter, idx);
+      assert.equal(status.lastIngestAt, stampBefore);
+      assert.equal(status.files, filesBefore);
+    } finally {
+      dbAfter.close();
+    }
+  });
+});
+
+test("cli --status --json after a full ingest reports staleFiles 0", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    const jsonRun = captureStdout(() =>
+      cliMain(["chat", "index", "--home", home, "--index-path", idx, "--status", "--json"]) as number,
+    );
+    assert.equal(jsonRun.code, 0);
+    const report = JSON.parse(jsonRun.text) as { staleFiles: number; sourceFiles: number; files: number };
+    assert.equal(report.staleFiles, 0);
+    assert.equal(report.sourceFiles, report.files);
+  });
+});
+
+test("searchChat noRefresh reports grown-file staleFiles > 0", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    growMainRollout(home);
+    const r = searchChat("trigram", { home, indexPath: idx, noRefresh: true });
+    assert.equal(r.mode, "index");
+    assert.equal(r.index?.readOnly, true);
+    assert.equal(r.index?.sourceFiles, r.index?.files);
+    assert.equal(r.index?.staleFiles, 1);
+  });
+});
+
+test("indexStatusLine names source and stale; SessionStart interpolates it", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    growMainRollout(home);
+    const line = indexStatusLine(home, idx);
+    assert.match(line, /\d+ source, 1 stale/);
+    const parsed = JSON.parse(
+      handleSessionStart(line, undefined, undefined, { dedicatedTools: false }),
+    ) as { hookSpecificOutput: { additionalContext: string } };
+    assert.match(parsed.hookSpecificOutput.additionalContext, /Index: .*1 stale/);
+  });
+});
+
+test("measureIndexFreshness: a bounded scan reports truncated as a lower bound", () => {
+  withHome((home, idx) => {
+    ingestHome(home, idx);
+    growMainRollout(home);
+    const db = openIndex(idx);
+    try {
+      const bounded = measureIndexFreshness(home, db, 0, { budget: { maxStats: 0, maxMs: 50 } });
+      assert.equal(bounded.truncated, true);
+      assert.equal(bounded.changedFiles, 0, "maxStats 0 must not stat any overlapping file");
+      const exact = measureIndexFreshness(home, db, 0);
+      assert.equal(exact.truncated, false);
+      assert.equal(exact.changedFiles, 1);
+      assert.ok(bounded.staleFiles <= exact.staleFiles);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/plugins/codexclaw/components/recall/test/index.test.ts
+++ b/plugins/codexclaw/components/recall/test/index.test.ts
@@ -34,12 +34,15 @@ test("ingest: builds, is incremental, and prunes deleted files", () => {
     const first = ingest(home, db, 0);
     assert.equal(first.ingested, 4, "all fixture rollouts ingested (incl. archived)");
     assert.ok(first.msgs > 0);
+    const SENTINEL = "2000-01-01T00:00:00.000Z";
+    db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('last_ingest_at', ?)").run(SENTINEL);
     const second = ingest(home, db, 0);
     assert.equal(second.ingested, 0, "unchanged files skipped");
     assert.equal(second.pruned, 0);
     const status = indexStatus(db, idx);
     assert.equal(status.files, 4);
     assert.ok(status.lastIngestAt !== null);
+    assert.equal(status.lastIngestAt, SENTINEL);
   } finally {
     db.close();
   }
@@ -223,6 +226,8 @@ test("cli: chat index --status and --rebuild work against --index-path", () => {
   try {
     assert.equal(cliMain(["chat", "index", "--home", home, "--index-path", idx, "--status"]), 0);
     assert.match(captured.join(""), /files: \d+, messages: \d+/);
+    assert.match(captured.join(""), /source files: \d+/);
+    assert.match(captured.join(""), /stale: \d+/);
     captured.length = 0;
     assert.equal(cliMain(["chat", "index", "--home", home, "--index-path", idx, "--rebuild"]), 0);
     assert.match(captured.join(""), /ingested \d+\/\d+ files/);


### PR DESCRIPTION
`--status` and the banner compare the index against the source JSONL read-only, and `staleFiles` counts **changed** files, not only missing ones: the reported case was three files that grew while the count stayed identical, which a count difference can never see. Because the banner runs at every session start the walk is bounded to the newest 512 files or 50ms, missing and extra come from a path-set difference at zero stat cost, and a truncated scan renders as a lower bound rather than pretending to be exact. `last_ingest_at` advances only when an ingest changed something.

Closes #144

## Stack (merge bottom-up)

| # | PR | branch | issues |
|---|---|---|---|
| L0 | #154 | `codex/memory-recall-roadmap` | — (roadmap) |
| L1 | #155 | `codex/fix-recall-cwd-normalization` | #138 |
| L2 | #156 | `codex/fix-memory-search-semantics` | #142, #143 |
| L3 | #157 | `codex/fix-recall-cli-arg-hygiene` | #139, #140 |
| L4 | #158 | `codex/fix-chat-index-freshness` | #144 | **<- you are here**
| L5 | #159 | `codex/fix-recall-intent-regex` | #137 |
| L6 | #160 | `codex/fix-memory-write-gate` | #135, #136, #141 |

**You are here: L4.** Base is `codex/fix-recall-cli-arg-hygiene`. **Review this PR's diff only** — it is already scoped to this layer.

## Review focus

the freshness budget — this runs at every SessionStart.

## Evidence

Every layer was planned to diff level before any code, audited by an independent `xai/grok-4.6` reviewer, and implemented only after the audit's blockers were folded. Each new test was observed **failing on the parent tip** before it was shown passing; the per-layer receipt in `devlog/_plan/260911_memory_recall_sweep/` records the exact red output.

Local gate: `npm run build` exit 0, and `npm test` showing exactly the two pre-existing environmental failures recorded in `002_host_verification_baseline.md` (`hook-bench` hardcodes `cwd: "/tmp"`, and `cxc map --help` needs `py`) and no third.

## Note on the target-branch check

`Enforce PR target branch` requires `dev`. Layers L1-L6 legitimately target the layer below, so that workflow will flag them. **Do not retarget them to `dev`** — that would dissolve the stack. Merge bottom-up; each merge retargets the next child.




