### PR TITLE
fix(recall): match the advertised recall triggers and stop firing on write requests (L5, #137)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C108_passing-brightgreen" alt="3,108 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C110_passing-brightgreen" alt="3,110 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C108_passing-brightgreen" alt="3,108 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C110_passing-brightgreen" alt="3,110 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C108_passing-brightgreen" alt="3,108 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C110_passing-brightgreen" alt="3,110 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/devlog/_plan/260911_memory_recall_sweep/050_wp6_recall_intent_regex.md
+++ b/devlog/_plan/260911_memory_recall_sweep/050_wp6_recall_intent_regex.md
@@ -500,3 +500,101 @@ index (`hook.ts:120-122`, `:169-170`). `detectRecallIntent` has no separate nume
 budget, but it runs on **every** user prompt, so the pattern list stays a flat array of
 cheap regexes — no lookbehind, no catastrophic backtracking, no new I/O.
 
+
+## Amendment B — wp6 A audit fold (2026-09-11)
+
+Independent `xai/grok-4.6` audit: **FAIL**, four blockers and four concerns.
+**Amendment B governs over Amendment A and the body.** The reviewer hand-evaluated
+the proposed list against all nine existing pins (none change under A.3), against the
+five `#137` utterances (all five correct), and against ten invented development
+utterances — where it found **seven false positives**. Those seven are the real
+finding of this audit.
+
+### B.1 The principle the issue got wrong
+
+`#137` says the implementation should match what `SKILL.md:3` advertises. Taken
+literally that is wrong, and the audit proved it:
+
+```text
+리콜 기능 구현해줘            -> would fire   (implement the recall feature)
+recall 훅 테스트 추가해줘      -> would fire   (add a test for the recall hook)
+chat search UX 개선해줘        -> would fire   (improve the chat-search UX)
+memory search 랭킹 고쳐줘      -> would fire   (fix memory-search ranking)
+메모리에서 찾는 코드를 고쳐줘   -> would fire   (fix the code that searches memory)
+I recall seeing this in the Node docs -> would fire
+the previous time CI failed    -> would fire
+```
+
+**`SKILL.md`'s trigger line is advertising for skill SELECTION; the hook detects
+user INTENT.** They are different matchers with different jobs. Every advertised
+trigger here is also a feature name in this repository, so matching the bare noun
+guarantees a false positive on the project's own development speech — and this hook
+fires on every prompt in the repo where that speech is most common.
+
+**Rule for this layer: match the REQUEST FORM, never the feature name.**
+
+### B.2 (blockers 1-3) The corrected patterns
+
+```text
+previous    /\bprevious\s+(session|work|conversation|discussion|chat)\b/i
+            NOTE: "time" is removed - "the previous time CI failed" is not recall
+previously  /\bpreviously\s+(we|i|you|the\s+team|discussed|agreed|decided)\b/i
+            keeps hook.test.ts:45 green
+prior       /\bprior\s+(work|session|conversation|discussion)\b/i
+리콜        /리콜해/ and /^\s*리콜\s*$/     NOT bare /리콜/
+메모리에서   /메모리에서\s*찾아/               NOT /메모리에서\s*찾/ - 찾는 is adnominal,
+            "메모리에서 찾는 코드" is a noun phrase about code, not a request
+recall      DROP the bare /\brecall\b/ entirely
+chat/memory search  DROP /\b(?:chat|memory)\s+search\b/ entirely
+```
+
+The last two deletions are deliberate. English recall requests are already covered by
+`remember when/what`, `what did we ...`, `last time`, `earlier session` and the
+`previously` rule. Adding the command names buys nothing and costs a false positive on
+every sentence about building them. `hook.test.ts:55` already pins that a literal
+`cxc chat search "..."` stays silent; these deletions keep that pin honest instead of
+fighting it.
+
+### B.3 (blocker 1) Delete §6.1, and delete the body's AFTER block
+
+§5's copy-paste AFTER still collapses `previous`/`previously`/`prior` into one
+alternation with a shared noun group, which flips `hook.test.ts:45` from true to
+false — and §6.1 then rewrites that pin to match. **Both are forbidden.** A.3's three
+separate regexes are the only AFTER. A pin is evidence; rewriting it to accommodate a
+regex is how a false negative gets shipped with a green suite.
+
+### B.4 (blocker 4) The new test must pin the negatives
+
+The new fixture carries, as explicit `false` cases, at least:
+`리콜 기능 구현해줘`, `메모리에서 찾는 코드를 고쳐줘`, `recall 훅 테스트 추가해줘`,
+`chat search UX 개선해줘`, `memory search 랭킹 고쳐줘`,
+`the previous time CI failed`, `I recall seeing this in the Node docs`,
+`prior art for this API`, `the previous test failed`.
+It also re-pins `previously we capped tool output — why?` as **true**, so a stray
+edit to §6.1's fixture cannot hide a pin break.
+
+### B.5 (concern 3, accepted) `기억해?` falls between the two matchers
+
+`기억해?` (question form with the `해` ending) will be neither a recall hit nor a
+write-gate hit: the write gate's pattern at `memory-write-gate.ts:79` does not list
+`해?`. That is a pre-existing gap in a different component's regex and widening this
+layer's pattern to cover it would re-introduce the `기억해` collision that #137 is
+about. Leave it, and record it here so it is a known gap rather than a surprise.
+
+The split that matters does hold: `기억나?`, `기억 안 나`, `기억하니` stay recall;
+`기억해줘`, `기억해둬`, `기억해서 둬` stay write-gate. No collision.
+
+### B.6 Cost
+
+The reviewer confirmed no proposed regex can backtrack catastrophically: flat
+alternations, `\s*` only, no lookbehind, no nested quantifiers. The list stays a flat
+array evaluated on every prompt, and the `UserPromptSubmit` budget at
+`hook.ts:120-122` is unaffected.
+
+### B.7 Evidence accounting
+
+Only two named tests are red on the parent: the five-utterance fixture and the
+advertised-triggers-fire-but-feature-talk-does-not fixture. The other seven named
+tests are pins that are already green. The layer's proof is those two; everything
+else is a guard rail.
+

--- a/devlog/_plan/260911_memory_recall_sweep/050_wp6_recall_intent_regex.md
+++ b/devlog/_plan/260911_memory_recall_sweep/050_wp6_recall_intent_regex.md
@@ -420,3 +420,83 @@ Done when:
 6. `npm run build` and `npm test` are green at this layer's tip, with dist rebuilt.
 
 Not done if the implementer adds a cross-package helper, edits the write-gate, or leaves `dist/hook.js` stale.
+
+## Amendment A — wp6 P revalidation (2026-09-11)
+
+Re-verified at `97c52684` by an independent `xai/grok-4.6` explorer.
+**This amendment governs.**
+
+### A.1 Stale citations
+
+| PRD says | Now |
+|---|---|
+| `hook.test.ts:431-442` wp6 test | **`:459-471`** (L4 grew the file; `:26-61` and `:45` did not move) |
+| `hook.ts:501-505` `noRefresh: true` | `searchChat(` is still `:501`; L4's comments are `:505-507`; **`noRefresh: true` is `:508`** |
+| header checkout `6aae1c97` | `codex/fix-recall-intent-regex` @ `97c52684` |
+
+§2.1 and §2.3 BEFORE blocks are not byte-for-byte: the source carries no `// L86`-style
+tags and has the `ALREADY_RECALLING` doc comment at `:104-108`. The regexes themselves
+match. **Do not apply either block as a range replace.**
+
+### A.2 Today's verdicts, confirmed against the current patterns
+
+| utterance | today | why |
+|---|---|---|
+| `revert the previous commit` | **true** — false positive | `:89` noun group is optional |
+| `기억해줘` | **true** — false positive | `:86` `해` overlaps the write gate at `memory-write-gate.ts:79` |
+| `이전 작업 이어서` | **false** — false negative | `:97` requires `이전에` |
+| `리콜해줘` | **false** — false negative | no `리콜` pattern |
+| `메모리에서 찾아줘` | **false** — false negative | no `메모리에서 찾` pattern |
+
+`SKILL.md:3` advertises: `recall, 리콜, past session, chat search, memory search,
+지난 세션, 이전 작업, 뭐였지, 어떻게 했었지`. Three of those never matched.
+
+### A.3 The conflict the issue did not see, and how to resolve it
+
+The issue says make `previous`/`prior` require a noun. **An existing pin dies if you do
+that literally.** `hook.test.ts:45` asserts that
+
+```text
+previously we capped tool output — why?
+```
+
+is a recall hit, and it passes today only because the noun group is optional. That
+utterance genuinely IS a recall request — it refers to past work — so the pin is right
+and the issue's wording is too blunt. `round2.test.ts:78`
+(`gap4: hardened hook patterns and suppression`) is a second pin on this behaviour and
+the PRD does not mention it at all.
+
+Resolution — split the adjective from the adverb, because English does:
+
+```text
+previous   (adjective)  -> require a session noun:
+                           /\bprevious\s+(session|work|conversation|discussion|time|chat)\b/i
+                           kills "revert the previous commit"
+previously (adverb)     -> require a past-work subject or verb:
+                           /\bpreviously\s+(we|i|you|the\s+team|discussed|agreed|decided)\b/i
+                           keeps "previously we capped tool output"
+prior      (adjective)  -> require a session noun, as the PRD already specifies
+```
+
+Both existing pins stay green and the reported false positive dies. **Neither pin may
+be edited, weakened or deleted to make this layer pass** — if a proposed pattern cannot
+satisfy both, the pattern is wrong, not the pin.
+
+### A.4 Do not weaken the other pins
+
+`hook.test.ts:26` (Korean idioms including `기억나?`), `:39` (English idioms), `:51`
+and `:55` (neutral prompts and `cxc chat search "..."` silence), `:63` (handler
+envelope for `지난번 세션 이어서`), `:459` (the 260910 widening), `:473` (suggested
+terms), and `round2.test.ts:78`.
+
+`기억나?` at `:26` matters for the `기억` rewrite: the question form must keep firing
+while `기억해줘` stops. That is the whole point — recall is a question, recording is a
+request.
+
+### A.5 Latency
+
+`UserPromptSubmit` must stay "well under its 5s hook budget" and must not open an
+index (`hook.ts:120-122`, `:169-170`). `detectRecallIntent` has no separate numeric
+budget, but it runs on **every** user prompt, so the pattern list stays a flat array of
+cheap regexes — no lookbehind, no catastrophic backtracking, no new I/O.
+

--- a/devlog/_plan/260911_memory_recall_sweep/051_wp6_receipt.md
+++ b/devlog/_plan/260911_memory_recall_sweep/051_wp6_receipt.md
@@ -1,0 +1,89 @@
+# 051 — wp6 receipt (L5 / #137, recall intent detection)
+
+Branch `codex/fix-recall-intent-regex`, based on `codex/fix-chat-index-freshness`.
+Implementation commit `a94113d0`.
+
+## Conclusion
+
+The hook stopped firing on `revert the previous commit` and on `기억해줘`, and started
+firing on the three triggers the skill had been advertising without implementing.
+Both directions of #137 are closed, and no existing pin was touched.
+
+## The finding that changed the fix
+
+`#137` asks the implementation to match what `skills/recall/SKILL.md:3` advertises.
+Taken literally that is wrong, and the audit proved it by inventing ten ordinary
+development utterances and running them through the proposed patterns. Seven fired:
+
+```text
+리콜 기능 구현해줘              implement the recall feature
+recall 훅 테스트 추가해줘        add a test for the recall hook
+chat search UX 개선해줘          improve the chat-search UX
+memory search 랭킹 고쳐줘        fix memory-search ranking
+메모리에서 찾는 코드를 고쳐줘     fix the code that searches memory
+the previous time CI failed
+I recall seeing this in the Node docs
+```
+
+`SKILL.md`'s trigger line is advertising for **skill selection**; this hook detects
+**user intent**. They are different matchers. Every advertised trigger is also a
+feature name in this repository, so matching the bare noun guarantees a false positive
+on exactly the conversations where this hook fires most — people building the recall
+feature. The rule this layer adopts is: **match the request form, never the feature
+name.** The bare `recall` and `chat|memory search` patterns were dropped outright.
+
+## What changed — `hook.ts` `RECALL_PATTERNS` only
+
+| before | after | why |
+|---|---|---|
+| `/기억\s*(나|안\s*나|하|해)/` | `/기억\s*(나|안\s*나|하니|하냐)/` | `기억해*` is a request to RECORD; the write gate owns it |
+| `/\bprevious(ly)?\s+(session|work|discussed|conversation)?\b/i` | `/\bprevious\s+(session|work|conversation|discussion|chat)\b/i` + `/\bpreviously\s+(we|i|you|the\s+team|discussed|agreed|decided)\b/i` | the optional noun was the false positive; splitting adjective from adverb keeps `hook.test.ts:45` green |
+| `/\bprior\s+(work|session|conversation)\b/i` | `+ discussion` | |
+| — | `/리콜해/`, `/^\s*리콜\s*$/`, `/이전\s*작업/`, `/메모리에서\s*찾아/` | the three advertised triggers, in request form only |
+
+`time` is deliberately absent from the `previous` noun list: "the previous time CI
+failed" is not a recall request.
+
+`메모리에서 찾아` rather than `메모리에서 찾` because `찾는` is adnominal —
+"메모리에서 찾는 코드" is a noun phrase about code, not a request to search memory.
+
+## Evidence
+
+RED on the parent `97c52684`, re-proved independently by the main session:
+
+```text
+git stash push -- recall/src recall/dist
+test.mjs hook.test.ts   -> tests 29, pass 27, fail 2
+  ✖ recall intent: issue #137 five-utterance fixture
+  ✖ recall intent: advertised triggers fire; write-gate and git nouns do not
+git stash pop -> tree restored
+```
+
+Exactly two red — the layer's proof — with all 27 pins green beside them, including
+`hook.test.ts:45`, `:26`'s `기억나?`, and `round2.test.ts:78` which the PRD had
+never mentioned.
+
+GREEN: `npm run build` exit 0; focused recall suite `tests 236, pass 236, fail 0`
+(234 before this layer); `round2.test.ts` 9/9.
+
+## A pin is evidence
+
+The PRD's own §5 AFTER block collapsed `previous`/`previously`/`prior` into one
+alternation, which flips `hook.test.ts:45` from true to false — and its §6.1 then
+rewrote that pin to match. Both were rejected. "previously we capped tool output —
+why?" genuinely is a recall request; the test was right and the regex was wrong.
+Rewriting a pin to accommodate a pattern is how a false negative ships with a green
+suite.
+
+## Known gap, declared
+
+`기억해?` — the question form with the `해` ending — now matches neither this hook
+nor the write gate, because `memory-write-gate.ts:79` does not list `해?`. Widening
+the recall pattern to cover it would re-create the exact `기억해` collision #137 is
+about. It is left alone and recorded here. If it matters, it belongs to the write
+gate's pattern in L6's component, not to this one.
+
+## Next
+
+wp7 / L6 / #135 + #136 + #141 on `codex/fix-memory-write-gate`, based on this branch.
+

--- a/plugins/codexclaw/components/recall/dist/hook.js
+++ b/plugins/codexclaw/components/recall/dist/hook.js
@@ -75,7 +75,9 @@ const CXC = ()         => cxcInvocation(import.meta.url);
 
 
 
-/** Past-work recall idioms. Korean forms cover 그때/지난번/저번/예전에/기억/뭐였지. */
+/** Past-work recall idioms. Korean forms cover 그때/지난번/저번/예전에/기억나/리콜/이전 작업/뭐였지.
+ *  `기억해*` is the write-gate's job (pabcd-state memory-write-gate.ts); recall keeps question forms only.
+ *  `previous`/`prior` require a memory noun — never a git/file noun. */
 const RECALL_PATTERNS                    = [
   /그때\s*(그|한|했|만든|작업)/,
   /지난\s*번/,
@@ -83,22 +85,27 @@ const RECALL_PATTERNS                    = [
   /저번\s*(에|세션|주|것|거)/,
   /예전에\s*(하|했|만든|작업|쓰)/,
   /전에\s*(했|만든|작업했|얘기했|말했)/,
-  /기억\s*(나|안\s*나|하|해)/,
+  /기억\s*(나|안\s*나|하니|하냐)/,
   /뭐였지|뭐\s*였더라|어떻게\s*했었지|어디까지\s*했/,
   /\blast\s+(time|session|week)\b/i,
-  /\bprevious(ly)?\s+(session|work|discussed|conversation)?\b/i,
+  /\bprevious\s+(session|work|conversation|discussion|chat)\b/i,
+  /\bpreviously\s+(we|i|you|the\s+team|discussed|agreed|decided)\b/i,
   /\bwhat\s+did\s+(we|i|you)\s+(do|discuss|decide|build)\b/i,
   /\bremember\s+(when|what|the|that|how)\b/i,
   /\b(as|we)\s+discussed\s+(earlier|before|previously|last\s+time)\b/i,
   /\bdiscussed\s+previously\b/i,
   /\bearlier\s+(session|conversation|work)\b/i,
-  // wp6: idioms the original set missed. Bare 그때 stays out — it reads as a
+  // 260910 widening. Bare 그때 stays out — it reads as a
   // plain time reference ("그때 봤어") far more often than as a recall request.
   /이전에\s*(하|했|만든|작업|얘기|말)/,
   /그\s*세션/,
   /그때에(?:는|도)?/,
-  /\bprior\s+(work|session|conversation)\b/i,
+  /\bprior\s+(work|session|conversation|discussion)\b/i,
   /\ba\s+while\s+ago\b/i,
+  /리콜해/,
+  /^\s*리콜\s*$/,
+  /이전\s*작업/,
+  /메모리에서\s*찾아/,
 ];
 
 /**

--- a/plugins/codexclaw/components/recall/src/hook.ts
+++ b/plugins/codexclaw/components/recall/src/hook.ts
@@ -75,7 +75,9 @@ export interface SessionStartPayload {
   source?: string;
 }
 
-/** Past-work recall idioms. Korean forms cover 그때/지난번/저번/예전에/기억/뭐였지. */
+/** Past-work recall idioms. Korean forms cover 그때/지난번/저번/예전에/기억나/리콜/이전 작업/뭐였지.
+ *  `기억해*` is the write-gate's job (pabcd-state memory-write-gate.ts); recall keeps question forms only.
+ *  `previous`/`prior` require a memory noun — never a git/file noun. */
 const RECALL_PATTERNS: readonly RegExp[] = [
   /그때\s*(그|한|했|만든|작업)/,
   /지난\s*번/,
@@ -83,22 +85,27 @@ const RECALL_PATTERNS: readonly RegExp[] = [
   /저번\s*(에|세션|주|것|거)/,
   /예전에\s*(하|했|만든|작업|쓰)/,
   /전에\s*(했|만든|작업했|얘기했|말했)/,
-  /기억\s*(나|안\s*나|하|해)/,
+  /기억\s*(나|안\s*나|하니|하냐)/,
   /뭐였지|뭐\s*였더라|어떻게\s*했었지|어디까지\s*했/,
   /\blast\s+(time|session|week)\b/i,
-  /\bprevious(ly)?\s+(session|work|discussed|conversation)?\b/i,
+  /\bprevious\s+(session|work|conversation|discussion|chat)\b/i,
+  /\bpreviously\s+(we|i|you|the\s+team|discussed|agreed|decided)\b/i,
   /\bwhat\s+did\s+(we|i|you)\s+(do|discuss|decide|build)\b/i,
   /\bremember\s+(when|what|the|that|how)\b/i,
   /\b(as|we)\s+discussed\s+(earlier|before|previously|last\s+time)\b/i,
   /\bdiscussed\s+previously\b/i,
   /\bearlier\s+(session|conversation|work)\b/i,
-  // wp6: idioms the original set missed. Bare 그때 stays out — it reads as a
+  // 260910 widening. Bare 그때 stays out — it reads as a
   // plain time reference ("그때 봤어") far more often than as a recall request.
   /이전에\s*(하|했|만든|작업|얘기|말)/,
   /그\s*세션/,
   /그때에(?:는|도)?/,
-  /\bprior\s+(work|session|conversation)\b/i,
+  /\bprior\s+(work|session|conversation|discussion)\b/i,
   /\ba\s+while\s+ago\b/i,
+  /리콜해/,
+  /^\s*리콜\s*$/,
+  /이전\s*작업/,
+  /메모리에서\s*찾아/,
 ];
 
 /**

--- a/plugins/codexclaw/components/recall/test/hook.test.ts
+++ b/plugins/codexclaw/components/recall/test/hook.test.ts
@@ -48,6 +48,72 @@ test("recall intent: english idioms trigger", () => {
   }
 });
 
+test("recall intent: issue #137 five-utterance fixture", () => {
+  assert.equal(detectRecallIntent("revert the previous commit"), false);
+  assert.equal(detectRecallIntent("기억해줘"), false);
+  assert.equal(detectRecallIntent("이전 작업 이어서"), true);
+  assert.equal(detectRecallIntent("리콜해줘"), true);
+  assert.equal(detectRecallIntent("메모리에서 찾아줘"), true);
+
+  assert.equal(
+    handleUserPromptSubmit({ hook_event_name: "UserPromptSubmit", prompt: "기억해줘" }),
+    "",
+  );
+  assert.match(
+    handleUserPromptSubmit({ hook_event_name: "UserPromptSubmit", prompt: "리콜해줘" }),
+    /cxc chat search/,
+  );
+});
+
+test("recall intent: advertised triggers fire; write-gate and git nouns do not", () => {
+  for (const p of [
+    "이전 작업 이어서",
+    "리콜해줘",
+    "메모리에서 찾아줘",
+    "previously we capped tool output — why?",
+    "리콜",
+    "이전작업",
+    "기억나?",
+    "기억 안 나",
+    "기억하니",
+    "기억하냐",
+    "previous session",
+    "previous work",
+    "previous conversation",
+    "previous discussion",
+    "previous chat",
+    "previously discussed the cap",
+    "prior discussion",
+  ]) {
+    assert.ok(detectRecallIntent(p), "should trigger: " + p);
+  }
+  for (const p of [
+    "리콜 기능 구현해줘",
+    "메모리에서 찾는 코드를 고쳐줘",
+    "recall 훅 테스트 추가해줘",
+    "chat search UX 개선해줘",
+    "memory search 랭킹 고쳐줘",
+    "the previous time CI failed",
+    "I recall seeing this in the Node docs",
+    "prior art for this API",
+    "the previous test failed",
+    "previous commit",
+    "bump the previous version",
+    "prior art",
+    "기억해",
+    "기억해둬",
+    "기억해서 둬",
+    "remember this",
+    "메모리에 남겨줘",
+  ]) {
+    assert.equal(detectRecallIntent(p), false, "should NOT trigger: " + p);
+  }
+  assert.equal(
+    detectRecallIntent('run cxc chat search "trigram" --days 0 and summarize'),
+    false,
+  );
+});
+
 test("recall intent: neutral prompts and self-recalling prompts stay silent", () => {
   for (const p of [
     "add a --json flag to the status command",


### PR DESCRIPTION
The hook fired on `revert the previous commit` because the noun after `previous` was optional, and on `기억해줘`, which is a request to RECORD something — the write gate owns that phrase. Three triggers the skill advertises never matched at all. `previous`/`prior` now require a session noun while `previously` requires a past-work subject, which keeps the existing pin on `previously we capped tool output` green. The advertised Korean triggers match their request forms only, and the bare `recall` and `chat|memory search` patterns are dropped — in this repository those are feature names, and matching them fires on ordinary talk about building them.

Closes #137

## Stack (merge bottom-up)

| # | PR | branch | issues |
|---|---|---|---|
| L0 | #154 | `codex/memory-recall-roadmap` | — (roadmap) |
| L1 | #155 | `codex/fix-recall-cwd-normalization` | #138 |
| L2 | #156 | `codex/fix-memory-search-semantics` | #142, #143 |
| L3 | #157 | `codex/fix-recall-cli-arg-hygiene` | #139, #140 |
| L4 | #158 | `codex/fix-chat-index-freshness` | #144 |
| L5 | #159 | `codex/fix-recall-intent-regex` | #137 | **<- you are here**
| L6 | #160 | `codex/fix-memory-write-gate` | #135, #136, #141 |

**You are here: L5.** Base is `codex/fix-chat-index-freshness`. **Review this PR's diff only** — it is already scoped to this layer.

## Review focus

false positives on ordinary development speech.

## Evidence

Every layer was planned to diff level before any code, audited by an independent `xai/grok-4.6` reviewer, and implemented only after the audit's blockers were folded. Each new test was observed **failing on the parent tip** before it was shown passing; the per-layer receipt in `devlog/_plan/260911_memory_recall_sweep/` records the exact red output.

Local gate: `npm run build` exit 0, and `npm test` showing exactly the two pre-existing environmental failures recorded in `002_host_verification_baseline.md` (`hook-bench` hardcodes `cwd: "/tmp"`, and `cxc map --help` needs `py`) and no third.

## Note on the target-branch check

`Enforce PR target branch` requires `dev`. Layers L1-L6 legitimately target the layer below, so that workflow will flag them. **Do not retarget them to `dev`** — that would dissolve the stack. Merge bottom-up; each merge retargets the next child.




