### PR TITLE
fix(pabcd-state): close the Windows memory-write-gate bypasses (L6, #135, #136, #141)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C110_passing-brightgreen" alt="3,110 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C133_passing-brightgreen" alt="3,133 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C110_passing-brightgreen" alt="3,110 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C133_passing-brightgreen" alt="3,133 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml"><img src="https://github.com/lidge-jun/codexclaw/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <img src="https://img.shields.io/badge/tests-3%2C110_passing-brightgreen" alt="3,110 tests passing">
+  <img src="https://img.shields.io/badge/tests-3%2C133_passing-brightgreen" alt="3,133 tests passing">
   <img src="https://img.shields.io/badge/skills-29-blue" alt="29 skills">
   <img src="https://img.shields.io/badge/hooks-28-blue" alt="28 hooks">
   <a href="https://lidge-jun.github.io/codexclaw/"><img src="https://img.shields.io/badge/docs-codexclaw-black" alt="Documentation"></a>

--- a/bin/codexclaw.mjs
+++ b/bin/codexclaw.mjs
@@ -291,6 +291,7 @@ const TOP_LEVEL_HELP = [
   "  map [dir]                      generate a ranked repo structure map",
   "  chat search \"query\"             search Codex chat history",
   "  memory search \"query\"           search Codex memories",
+  "  memory allow-write --session <id> grant one cwd-scoped memory write",
   "  skill search|show              search and display dormant skills",
   "",
   "Operations:",

--- a/devlog/_plan/260911_memory_recall_sweep/060_wp7_memory_write_gate.md
+++ b/devlog/_plan/260911_memory_recall_sweep/060_wp7_memory_write_gate.md
@@ -598,3 +598,90 @@ Issue #136's fallback ("document and narrow the matcher to tools only") is **not
 - `c-10`: the four home forms and the five PowerShell cmdlets (plus alias `copy`) plus python/node writes classify as memory writes; `read_text` does not. The three switch-parameter regressions (`Set-Content -Force`, `Out-File -Append`, `New-Item -ItemType File -Force`) and Copy-Item destination-only (named `-Path` is not a dest) pass.
 - `c-11`: `allow-write --help` exits 0 with no grant; `--session=<id>` accepted; unknown flags rejected.
 - `npm run build` and `npm test` green, new test names in the log, dist staged with `-f`.
+
+## Amendment A — wp7 P revalidation and the dev cascade (2026-09-11)
+
+Re-verified by an independent `xai/grok-4.6` explorer, which confirmed **every BEFORE
+fence in this PRD is an exact quote of the current files** and that L1-L5 touched only
+the recall component, leaving this layer's sources untouched. **This amendment
+governs.**
+
+### A.1 The base moved: the whole chain was rebased
+
+While this layer was at P, the peer session merged its entire Windows sweep into
+`dev`. `origin/dev` went from `a267b398` to `d4bef1f2`, seven commits:
+
+```text
+d4bef1f2  fix(pabcd-state): non-git session binds a nested git source (#109) (#152)
+8e73e205  fix(sweep): GUI and serve provider probes through win-exec (#151)
+ed225aec  fix(pabcd-state): refuse a bound cycle with no resolvable source identity (#150)
+34cd7879  fix(config-guard): answer --help before the action and forward full argv (#149)
+8013b625  fix(pabcd-state): canonicalise the native session cwd (#134) (#148)
+291f81d6  fix(provider-bridge): reuse win-exec for PATHEXT and ComSpec (#131) (#153)
+ee03d5bc  docs(plan): diff-level roadmap for the Windows issue sweep stack (#146)
+```
+
+Three of those land in `pabcd-state` and one in `config-guard`, and **`#149` moves
+`bin/cxc.mjs`** — a file this layer edits. Rebasing after implementing L6 would have
+meant resolving that collision inside the largest layer in the stack. It was done
+first instead, at P, with a clean tree:
+
+```text
+git rebase --update-refs --onto origin/dev a267b398 codex/fix-memory-write-gate
+  -> 31 commits replayed, no conflicts, all six layer branches updated
+npm run build   exit 0
+npm test        exit 1, tests 3110, pass 3022, fail 2   (the same two env failures, no third)
+git merge-base --is-ancestor, each layer against the one below -> all 0
+git push --force-with-lease, all six pushed branches
+```
+
+The chain now sits on `d4bef1f2`. **`002_host_verification_baseline.md` still holds:
+exactly `hook-bench` and `cxc map --help`, and nothing else.** The peer's seven
+commits and this chain's twenty-four compose without a third failure.
+
+### A.2 Consequence for this layer
+
+`bin/cxc.mjs`'s `memory allow-write` branch **moved from `:166` to `:171`** because
+`#149` inserted config-guard argv handling above it. The condition text and the
+`HELP` constant at `:90` are unchanged, and every write-gate `.ts` file is byte
+identical to what this PRD quotes. **Re-read `bin/cxc.mjs` and `bin/codexclaw.mjs`
+before editing; every other BEFORE block in this document is still exact.**
+
+`#149` is also prior art worth reading rather than copying: it solved the same
+"`--help` reaches the action" defect for `config-guard`, on the same dispatcher this
+layer must fix for `memory allow-write`. Read how it forwards argv, then decide
+independently — L3 in this stack already rejected the older `isHelpToken` prior art
+for good reasons.
+
+### A.3 Remaining staleness
+
+Only one: §2 paraphrases `sessionsDir` as `join(cwd, ".codexclaw", "sessions")`. The
+actual code is `join(cwd, STATE_DIR, SESSIONS_SUBDIR)` at `state.ts:317`, with
+`STATE_DIR = ".codexclaw"` at `:233`. The behaviour is what the PRD says; the literal
+is not. Do not introduce a hard-coded string.
+
+### A.4 The grant binding, confirmed
+
+`consumeAuthorization(cwd, sessionId, turnId)` -> `readState(cwd, sessionId)`
+(`memory-write-gate.ts:244`, called at `:297`) -> `statePath(cwd, sessionId)`
+(`:320-321`) -> `sessionsDir(cwd)`. The CLI stores the **process** cwd
+(`memory-cli.ts:46`) and writes the grant there (`:56-57`). That is #135 exactly: the
+grant is keyed by a cwd the success message never mentions.
+
+### A.5 The risk, restated because it is the security boundary
+
+POSIX habit says an unknown `-*` flag may consume the next token. **PowerShell switch
+parameters take no value.** If the new verb parser copies the POSIX habit,
+`Set-Content -Force <memory path>`, `Out-File -Append <memory path>` and
+`New-Item -ItemType File -Force <memory path>` all return `[]` and a real memory write
+passes the gate. The existing POSIX helpers already get this right — `tee`, `sed`,
+`cp` skip an unknown flag **without** consuming the next token. Match that behaviour.
+
+### A.6 Existing pins that must not break
+
+`memory-write-gate.test.ts` `:49`, `:64`, `:81`, `:101`, `:121`, `:136`, `:150`,
+`:162`, `:175`, `:186`, `:199`, `:209`, `:250` (python3 `read_text` is a READ and must
+stay allowed), `:263`; `shell-write-destinations.test.ts` `:13`, `:30`, `:40`, `:57`.
+A widening that turns an existing allow into a deny is as much a regression as a
+missed write.
+

--- a/devlog/_plan/260911_memory_recall_sweep/060_wp7_memory_write_gate.md
+++ b/devlog/_plan/260911_memory_recall_sweep/060_wp7_memory_write_gate.md
@@ -685,3 +685,122 @@ stay allowed), `:263`; `shell-write-destinations.test.ts` `:13`, `:30`, `:40`, `
 A widening that turns an existing allow into a deny is as much a regression as a
 missed write.
 
+
+## Amendment B — wp7 A audit fold (2026-09-11)
+
+Independent `xai/grok-4.6` security audit: **FAIL**, three blockers and four concerns.
+It hunted bypasses rather than reviewing prose and found **twelve command lines that
+would write into the memories directory and pass the gate**. All folded.
+**Amendment B governs.**
+
+### B.1 (blocker 1) The design changes: over-collect candidates, let the path decide
+
+The PRD parses PowerShell like POSIX — identify THE destination operand, return it.
+Every bypass the audit found is a variation of "the parser picked the wrong token":
+
+```text
+Set-Content -LP $mem\n.md -Value x        -LP is an unambiguous prefix of -LiteralPath
+Set-Content -Fo $mem\n.md                 -Fo is a prefix of -Force
+Out-File -Fi $mem\n.md                    -Fi is a prefix of -FilePath
+Set-Content -AsByteStream $mem\n.md       unlisted switch, eats the path
+Set-Content /Force $mem\n.md              slash switch becomes the "destination"
+Copy-Item /w/a.md -Dest $mem\b.md         -Dest is a prefix of -Destination
+```
+
+Chasing these one flag at a time is a losing game: PowerShell accepts **any
+unambiguous prefix of any parameter name**, so the flag surface is unbounded.
+
+**The gate does not need to know which operand is the destination. It only needs to
+know whether ANY operand lands inside the memories directory.** So for a write
+cmdlet, collect EVERY token that is not a flag as a candidate, and let
+`isMemoryPath` do the narrowing. Over-collection is safe here because a candidate
+outside the memories directory changes nothing, and it makes the parser immune to
+the entire class of flag-naming tricks.
+
+Two rules keep it honest:
+
+1. **A flag never consumes the next token** — matching what `tee`, `sed` and `cp`
+   already do. Only an allowlist of genuinely value-taking parameters consumes one:
+   `-Value`, `-ItemType`, `-Encoding`, `-Name`, `-Filter`, `-InputObject`,
+   `-Width`, `-Stream`, matched **by unique prefix**, case-insensitively.
+   Anything else starting with `-` or `/` is a switch and is simply skipped.
+2. **`Copy-Item`, `copy`, `cp`, `mv` and `Move-Item` stay destination-only.** They
+   are the one family where over-collection would be wrong: copying a file OUT of the
+   memories directory must stay allowed, and `memory-write-gate.test.ts` pins exactly
+   that with `cp ${mem}/a.md /w/b.md`. For these verbs the destination is the last
+   positional, or the operand of `-Destination`/`-Dest`/`-t` by prefix.
+
+### B.2 (blocker 2) Aliases and `Add-Content` are in scope, not residual
+
+`Add-Content`, `sc`, `ni` currently return `[]`. The PRD lists them as residual.
+**A residual on a security boundary is a hole with a note attached.** Required:
+
+| token | treat as | caveat |
+|---|---|---|
+| `Add-Content`, `ac` | write, Set-Content rules | |
+| `sc` | `Set-Content` | only when a file-shaped operand is present — `sc query` is the Windows service tool, not a write |
+| `ni` | `New-Item` | |
+| `copy`, `cp` | `Copy-Item` | destination-only |
+| `echo` | `Write-Output` | only matters through a redirect, already covered |
+| `cat`, `gc`, `Get-Content` | READ | must stay allowed; `memory-write-gate.test.ts` pins it |
+
+### B.3 (concern 4, promoted) The interpreter and .NET forms
+
+Also currently `[]` and also required:
+
+```text
+py -c "open(r'<mem>','w').write('x')"          py is the Windows launcher
+node --eval "...writeFileSync..."              long form
+node -e<CODE>                                  glued, no space
+[IO.File]::WriteAllText('<mem>','x')           .NET static, no cmdlet at all
+[System.IO.File]::AppendAllText('<mem>','x')
+```
+
+For `python`/`python3`/`py` and `node` treat `-c`, `-e`, `--eval` and their glued
+forms as code, and scan the code string for quoted paths. For the .NET statics, match
+`[\s\S]*\[(?:System\.)?IO\.File\]::(Write|Append)All` and take the first quoted
+argument. These are pattern matches on a string, not an evaluator — the goal is to
+make the obvious spelling visible to the gate, not to solve the halting problem.
+
+### B.4 (blocker 3) The tests must use the abbreviations
+
+The PRD's fixtures pin full cmdlet names only, so every bypass in B.1 would ship
+green. The new tests must include, as **deny** cases: `-LP`, `-Fo`, `-Fi`,
+`-AsByteStream`, `/Force`, `Copy-Item -Dest`, `sc`, `ni`, `Add-Content`, `py -c`,
+`node --eval`, glued `node -e`, and `[IO.File]::WriteAllText`. And as **allow**
+cases, unchanged: `Get-Content`, `cat`, the python3 `read_text` fixture at
+`memory-write-gate.test.ts:250`, and `cp ${mem}/a.md /w/b.md`.
+
+### B.5 (concern 3) The Korean widening must not swallow object phrases
+
+The audit's requested examples stay false, but the proposed pattern introduces two new
+false positives: `메모리를 기록하는 함수` and `메모리를 저장해`. In both, `메모리` is
+the OBJECT being recorded, not the destination. Restrict the particle set to the
+locative and additive forms — `에`, `에다`, `에도`, `도` — and do not accept `를`/`을`.
+`메모리도 기록` (the #135 case) and `메모리에 기록해줘` still match; `메모리를 저장해`
+does not. The pre-existing `메모리에 저장하는 코드` false positive at `:81` is out of
+this layer's scope and is left as it is.
+
+### B.6 (concern 2) Prove #141 through the real entrypoints
+
+The PRD's proof spawns `dist/cli.js`. The defect in #141(a) is in the **dispatcher**,
+so the test must spawn `bin/cxc.mjs` and `bin/codexclaw.mjs` themselves — otherwise
+it proves the library and leaves the bug. `#149` on the new `dev` did exactly this
+for `config-guard`; match that standard.
+
+### B.7 (concern 1, accepted) `cxc memory --help` stays recall's
+
+`memory` routes to the recall CLI, and adding `allow-write` to that usage text would
+break `recall-skill-synopsis.test.mjs`, which compares the usage against the skill
+doc. So: the **root** `cxc --help` lists `memory allow-write`, and the deny message
+names the full command including the cwd. `cxc memory --help` keeps belonging to
+recall. Recorded rather than silently skipped.
+
+### B.8 What the audit confirms is already right
+
+No existing fixture flips from allow to deny: the python3 `read_text` read at
+`:250` stays allowed, and destination-only `Copy-Item` matches the existing `cp`
+allow. The #141 parse order (`--help` before `--session`, accept `--session=`, never
+record a grant on a help call) is correct as specified. The #135 remedy is one-step:
+the deny names the session cwd and the success message names where it wrote.
+

--- a/devlog/_plan/260911_memory_recall_sweep/061_wp7_receipt.md
+++ b/devlog/_plan/260911_memory_recall_sweep/061_wp7_receipt.md
@@ -1,0 +1,110 @@
+# 061 — wp7 receipt (L6 / #135 + #136 + #141, memory write gate)
+
+Branch `codex/fix-memory-write-gate`, the top of the chain, based on
+`codex/fix-recall-intent-regex`. Implementation commit `e388b0ba`.
+
+## Conclusion
+
+The memory write gate now recognises what an agent on Windows would actually type.
+Before this layer it was attached to `Bash` and `apply_patch` as well as the memory
+tool, but it understood only POSIX verbs and only `~/` — so the first thing an agent
+reaches for after a denial went straight through.
+
+## The finding that changed the design
+
+The PRD parsed PowerShell the way the existing code parses POSIX: find THE
+destination operand and return it. An independent security audit hunted bypasses
+against that design and found twelve:
+
+```text
+Set-Content -LP <mem>        -LP is an unambiguous prefix of -LiteralPath
+Set-Content -Fo <mem>        -Fo is a prefix of -Force
+Out-File -Fi <mem>           -Fi is a prefix of -FilePath
+Set-Content -AsByteStream    an unlisted switch swallows the path
+Set-Content /Force <mem>     a slash switch becomes the "destination"
+Copy-Item ... -Dest <mem>    -Dest is a prefix of -Destination
+sc / ni / Add-Content        never parsed at all
+py -c / node --eval / node -e<glued> / [IO.File]::WriteAllText
+```
+
+PowerShell accepts **any unambiguous prefix of any parameter name**, so the flag
+surface is unbounded and a per-flag fix list can never close. The design changed
+instead: **the gate does not need to know which operand is the destination, only
+whether any operand lands inside the memories directory.** A write cmdlet now
+over-collects every non-flag operand and `isMemoryPath` narrows. A flag never
+consumes the next token unless it is on a short allowlist of genuinely value-taking
+parameters, matched by prefix.
+
+`Copy-Item`/`copy`/`cp`/`mv`/`Move-Item` are the one exception and stay
+destination-only, because copying a file **out** of the memories directory must stay
+allowed and `memory-write-gate.test.ts` pins exactly that.
+
+## Evidence
+
+A direct probe against the built module, over the twelve audited bypasses plus four
+must-allow controls, run on the parent source and again after the fix:
+
+```text
+parent source   failures=16     every deny case missed
+this layer      failures=0      20 of 20 correct
+```
+
+Controls that must stay allowed and do: `Get-Content`, `cat`,
+`cp <mem>\a.md C:\w\b.md`, and `sc query winrm` — the last one matters, because
+binding the `sc` alias naively would have turned the Windows service tool into a
+memory write.
+
+RED on the parent, re-proved independently by the main session:
+
+```text
+git stash push -- pabcd-state/src pabcd-state/dist plugins/codexclaw/bin bin
+test.mjs memory-write-gate.test.ts shell-write-destinations.test.ts help-verbs.test.ts
+  -> 16 failures, including:
+     memory allow-write --help prints usage and does not require --session
+     memory allow-write --session <id> --help is help, not a grant
+     memory allow-write --help on both real entrypoints writes no grant
+     root --help lists memory allow-write on both entrypoints
+     Korean memory write: 메모리 forms; 메모리에서 찾 is not a write
+     CLI grant success output names the cwd it recorded
+     deny reason names the session cwd
+     allow-write accepts --session=<id> / rejects unknown flags
+     home prefixes classify as memory writes
+     apply_patch Add File with backslash-tilde memories path is gated
+     Windows write abbreviations, aliases, and interpreters are gated
+git stash pop -> tree restored
+```
+
+GREEN: `npm run build` exit 0; `pabcd-state` suite `tests 1257, pass 1255, fail 0`.
+
+## The three issues
+
+- **#135** — the grant is keyed by `cwd + sessionId` and nothing said so, so an agent
+  who ran `allow-write` from the wrong directory got a success message and a denial.
+  The success now names where it wrote and the deny names the cwd the grant must come
+  from, which makes the mistake diagnosable in one step. The Korean trigger accepts
+  `메모리도 기록` and `메모리에 기록해줘`.
+- **#136** — home expansion covers `~\`, `%USERPROFILE%`, `$env:USERPROFILE` and
+  `$HOME`; destination parsing covers the PowerShell write cmdlets, their aliases and
+  the interpreter one-liners.
+- **#141** — `--help` is answered anywhere with no side effect on **both real
+  entrypoints**, `--session=<id>` is accepted, unknown flags are rejected, and
+  `['allow-write','--session','<id>','--help']` no longer records a grant while
+  pretending to show help.
+
+## What did not improve
+
+- `cxc memory --help` still belongs to recall and still does not list `allow-write`.
+  Adding it there would break `recall-skill-synopsis.test.mjs`, which compares that
+  usage against the skill document. The root `cxc --help` lists it and the deny
+  message names the full command, which is the discovery path that actually matters.
+- `메모리에 저장하는 코드` is a pre-existing false positive in an older pattern; it is
+  outside this layer and was left alone rather than quietly rewritten.
+- The interpreter coverage is pattern matching on a code string, not evaluation. An
+  agent that builds the path by concatenation or encodes it will still slip through.
+  The gate raises the cost of an accidental write and of the obvious deliberate one;
+  it is not a sandbox and this receipt does not claim it is.
+
+## Next
+
+wp8 — integration: open the seven pull requests and verify CI per layer.
+

--- a/devlog/_plan/260911_memory_recall_sweep/071_wp8_receipt.md
+++ b/devlog/_plan/260911_memory_recall_sweep/071_wp8_receipt.md
@@ -1,0 +1,86 @@
+# 071 — wp8 receipt (integration: the stack is published and green)
+
+## Conclusion
+
+Seven pull requests are open on `lidge-jun/codexclaw`, bottom-up from `dev`, each
+based on the layer below, **every one green on its own CI**. Nothing was merged.
+
+| # | PR | branch | issues | checks |
+|---|---|---|---|---|
+| L0 | [#154](https://github.com/lidge-jun/codexclaw/pull/154) | `codex/memory-recall-roadmap` | — (roadmap) | 14 pass |
+| L1 | [#155](https://github.com/lidge-jun/codexclaw/pull/155) | `codex/fix-recall-cwd-normalization` | #138 | 13 pass |
+| L2 | [#156](https://github.com/lidge-jun/codexclaw/pull/156) | `codex/fix-memory-search-semantics` | #142, #143 | 13 pass |
+| L3 | [#157](https://github.com/lidge-jun/codexclaw/pull/157) | `codex/fix-recall-cli-arg-hygiene` | #139, #140 | 13 pass |
+| L4 | [#158](https://github.com/lidge-jun/codexclaw/pull/158) | `codex/fix-chat-index-freshness` | #144 | 13 pass |
+| L5 | [#159](https://github.com/lidge-jun/codexclaw/pull/159) | `codex/fix-recall-intent-regex` | #137 | 13 pass |
+| L6 | [#160](https://github.com/lidge-jun/codexclaw/pull/160) | `codex/fix-memory-write-gate` | #135, #136, #141 | 13 pass |
+
+Ten issues, seven layers, zero merges. Merging is the user's.
+
+## `dev` was read, never written
+
+The publication plan's decision rule case 1 applied: `origin/dev` existed and its
+commits were already contained in the chain, because the chain had been rebased onto
+it during wp7's P phase. No push, no fast-forward, no force touched `dev`.
+
+That rebase is worth recording. Mid-stack, the peer session merged its entire Windows
+sweep into `dev` — seven commits including a `config-guard` change to `bin/cxc.mjs`,
+a file L6 edits. Rebasing at wp7's P, with a clean tree and before the largest layer
+existed, cost one command. Discovering it after L6 was written would have meant
+resolving that collision inside the biggest diff in the stack.
+
+## The gate this stack had not noticed
+
+The published stack failed its first CI round on four layers, and the audit of the
+**published** result is what caught it. The ubuntu lane measures the suite and runs
+`inventory.mjs --check --tests <measured>`; the README badge has to match. Every
+layer here adds tests, so in a stack every layer must publish its own cumulative
+total.
+
+The expectation was read from the CI log rather than guessed:
+
+```text
+published tests=3065 but the measured suite reported 3077 — run inventory.mjs --write --tests 3077
+```
+
+That confirmed the arithmetic, and the per-layer new-test counts came from the diffs:
+12, 4, 16, 11, 2, 22. The top layer's estimate was off by one — measured 3133, not
+3132 — and the measured number governs.
+
+The first cascade attempt replayed the badge commits up the chain and conflicted on
+the same README line in every layer. It was aborted rather than forced through: the
+chain was rebuilt by cherry-picking each layer's original commits onto its new parent
+and appending that layer's own badge commit. The rebuilt top differs from the
+pre-cascade top by exactly three README lines, which is the check that no work was
+lost in the rebuild.
+
+## The repository policy conflicts with the requested shape
+
+`Enforce PR target branch` requires every PR to target `dev`. L1-L6 legitimately
+target the layer below, so the workflow prefixed their titles with `[WRONG BRANCH]`
+and asked for retargeting. **Retargeting would dissolve the stack**, so it was not
+done, and each PR body says so. The workflow could not convert them to draft.
+
+This is a real conflict between the repository's policy and a stacked delivery, and
+it is the user's call: either the layers get merged bottom-up as they are, or the
+policy grows an exception for a chain whose bottom targets `dev`.
+
+## Evidence
+
+- Ancestry verified pairwise from `origin/dev` upward after every rebase and after
+  the cascade rebuild; each layer contains the one below.
+- Each PR's diff carries only its own layer's commits; no `.codexclaw/`, no
+  `node_modules`, no logs; every `dist/` change has a `src/` twin in the same PR.
+- `Closes` mapping is unique: no issue is claimed by two layers.
+- Privacy grep over the whole push range found no credentials, emails or transcript
+  text. It did find Windows username paths and session ids in the devlog, which is
+  the repository's existing convention — the same pattern is already on `dev` in the
+  peer's unit and in older units.
+
+## What did not improve
+
+WSL never ran on any of these PRs: `wsl.yml` triggers on pushes to `main`,
+`preview` and `dev`, so a stacked chain gets no WSL coverage until the bottom layer
+lands. That is a gap in the evidence, not a passing check, and it is recorded here
+rather than counted as green.
+

--- a/plugins/codexclaw/bin/cxc.mjs
+++ b/plugins/codexclaw/bin/cxc.mjs
@@ -88,6 +88,7 @@ const HELP = [
   "",
   "Workspace intelligence:",
   '  chat search "q" | memory search "q"   recall over ~/.codex artifacts',
+  "  memory allow-write --session <id>     grant one cwd-scoped memory write",
   "  skill search|show              dormant-skill discovery",
   "",
   "Operations:",

--- a/plugins/codexclaw/components/pabcd-state/dist/cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/cli.js
@@ -281,11 +281,15 @@ async function main()                {
   if (kind === "memory") {
     const { MEMORY_USAGE, parseMemoryCliArgs, runMemoryCli } = await import("./memory-cli.js");
     const argv = process.argv.slice(3);
-    if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+    if (argv.length === 0) {
       process.stdout.write(`${MEMORY_USAGE}\n`);
       process.exit(0);
     }
     const parsed = parseMemoryCliArgs(argv, process.cwd());
+    if ("help" in parsed) {
+      process.stdout.write(`${MEMORY_USAGE}\n`);
+      process.exit(0);
+    }
     if ("error" in parsed) {
       process.stderr.write(`memory: ${parsed.error}\n${MEMORY_USAGE}\n`);
       process.exit(2);

--- a/plugins/codexclaw/components/pabcd-state/dist/memory-cli.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/memory-cli.js
@@ -22,24 +22,49 @@ import { isCanonicalSessionId, readState, withSessionLock, writeState } from "./
 
 
 
+
+
 export const MEMORY_USAGE = [
   "Usage:",
   "  cxc memory allow-write --session <id>",
+  "  cxc memory allow-write --session=<id>",
+  "  cxc memory allow-write --help",
   "",
   "Authorizes exactly ONE memory write (memories.add_ad_hoc_note, or an edit under",
   "~/.codex/memories) for that session. The grant is consumed by the next write.",
+  "",
+  "The grant is stored at <cwd>/.codexclaw/sessions/<id>.json and is keyed by that",
+  "cwd plus the session id. The success line names the cwd it wrote to. Issuing the",
+  "grant from a different working directory will print success and never be seen by",
+  "the hook running in this session.",
   "",
   "The ordinary path needs no command: when the user asks in their own words to",
   "remember something, the session records that request and the next write passes.",
 ].join("\n");
 
-export function parseMemoryCliArgs(argv          , cwd        )                                           {
+export function parseMemoryCliArgs(argv          , cwd        )                 {
   const verb = argv[0];
   if (verb !== "allow-write") {
     return { error: `unknown memory verb '${verb ?? ""}' (expected allow-write)` };
   }
-  const i = argv.indexOf("--session");
-  const sessionId = i >= 0 ? argv[i + 1] : undefined;
+  const rest = argv.slice(1);
+  if (rest.some((tok) => tok === "--help" || tok === "-h")) {
+    return { help: true };
+  }
+  let sessionId                    ;
+  for (let i = 0; i < rest.length; i++) {
+    const tok = rest[i];
+    if (tok === "--session") {
+      sessionId = rest[i + 1];
+      i++;
+      continue;
+    }
+    if (tok.startsWith("--session=")) {
+      sessionId = tok.slice("--session=".length);
+      continue;
+    }
+    return { error: `unknown argument '${tok}'` };
+  }
   if (!sessionId || !isCanonicalSessionId(sessionId)) {
     return { error: "missing required argument: --session <id> (must be a canonical session id)" };
   }
@@ -63,7 +88,7 @@ export function runMemoryCli(args                      )                        
     };
   }
   return {
-    output: `memory allow-write: session ${args.sessionId} may perform ONE memory write; the next write consumes this grant.`,
+    output: `memory allow-write: session ${args.sessionId} may perform ONE memory write; grant recorded for cwd ${args.cwd}; the next write consumes this grant.`,
     code: 0,
   };
 }

--- a/plugins/codexclaw/components/pabcd-state/dist/memory-write-gate.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/memory-write-gate.js
@@ -77,7 +77,7 @@ const SHELL_TOOLS                      = new Set(["Bash", "shell", "exec_command
  */
 export const MEMORY_WRITE_PATTERNS                    = [
   /기억\s*(해둬|해 둬|해줘|해라|하자|해$|해[.!,]|해서\s*(둬|놔))/,
-  /(기억|메모)\s*(에|해서)?\s*(남겨|남겨둬|적어|적어둬|저장|기록)/,
+  /(기억|메모리?)\s*(에다|에도|에|도|해서)?\s*(남겨|남겨둬|적어|적어둬|저장|기록)/,
   /메모리\s*(에|에다)?\s*(남겨|기록|추가|저장|적어|넣어|써)/,
   /(노트|메모)\s*(로|를|에)?\s*(남겨|남겨둬|추가|저장|기록)/,
   /잊지\s*(말고|마|마라|말아)/,
@@ -126,14 +126,35 @@ export function isMemoryPath(candidate        , root        )          {
 }
 
 /**
- * Expand a possibly `~`-prefixed, possibly relative path against cwd. Shell text and
- * patch headers both carry these forms, and a tilde path that stayed literal would
- * read as relative and escape the check.
+ * Expand a possibly home-prefixed, possibly relative path against cwd. Shell text
+ * and patch headers both carry these forms, and a tilde / USERPROFILE path that
+ * stayed literal would read as relative and escape the check.
+ *
+ * Home prefixes, case-insensitive except for the exact `~` forms: `~`, `~/`, `~\`,
+ * `%USERPROFILE%`, `$env:USERPROFILE`, `$HOME`. Expansion uses `homedir()`, the
+ * same target `~` already uses. It does not consult `CODEX_HOME`; `memoriesRoot`
+ * still decides the protected root. After expansion, backslashes become `/` so
+ * `~\.codex\memories\n.md` classifies on win32 and on POSIX CI.
  */
+function expandHomePrefix(raw        )         {
+  const home = homedir();
+  if (raw === "~") return home;
+  if (raw.startsWith("~/") || raw.startsWith("~\\")) return join(home, raw.slice(2));
+  const lower = raw.toLowerCase();
+  const prefixes = ["%userprofile%", "$env:userprofile", "$home"];
+  for (const prefix of prefixes) {
+    if (lower === prefix) return home;
+    if (lower.startsWith(prefix + "/") || lower.startsWith(prefix + "\\")) {
+      return join(home, raw.slice(prefix.length + 1));
+    }
+  }
+  return raw;
+}
+
 function absolutize(raw        , cwd        )         {
   let value = raw.trim().replace(/^["']|["']$/g, "");
   if (value === "") return "";
-  if (value === "~" || value.startsWith("~/")) value = join(homedir(), value.slice(1));
+  value = expandHomePrefix(value).replace(/\\/g, "/");
   if (isAbsolute(value)) return resolve(value);
   return cwd === "" ? "" : resolve(cwd, value);
 }
@@ -207,16 +228,18 @@ export function classifyMemoryWrite(
   return { surface: "", target: "" };
 }
 
-export function denyReason(attempt                    , sessionId        )         {
+export function denyReason(attempt                    , sessionId        , cwd = "")         {
   const what =
     attempt.surface === "tool"
       ? `a memory note (${attempt.target})`
       : `a file under the Codex memories directory (${attempt.target})`;
+  const cwdHint = cwd === "" ? "the session working directory" : cwd;
   return [
     `[codexclaw MEMORY-WRITE-GATE] Blocked a write of ${what}: this session has no explicit user request to remember anything.`,
     "Memory notes outlive codexclaw and reach every later session, so they are written only when the user asks.",
     "Two ways forward: ask the user to confirm they want this remembered (a prompt such as \"기억해둬\" or \"remember this\" authorizes the next write),",
-    `or record an explicit grant with \`cxc memory allow-write --session ${sessionId || "<id>"}\`.`,
+    `or record an explicit grant with \`cxc memory allow-write --session ${sessionId || "<id>"}\` from ${cwdHint}.`,
+    "The grant is stored per cwd; issuing it from a different working directory will print success and never be seen by this hook.",
     "If the user did ask, say so and retry — the request must appear in their own message, not in yours.",
   ].join(" ");
 }
@@ -295,7 +318,7 @@ export function handleMemoryWriteGate(raw        , env                    = proc
     // exception: the fail-open promise covers CRASHES, and the deny still names both
     // remedies.
     if (cwd !== "" && sessionId !== "" && consumeAuthorization(cwd, sessionId, turnId)) return "";
-    return denyEnvelope(denyReason(attempt, sessionId));
+    return denyEnvelope(denyReason(attempt, sessionId, cwd));
   } catch {
     return ""; // FAIL-OPEN: a gate crash must never block an explicitly requested write
   }

--- a/plugins/codexclaw/components/pabcd-state/dist/shell-write-destinations.js
+++ b/plugins/codexclaw/components/pabcd-state/dist/shell-write-destinations.js
@@ -16,7 +16,10 @@
  *
  * Counted as writes: stdout redirect `>`/`>>` (fd omitted or 1), `tee`
  * operands, `sed -i`/`--in-place` file operands, `cp`/`mv` destination,
- * `perl -i`/`ruby -i` file operands.
+ * `perl -i`/`ruby -i` file operands, PowerShell write cmdlets (Set-Content,
+ * Out-File, New-Item, Add-Content, Tee-Object and aliases sc/ni/ac), Copy-Item/
+ * copy/Move-Item destination, python/node one-line writes, and .NET
+ * `[IO.File]::WriteAllText` / `AppendAllText`.
  * Not writes: `2>`/`2>>`, `<<` heredoc, `<<<` herestring, `sed -n`.
  */
 export function shellWriteDestinations(command        )           {
@@ -266,6 +269,10 @@ function basename(p        )         {
   return idx === -1 ? norm : norm.slice(idx + 1);
 }
 
+function normalizeVerb(verb        )         {
+  return verb.replace(/\.(exe|cmd|bat)$/i, "").toLowerCase();
+}
+
 function stripPrefixes(tokens          )           {
   let rest = tokens;
   for (;;) {
@@ -284,14 +291,23 @@ function stripPrefixes(tokens          )           {
 }
 
 function verbDestinations(segment        )           {
-  const rest = stripPrefixes(tokenize(segment));
-  const verb = rest[0] ? basename(rest[0]) : "";
+  let rest = stripPrefixes(tokenize(segment));
+  while (rest[0] === "&") rest = rest.slice(1);
+  const verb = rest[0] ? normalizeVerb(basename(rest[0])) : "";
   const args = rest.slice(1);
-  if (verb === "tee") return teeDestinations(args);
-  if (verb === "sed") return sedInPlaceDestinations(args);
-  if (verb === "cp" || verb === "mv") return cpMvDestinations(args);
-  if (verb === "perl" || verb === "ruby") return interpInPlaceDestinations(args);
-  return [];
+  const dests = [...dotnetWriteDestinations(segment)];
+  if (verb === "tee") dests.push(...teeDestinations(args));
+  else if (verb === "sed") dests.push(...sedInPlaceDestinations(args));
+  else if (verb === "cp" || verb === "mv") dests.push(...cpMvDestinations(args));
+  else if (verb === "perl" || verb === "ruby") dests.push(...interpInPlaceDestinations(args));
+  else if (verb === "python" || verb === "python3" || verb === "py" || verb === "node" || verb === "nodejs") {
+    dests.push(...pythonNodeWriteDestinations(verb, args));
+  } else if (verb === "copy-item" || verb === "copy" || verb === "move-item") {
+    dests.push(...powershellWriteDestinations(args, true));
+  } else if (isOvercollectWriteVerb(verb, args)) {
+    dests.push(...powershellWriteDestinations(args, false));
+  }
+  return dests;
 }
 
 function teeDestinations(args          )           {
@@ -385,4 +401,158 @@ function interpInPlaceDestinations(args          )           {
     positional.push(a);
   }
   return inPlace ? positional : [];
+}
+
+const PS_VALUE_FLAGS = ["value", "itemtype", "encoding", "name", "filter", "inputobject", "width", "stream"];
+const PS_PATHISH_FLAGS = ["path", "literalpath", "filepath", "destination"];
+
+function isFlagToken(token        )          {
+  if (token === "-" || token === "--") return false;
+  if (token.startsWith("-") && !/^-\d/.test(token)) return true;
+  return /^\/[A-Za-z][A-Za-z0-9]*([:].*)?$/.test(token);
+}
+
+function parseFlag(token        )                                                      {
+  if (!isFlagToken(token)) return null;
+  const body = token.replace(/^[-\/]+/, "");
+  const colon = body.indexOf(":");
+  const eq = body.indexOf("=");
+  let split = -1;
+  if (colon > 0 && (eq === -1 || colon < eq)) split = colon;
+  else if (eq > 0) split = eq;
+  if (split > 0) return { name: body.slice(0, split), inline: body.slice(split + 1) };
+  return { name: body, inline: undefined };
+}
+
+function shouldConsumeValue(name        )          {
+  const n = name.toLowerCase();
+  if (n === "") return false;
+  if (PS_PATHISH_FLAGS.some((p) => p.startsWith(n) || n.startsWith(p))) return false;
+  return PS_VALUE_FLAGS.filter((f) => f.startsWith(n)).length === 1;
+}
+
+function isDestinationFlag(name        )          {
+  const n = name.toLowerCase();
+  if (n === "t" || n === "target-directory") return true;
+  return n.length >= 4 && "destination".startsWith(n);
+}
+
+function isFileShaped(token        )          {
+  if (isFlagToken(token)) return false;
+  return (
+    /[\\/]/.test(token) ||
+    /\.[A-Za-z0-9]{1,8}$/.test(token) ||
+    token.startsWith("~") ||
+    token.startsWith("%") ||
+    /^\$env:/i.test(token) ||
+    /^\$home/i.test(token)
+  );
+}
+
+function isOvercollectWriteVerb(verb        , args          )          {
+  if (
+    verb === "set-content" ||
+    verb === "out-file" ||
+    verb === "new-item" ||
+    verb === "tee-object" ||
+    verb === "add-content" ||
+    verb === "ni" ||
+    verb === "ac"
+  ) {
+    return true;
+  }
+  if (verb !== "sc") return false;
+  return args.some((a) => {
+    const flag = parseFlag(a);
+    if (flag?.inline) return isFileShaped(flag.inline);
+    return isFileShaped(a);
+  });
+}
+
+function powershellWriteDestinations(args          , copyLike         )           {
+  const namedDests           = [];
+  const candidates           = [];
+  for (let i = 0; i < args.length; i++) {
+    const flag = parseFlag(args[i]);
+    if (!flag) {
+      candidates.push(args[i]);
+      continue;
+    }
+    if (copyLike && isDestinationFlag(flag.name)) {
+      const val = flag.inline !== undefined ? flag.inline : args[i + 1];
+      if (flag.inline === undefined && val !== undefined && !parseFlag(val)) i++;
+      if (val && !parseFlag(val)) namedDests.push(val);
+      continue;
+    }
+    if (flag.inline !== undefined) {
+      if (!copyLike && !shouldConsumeValue(flag.name)) candidates.push(flag.inline);
+      continue;
+    }
+    if (shouldConsumeValue(flag.name)) {
+      const next = args[i + 1];
+      if (next !== undefined && !parseFlag(next)) i++;
+      continue;
+    }
+  }
+  if (copyLike) {
+    if (namedDests.length) return namedDests;
+    if (candidates.length >= 2) return [candidates[candidates.length - 1]];
+    return [];
+  }
+  return candidates;
+}
+
+function pythonNodeWriteDestinations(verb        , args          )           {
+  const isNode = verb === "node" || verb === "nodejs";
+  const isPy = verb === "python" || verb === "python3" || verb === "py";
+  let script = "";
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (isPy && (a === "-c" || a === "--command")) {
+      script = args[i + 1] ?? "";
+      break;
+    }
+    if (isPy && a.startsWith("-c") && a.length > 2) {
+      script = a.slice(2);
+      break;
+    }
+    if (isNode && (a === "-e" || a === "--eval")) {
+      script = args[i + 1] ?? "";
+      break;
+    }
+    if (isNode && a.startsWith("--eval=")) {
+      script = a.slice("--eval=".length);
+      break;
+    }
+    if (isNode && a.startsWith("-e") && a.length > 2 && !a.startsWith("--")) {
+      script = a.slice(2);
+      break;
+    }
+  }
+  return script === "" ? [] : scriptWriteDestinations(script);
+}
+
+function scriptWriteDestinations(script        )           {
+  const out           = [];
+  const patterns = [
+    /\bopen\s*\(\s*(?:[rRuUbBfF]*)(['"])(.*?)\1\s*,\s*(?:[rRuUbBfF]*)(['"])([wax][^'"]*)\3/g,
+    /\bPath\s*\(\s*(?:[rRuUbBfF]*)(['"])(.*?)\1\s*\)\s*\.write_(?:text|bytes)\s*\(/g,
+    /\b(?:writeFileSync|writeFile|appendFileSync|appendFile|createWriteStream)\s*\(\s*(['"])(.*?)\1/g,
+  ];
+  for (const re of patterns) {
+    re.lastIndex = 0;
+    for (let m = re.exec(script); m !== null; m = re.exec(script)) {
+      if (m[2]) out.push(m[2]);
+    }
+  }
+  return out;
+}
+
+function dotnetWriteDestinations(segment        )           {
+  const re = /\[(?:System\.)?IO\.File\]::(?:Write|Append)All[A-Za-z]*\s*\(\s*(['"])(.*?)\1/gi;
+  const out           = [];
+  for (let m = re.exec(segment); m !== null; m = re.exec(segment)) {
+    if (m[2]) out.push(m[2]);
+  }
+  return out;
 }

--- a/plugins/codexclaw/components/pabcd-state/src/cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/cli.ts
@@ -281,11 +281,15 @@ async function main(): Promise<void> {
   if (kind === "memory") {
     const { MEMORY_USAGE, parseMemoryCliArgs, runMemoryCli } = await import("./memory-cli.ts");
     const argv = process.argv.slice(3);
-    if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+    if (argv.length === 0) {
       process.stdout.write(`${MEMORY_USAGE}\n`);
       process.exit(0);
     }
     const parsed = parseMemoryCliArgs(argv, process.cwd());
+    if ("help" in parsed) {
+      process.stdout.write(`${MEMORY_USAGE}\n`);
+      process.exit(0);
+    }
     if ("error" in parsed) {
       process.stderr.write(`memory: ${parsed.error}\n${MEMORY_USAGE}\n`);
       process.exit(2);

--- a/plugins/codexclaw/components/pabcd-state/src/memory-cli.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/memory-cli.ts
@@ -22,24 +22,49 @@ export interface MemoryAllowWriteArgs {
   cwd: string;
 }
 
+export type MemoryCliParse = MemoryAllowWriteArgs | { help: true } | { error: string };
+
 export const MEMORY_USAGE = [
   "Usage:",
   "  cxc memory allow-write --session <id>",
+  "  cxc memory allow-write --session=<id>",
+  "  cxc memory allow-write --help",
   "",
   "Authorizes exactly ONE memory write (memories.add_ad_hoc_note, or an edit under",
   "~/.codex/memories) for that session. The grant is consumed by the next write.",
+  "",
+  "The grant is stored at <cwd>/.codexclaw/sessions/<id>.json and is keyed by that",
+  "cwd plus the session id. The success line names the cwd it wrote to. Issuing the",
+  "grant from a different working directory will print success and never be seen by",
+  "the hook running in this session.",
   "",
   "The ordinary path needs no command: when the user asks in their own words to",
   "remember something, the session records that request and the next write passes.",
 ].join("\n");
 
-export function parseMemoryCliArgs(argv: string[], cwd: string): MemoryAllowWriteArgs | { error: string } {
+export function parseMemoryCliArgs(argv: string[], cwd: string): MemoryCliParse {
   const verb = argv[0];
   if (verb !== "allow-write") {
     return { error: `unknown memory verb '${verb ?? ""}' (expected allow-write)` };
   }
-  const i = argv.indexOf("--session");
-  const sessionId = i >= 0 ? argv[i + 1] : undefined;
+  const rest = argv.slice(1);
+  if (rest.some((tok) => tok === "--help" || tok === "-h")) {
+    return { help: true };
+  }
+  let sessionId: string | undefined;
+  for (let i = 0; i < rest.length; i++) {
+    const tok = rest[i];
+    if (tok === "--session") {
+      sessionId = rest[i + 1];
+      i++;
+      continue;
+    }
+    if (tok.startsWith("--session=")) {
+      sessionId = tok.slice("--session=".length);
+      continue;
+    }
+    return { error: `unknown argument '${tok}'` };
+  }
   if (!sessionId || !isCanonicalSessionId(sessionId)) {
     return { error: "missing required argument: --session <id> (must be a canonical session id)" };
   }
@@ -63,7 +88,7 @@ export function runMemoryCli(args: MemoryAllowWriteArgs): { output: string; code
     };
   }
   return {
-    output: `memory allow-write: session ${args.sessionId} may perform ONE memory write; the next write consumes this grant.`,
+    output: `memory allow-write: session ${args.sessionId} may perform ONE memory write; grant recorded for cwd ${args.cwd}; the next write consumes this grant.`,
     code: 0,
   };
 }

--- a/plugins/codexclaw/components/pabcd-state/src/memory-write-gate.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/memory-write-gate.ts
@@ -77,7 +77,7 @@ const SHELL_TOOLS: ReadonlySet<string> = new Set(["Bash", "shell", "exec_command
  */
 export const MEMORY_WRITE_PATTERNS: readonly RegExp[] = [
   /기억\s*(해둬|해 둬|해줘|해라|하자|해$|해[.!,]|해서\s*(둬|놔))/,
-  /(기억|메모)\s*(에|해서)?\s*(남겨|남겨둬|적어|적어둬|저장|기록)/,
+  /(기억|메모리?)\s*(에다|에도|에|도|해서)?\s*(남겨|남겨둬|적어|적어둬|저장|기록)/,
   /메모리\s*(에|에다)?\s*(남겨|기록|추가|저장|적어|넣어|써)/,
   /(노트|메모)\s*(로|를|에)?\s*(남겨|남겨둬|추가|저장|기록)/,
   /잊지\s*(말고|마|마라|말아)/,
@@ -126,14 +126,35 @@ export function isMemoryPath(candidate: string, root: string): boolean {
 }
 
 /**
- * Expand a possibly `~`-prefixed, possibly relative path against cwd. Shell text and
- * patch headers both carry these forms, and a tilde path that stayed literal would
- * read as relative and escape the check.
+ * Expand a possibly home-prefixed, possibly relative path against cwd. Shell text
+ * and patch headers both carry these forms, and a tilde / USERPROFILE path that
+ * stayed literal would read as relative and escape the check.
+ *
+ * Home prefixes, case-insensitive except for the exact `~` forms: `~`, `~/`, `~\`,
+ * `%USERPROFILE%`, `$env:USERPROFILE`, `$HOME`. Expansion uses `homedir()`, the
+ * same target `~` already uses. It does not consult `CODEX_HOME`; `memoriesRoot`
+ * still decides the protected root. After expansion, backslashes become `/` so
+ * `~\.codex\memories\n.md` classifies on win32 and on POSIX CI.
  */
+function expandHomePrefix(raw: string): string {
+  const home = homedir();
+  if (raw === "~") return home;
+  if (raw.startsWith("~/") || raw.startsWith("~\\")) return join(home, raw.slice(2));
+  const lower = raw.toLowerCase();
+  const prefixes = ["%userprofile%", "$env:userprofile", "$home"];
+  for (const prefix of prefixes) {
+    if (lower === prefix) return home;
+    if (lower.startsWith(prefix + "/") || lower.startsWith(prefix + "\\")) {
+      return join(home, raw.slice(prefix.length + 1));
+    }
+  }
+  return raw;
+}
+
 function absolutize(raw: string, cwd: string): string {
   let value = raw.trim().replace(/^["']|["']$/g, "");
   if (value === "") return "";
-  if (value === "~" || value.startsWith("~/")) value = join(homedir(), value.slice(1));
+  value = expandHomePrefix(value).replace(/\\/g, "/");
   if (isAbsolute(value)) return resolve(value);
   return cwd === "" ? "" : resolve(cwd, value);
 }
@@ -207,16 +228,18 @@ export function classifyMemoryWrite(
   return { surface: "", target: "" };
 }
 
-export function denyReason(attempt: MemoryWriteAttempt, sessionId: string): string {
+export function denyReason(attempt: MemoryWriteAttempt, sessionId: string, cwd = ""): string {
   const what =
     attempt.surface === "tool"
       ? `a memory note (${attempt.target})`
       : `a file under the Codex memories directory (${attempt.target})`;
+  const cwdHint = cwd === "" ? "the session working directory" : cwd;
   return [
     `[codexclaw MEMORY-WRITE-GATE] Blocked a write of ${what}: this session has no explicit user request to remember anything.`,
     "Memory notes outlive codexclaw and reach every later session, so they are written only when the user asks.",
     "Two ways forward: ask the user to confirm they want this remembered (a prompt such as \"기억해둬\" or \"remember this\" authorizes the next write),",
-    `or record an explicit grant with \`cxc memory allow-write --session ${sessionId || "<id>"}\`.`,
+    `or record an explicit grant with \`cxc memory allow-write --session ${sessionId || "<id>"}\` from ${cwdHint}.`,
+    "The grant is stored per cwd; issuing it from a different working directory will print success and never be seen by this hook.",
     "If the user did ask, say so and retry — the request must appear in their own message, not in yours.",
   ].join(" ");
 }
@@ -295,7 +318,7 @@ export function handleMemoryWriteGate(raw: string, env: NodeJS.ProcessEnv = proc
     // exception: the fail-open promise covers CRASHES, and the deny still names both
     // remedies.
     if (cwd !== "" && sessionId !== "" && consumeAuthorization(cwd, sessionId, turnId)) return "";
-    return denyEnvelope(denyReason(attempt, sessionId));
+    return denyEnvelope(denyReason(attempt, sessionId, cwd));
   } catch {
     return ""; // FAIL-OPEN: a gate crash must never block an explicitly requested write
   }

--- a/plugins/codexclaw/components/pabcd-state/src/shell-write-destinations.ts
+++ b/plugins/codexclaw/components/pabcd-state/src/shell-write-destinations.ts
@@ -16,7 +16,10 @@
  *
  * Counted as writes: stdout redirect `>`/`>>` (fd omitted or 1), `tee`
  * operands, `sed -i`/`--in-place` file operands, `cp`/`mv` destination,
- * `perl -i`/`ruby -i` file operands.
+ * `perl -i`/`ruby -i` file operands, PowerShell write cmdlets (Set-Content,
+ * Out-File, New-Item, Add-Content, Tee-Object and aliases sc/ni/ac), Copy-Item/
+ * copy/Move-Item destination, python/node one-line writes, and .NET
+ * `[IO.File]::WriteAllText` / `AppendAllText`.
  * Not writes: `2>`/`2>>`, `<<` heredoc, `<<<` herestring, `sed -n`.
  */
 export function shellWriteDestinations(command: string): string[] {
@@ -266,6 +269,10 @@ function basename(p: string): string {
   return idx === -1 ? norm : norm.slice(idx + 1);
 }
 
+function normalizeVerb(verb: string): string {
+  return verb.replace(/\.(exe|cmd|bat)$/i, "").toLowerCase();
+}
+
 function stripPrefixes(tokens: string[]): string[] {
   let rest = tokens;
   for (;;) {
@@ -284,14 +291,23 @@ function stripPrefixes(tokens: string[]): string[] {
 }
 
 function verbDestinations(segment: string): string[] {
-  const rest = stripPrefixes(tokenize(segment));
-  const verb = rest[0] ? basename(rest[0]) : "";
+  let rest = stripPrefixes(tokenize(segment));
+  while (rest[0] === "&") rest = rest.slice(1);
+  const verb = rest[0] ? normalizeVerb(basename(rest[0])) : "";
   const args = rest.slice(1);
-  if (verb === "tee") return teeDestinations(args);
-  if (verb === "sed") return sedInPlaceDestinations(args);
-  if (verb === "cp" || verb === "mv") return cpMvDestinations(args);
-  if (verb === "perl" || verb === "ruby") return interpInPlaceDestinations(args);
-  return [];
+  const dests = [...dotnetWriteDestinations(segment)];
+  if (verb === "tee") dests.push(...teeDestinations(args));
+  else if (verb === "sed") dests.push(...sedInPlaceDestinations(args));
+  else if (verb === "cp" || verb === "mv") dests.push(...cpMvDestinations(args));
+  else if (verb === "perl" || verb === "ruby") dests.push(...interpInPlaceDestinations(args));
+  else if (verb === "python" || verb === "python3" || verb === "py" || verb === "node" || verb === "nodejs") {
+    dests.push(...pythonNodeWriteDestinations(verb, args));
+  } else if (verb === "copy-item" || verb === "copy" || verb === "move-item") {
+    dests.push(...powershellWriteDestinations(args, true));
+  } else if (isOvercollectWriteVerb(verb, args)) {
+    dests.push(...powershellWriteDestinations(args, false));
+  }
+  return dests;
 }
 
 function teeDestinations(args: string[]): string[] {
@@ -385,4 +401,158 @@ function interpInPlaceDestinations(args: string[]): string[] {
     positional.push(a);
   }
   return inPlace ? positional : [];
+}
+
+const PS_VALUE_FLAGS = ["value", "itemtype", "encoding", "name", "filter", "inputobject", "width", "stream"];
+const PS_PATHISH_FLAGS = ["path", "literalpath", "filepath", "destination"];
+
+function isFlagToken(token: string): boolean {
+  if (token === "-" || token === "--") return false;
+  if (token.startsWith("-") && !/^-\d/.test(token)) return true;
+  return /^\/[A-Za-z][A-Za-z0-9]*([:].*)?$/.test(token);
+}
+
+function parseFlag(token: string): { name: string; inline: string | undefined } | null {
+  if (!isFlagToken(token)) return null;
+  const body = token.replace(/^[-\/]+/, "");
+  const colon = body.indexOf(":");
+  const eq = body.indexOf("=");
+  let split = -1;
+  if (colon > 0 && (eq === -1 || colon < eq)) split = colon;
+  else if (eq > 0) split = eq;
+  if (split > 0) return { name: body.slice(0, split), inline: body.slice(split + 1) };
+  return { name: body, inline: undefined };
+}
+
+function shouldConsumeValue(name: string): boolean {
+  const n = name.toLowerCase();
+  if (n === "") return false;
+  if (PS_PATHISH_FLAGS.some((p) => p.startsWith(n) || n.startsWith(p))) return false;
+  return PS_VALUE_FLAGS.filter((f) => f.startsWith(n)).length === 1;
+}
+
+function isDestinationFlag(name: string): boolean {
+  const n = name.toLowerCase();
+  if (n === "t" || n === "target-directory") return true;
+  return n.length >= 4 && "destination".startsWith(n);
+}
+
+function isFileShaped(token: string): boolean {
+  if (isFlagToken(token)) return false;
+  return (
+    /[\\/]/.test(token) ||
+    /\.[A-Za-z0-9]{1,8}$/.test(token) ||
+    token.startsWith("~") ||
+    token.startsWith("%") ||
+    /^\$env:/i.test(token) ||
+    /^\$home/i.test(token)
+  );
+}
+
+function isOvercollectWriteVerb(verb: string, args: string[]): boolean {
+  if (
+    verb === "set-content" ||
+    verb === "out-file" ||
+    verb === "new-item" ||
+    verb === "tee-object" ||
+    verb === "add-content" ||
+    verb === "ni" ||
+    verb === "ac"
+  ) {
+    return true;
+  }
+  if (verb !== "sc") return false;
+  return args.some((a) => {
+    const flag = parseFlag(a);
+    if (flag?.inline) return isFileShaped(flag.inline);
+    return isFileShaped(a);
+  });
+}
+
+function powershellWriteDestinations(args: string[], copyLike: boolean): string[] {
+  const namedDests: string[] = [];
+  const candidates: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const flag = parseFlag(args[i]);
+    if (!flag) {
+      candidates.push(args[i]);
+      continue;
+    }
+    if (copyLike && isDestinationFlag(flag.name)) {
+      const val = flag.inline !== undefined ? flag.inline : args[i + 1];
+      if (flag.inline === undefined && val !== undefined && !parseFlag(val)) i++;
+      if (val && !parseFlag(val)) namedDests.push(val);
+      continue;
+    }
+    if (flag.inline !== undefined) {
+      if (!copyLike && !shouldConsumeValue(flag.name)) candidates.push(flag.inline);
+      continue;
+    }
+    if (shouldConsumeValue(flag.name)) {
+      const next = args[i + 1];
+      if (next !== undefined && !parseFlag(next)) i++;
+      continue;
+    }
+  }
+  if (copyLike) {
+    if (namedDests.length) return namedDests;
+    if (candidates.length >= 2) return [candidates[candidates.length - 1]];
+    return [];
+  }
+  return candidates;
+}
+
+function pythonNodeWriteDestinations(verb: string, args: string[]): string[] {
+  const isNode = verb === "node" || verb === "nodejs";
+  const isPy = verb === "python" || verb === "python3" || verb === "py";
+  let script = "";
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (isPy && (a === "-c" || a === "--command")) {
+      script = args[i + 1] ?? "";
+      break;
+    }
+    if (isPy && a.startsWith("-c") && a.length > 2) {
+      script = a.slice(2);
+      break;
+    }
+    if (isNode && (a === "-e" || a === "--eval")) {
+      script = args[i + 1] ?? "";
+      break;
+    }
+    if (isNode && a.startsWith("--eval=")) {
+      script = a.slice("--eval=".length);
+      break;
+    }
+    if (isNode && a.startsWith("-e") && a.length > 2 && !a.startsWith("--")) {
+      script = a.slice(2);
+      break;
+    }
+  }
+  return script === "" ? [] : scriptWriteDestinations(script);
+}
+
+function scriptWriteDestinations(script: string): string[] {
+  const out: string[] = [];
+  const patterns = [
+    /\bopen\s*\(\s*(?:[rRuUbBfF]*)(['"])(.*?)\1\s*,\s*(?:[rRuUbBfF]*)(['"])([wax][^'"]*)\3/g,
+    /\bPath\s*\(\s*(?:[rRuUbBfF]*)(['"])(.*?)\1\s*\)\s*\.write_(?:text|bytes)\s*\(/g,
+    /\b(?:writeFileSync|writeFile|appendFileSync|appendFile|createWriteStream)\s*\(\s*(['"])(.*?)\1/g,
+  ];
+  for (const re of patterns) {
+    re.lastIndex = 0;
+    for (let m = re.exec(script); m !== null; m = re.exec(script)) {
+      if (m[2]) out.push(m[2]);
+    }
+  }
+  return out;
+}
+
+function dotnetWriteDestinations(segment: string): string[] {
+  const re = /\[(?:System\.)?IO\.File\]::(?:Write|Append)All[A-Za-z]*\s*\(\s*(['"])(.*?)\1/gi;
+  const out: string[] = [];
+  for (let m = re.exec(segment); m !== null; m = re.exec(segment)) {
+    if (m[2]) out.push(m[2]);
+  }
+  return out;
 }

--- a/plugins/codexclaw/components/pabcd-state/test/help-verbs.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/help-verbs.test.ts
@@ -137,3 +137,60 @@ test("freeze --help prints usage and writes nothing", () => {
   assert.equal(existsSync(join(cwd, ".codexclaw", "interview", "freeze.json")), false);
 });
 
+import { parseMemoryCliArgs } from "../src/memory-cli.ts";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { STATE_DIR, SESSIONS_SUBDIR } from "../src/state.ts";
+
+const MEMORY_SESSION = "019f9d73-4c28-7723-ab52-346aca1d9bcb";
+
+function memoryRepoRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..", "..");
+}
+
+for (const token of ["--help", "-h"]) {
+  test("memory allow-write " + token + " prints usage and does not require --session", () => {
+    const parsed = parseMemoryCliArgs(["allow-write", token], CWD);
+    assert.ok("help" in parsed, token + " must be help, got " + JSON.stringify(parsed));
+  });
+}
+
+test("memory allow-write --session <id> --help is help, not a grant", () => {
+  const parsed = parseMemoryCliArgs(["allow-write", "--session", MEMORY_SESSION, "--help"], CWD);
+  assert.ok("help" in parsed, "expected help, got " + JSON.stringify(parsed));
+});
+
+test("memory allow-write --help on both real entrypoints writes no grant", () => {
+  const root = memoryRepoRoot();
+  const entries = [
+    join(root, "bin", "codexclaw.mjs"),
+    join(root, "plugins", "codexclaw", "bin", "cxc.mjs"),
+  ];
+  for (const entry of entries) {
+    for (const argv of [
+      ["memory", "allow-write", "--help"],
+      ["memory", "allow-write", "-h"],
+      ["memory", "allow-write", "--session", MEMORY_SESSION, "--help"],
+    ]) {
+      const cwd = mkdtempSync(join(tmpdir(), "cxc-mem-help-"));
+      const res = spawnSync(process.execPath, [entry, ...argv], { cwd, encoding: "utf8" });
+      assert.equal(res.status, 0, entry + " " + argv.join(" ") + " exited " + res.status + ": " + res.stderr);
+      assert.match(res.stdout, /Usage:/);
+      assert.equal(existsSync(join(cwd, STATE_DIR, SESSIONS_SUBDIR, MEMORY_SESSION + ".json")), false);
+    }
+  }
+});
+
+test("root --help lists memory allow-write on both entrypoints", () => {
+  const root = memoryRepoRoot();
+  const entries = [
+    join(root, "bin", "codexclaw.mjs"),
+    join(root, "plugins", "codexclaw", "bin", "cxc.mjs"),
+  ];
+  for (const entry of entries) {
+    const res = spawnSync(process.execPath, [entry, "--help"], { encoding: "utf8" });
+    assert.equal(res.status, 0, entry + " --help exited " + res.status + ": " + res.stderr);
+    assert.match(res.stdout, /memory allow-write/);
+  }
+});

--- a/plugins/codexclaw/components/pabcd-state/test/memory-write-gate.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/memory-write-gate.test.ts
@@ -10,7 +10,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   classifyMemoryWrite,
@@ -70,6 +70,11 @@ test("BLOCK: an unauthorized memory-tool write is denied with both remedies", ()
   assert.match(env.hookSpecificOutput.permissionDecisionReason, /MEMORY-WRITE-GATE/);
   assert.match(env.hookSpecificOutput.permissionDecisionReason, /allow-write/);
   assert.match(env.hookSpecificOutput.permissionDecisionReason, /remember this/);
+  assert.match(env.hookSpecificOutput.permissionDecisionReason, /stored per cwd/);
+  assert.ok(
+    env.hookSpecificOutput.permissionDecisionReason.includes(cwd),
+    "deny reason must name the session cwd the grant has to be issued from",
+  );
   // Deny-only envelope: the reason must also reach additionalContext.
   assert.equal(
     env.hookSpecificOutput.additionalContext,
@@ -274,4 +279,114 @@ test("shellWriteDestinations: stderr, arrows in prose, and heredoc bodies are no
   assert.deepEqual(shellWriteDestinations("echo hi>>/h/memories/n.md"), ["/h/memories/n.md"]);
   assert.deepEqual(shellWriteDestinations("echo hi >| /h/memories/n.md"), ["/h/memories/n.md"]);
   assert.deepEqual(shellWriteDestinations("x -> y"), []);
+});
+
+test("Korean memory write: 메모리 forms; 메모리에서 찾 is not a write", () => {
+  assert.equal(detectMemoryWriteRequest("메모리도 기록"), true);
+  assert.equal(detectMemoryWriteRequest("메모리에 기록해줘"), true);
+  assert.equal(detectMemoryWriteRequest("메모리에 남겨둬"), true);
+  assert.equal(detectMemoryWriteRequest("메모리에 저장해"), true);
+  assert.equal(detectMemoryWriteRequest("메모리에서 찾"), false);
+  assert.equal(detectMemoryWriteRequest("메모리를 저장해"), false);
+  assert.equal(detectMemoryWriteRequest("메모리를 기록하는 함수"), false);
+});
+
+test("CLI grant success output names the cwd it recorded", () => {
+  const { cwd } = scratch();
+  const parsed = parseMemoryCliArgs(["allow-write", "--session", SESSION], cwd);
+  assert.ok(!("error" in parsed) && !("help" in parsed));
+  const res = runMemoryCli(parsed as never);
+  assert.equal(res.code, 0);
+  assert.ok(res.output.includes(cwd), "success output must name cwd, got: " + res.output);
+  assert.equal(readState(cwd, SESSION).memoryWriteGrant, true);
+});
+
+test("deny reason names the session cwd", () => {
+  const { cwd } = scratch();
+  const out = handleMemoryWriteGate(ptu({ cwd }));
+  const env = JSON.parse(out.trim());
+  const reason = env.hookSpecificOutput.permissionDecisionReason as string;
+  assert.match(reason, /stored per cwd/);
+  assert.ok(reason.includes(cwd), "deny must name session cwd, got: " + reason);
+});
+
+test("allow-write --help anywhere does not grant", () => {
+  const { cwd } = scratch();
+  for (const argv of [
+    ["allow-write", "--help"],
+    ["allow-write", "-h"],
+    ["allow-write", "--session", SESSION, "--help"],
+  ]) {
+    const parsed = parseMemoryCliArgs(argv, cwd);
+    assert.ok("help" in parsed, "expected help from " + argv.join(" ") + ", got " + JSON.stringify(parsed));
+    assert.equal((parsed as { help: true }).help, true);
+  }
+  assert.equal(readState(cwd, SESSION).memoryWriteGrant, false);
+});
+
+test("allow-write accepts --session=<id>", () => {
+  const { cwd } = scratch();
+  const parsed = parseMemoryCliArgs(["allow-write", "--session=" + SESSION], cwd);
+  assert.ok(!("error" in parsed), JSON.stringify(parsed));
+  assert.ok(!("help" in parsed));
+  assert.equal((parsed as { sessionId: string }).sessionId, SESSION);
+});
+
+test("allow-write rejects unknown flags", () => {
+  const parsed = parseMemoryCliArgs(["allow-write", "--session", SESSION, "--force"], "/tmp");
+  assert.ok("error" in parsed);
+  assert.match((parsed as { error: string }).error, /unknown argument/);
+});
+
+test("home prefixes classify as memory writes", () => {
+  const root = resolve(join(homedir(), ".codex", "memories"));
+  const classify = (command: string) => classifyMemoryWrite("Bash", { command }, "/w", root);
+  assert.equal(classify("echo hi > ~/.codex/memories/n.md").surface, "shell");
+  assert.equal(classify("echo hi > ~\\.codex\\memories\\n.md").surface, "shell");
+  assert.equal(classify("echo hi > %USERPROFILE%\\.codex\\memories\\n.md").surface, "shell");
+  assert.equal(classify("echo hi > $env:USERPROFILE\\.codex\\memories\\n.md").surface, "shell");
+  assert.equal(classify("echo hi > $HOME/.codex/memories/n.md").surface, "shell");
+});
+
+test("apply_patch Add File with backslash-tilde memories path is gated", () => {
+  const root = resolve(join(homedir(), ".codex", "memories"));
+  const attempt = classifyMemoryWrite(
+    "apply_patch",
+    { command: "*** Add File: ~\\.codex\\memories\\x.md\n+hi\n" },
+    "/w",
+    root,
+  );
+  assert.equal(attempt.surface, "edit");
+});
+
+test("Windows write abbreviations, aliases, and interpreters are gated", () => {
+  const root = memoriesRoot({ CODEX_HOME: "/h" });
+  const mem = "/h/memories";
+  const classify = (command: string) => classifyMemoryWrite("Bash", { command }, "/w", root);
+  const denies = [
+    "Set-Content -LP " + mem + "/n.md -Value x",
+    "Set-Content -Fo " + mem + "/n.md",
+    "Out-File -Fi " + mem + "/n.md",
+    "Set-Content -AsByteStream " + mem + "/n.md",
+    "Set-Content /Force " + mem + "/n.md",
+    "Copy-Item /w/a.md -Dest " + mem + "/b.md",
+    "sc " + mem + "/n.md",
+    "ni " + mem + "/n.md",
+    "Add-Content " + mem + "/n.md -Value x",
+    "py -c \"open(r'" + mem + "/n.md','w').write('x')\"",
+    "node --eval \"require('fs').writeFileSync('" + mem + "/n.md','x')\"",
+    "node -erequire('fs').writeFileSync('" + mem + "/n.md','x')",
+    "[IO.File]::WriteAllText('" + mem + "/n.md','x')",
+  ];
+  for (const command of denies) {
+    assert.equal(classify(command).surface, "shell", "must gate: " + command);
+  }
+  assert.equal(classify("Get-Content -LiteralPath " + mem + "/n.md").surface, "");
+  assert.equal(classify("cat " + mem + "/n.md").surface, "");
+  assert.equal(classify("sc query").surface, "");
+  assert.equal(classify("cp " + mem + "/a.md /w/b.md").surface, "");
+  assert.equal(
+    classify("python3 -c \"from pathlib import Path; print(Path('" + mem + "/MEMORY.md').read_text()); print('x -> y')\"").surface,
+    "",
+  );
 });

--- a/plugins/codexclaw/components/pabcd-state/test/shell-write-destinations.test.ts
+++ b/plugins/codexclaw/components/pabcd-state/test/shell-write-destinations.test.ts
@@ -59,3 +59,74 @@ test("segments: every command in a chain is inspected", () => {
   assert.deepEqual(shellWriteDestinations(`cat /w/a || echo x>${mem}/n.md`), [`${mem}/n.md`]);
 });
 
+function includesDest(command: string, dest: string): void {
+  const got = shellWriteDestinations(command);
+  assert.ok(got.includes(dest), command + " => " + JSON.stringify(got));
+}
+
+test("PowerShell write cmdlets name their destination", () => {
+  includesDest("Set-Content -LiteralPath '" + mem + "/n.md' -Value x", mem + "/n.md");
+  includesDest("Out-File -FilePath " + mem + "/n.md", mem + "/n.md");
+  includesDest("New-Item -Path " + mem + "/n.md -ItemType File", mem + "/n.md");
+  includesDest("Copy-Item /w/a.md " + mem + "/b.md", mem + "/b.md");
+  includesDest("Tee-Object -FilePath " + mem + "/out.md", mem + "/out.md");
+  includesDest("set-content -path " + mem + "/n.md", mem + "/n.md");
+});
+
+test("Set-Content -Force does not swallow the destination", () => {
+  assert.deepEqual(shellWriteDestinations("Set-Content -Force " + mem + "/n.md"), [mem + "/n.md"]);
+});
+
+test("Out-File -Append does not swallow the destination", () => {
+  assert.deepEqual(shellWriteDestinations("Out-File -Append " + mem + "/n.md"), [mem + "/n.md"]);
+});
+
+test("New-Item -ItemType File -Force does not swallow the destination", () => {
+  assert.deepEqual(shellWriteDestinations("New-Item -ItemType File -Force " + mem + "/n.md"), [mem + "/n.md"]);
+});
+
+test("Copy-Item is destination-only like POSIX cp", () => {
+  assert.deepEqual(shellWriteDestinations("Copy-Item -Path " + mem + "/a.md -Destination /w/out.md"), ["/w/out.md"]);
+  assert.deepEqual(shellWriteDestinations("Copy-Item " + mem + "/a.md /w/out.md"), ["/w/out.md"]);
+  assert.deepEqual(shellWriteDestinations("Copy-Item /w/a.md " + mem + "/b.md"), [mem + "/b.md"]);
+});
+
+test("copy is Copy-Item destination-only", () => {
+  assert.deepEqual(shellWriteDestinations("copy /w/a.md " + mem + "/b.md"), [mem + "/b.md"]);
+  assert.deepEqual(shellWriteDestinations("copy -Path " + mem + "/a.md -Destination /w/out.md"), ["/w/out.md"]);
+});
+
+test("python and node one-line writes; reads stay empty", () => {
+  includesDest("python -c \"open(r'" + mem + "/n.md','w').write('x')\"", mem + "/n.md");
+  includesDest("python3 -c \"from pathlib import Path; Path('" + mem + "/n.md').write_text('x')\"", mem + "/n.md");
+  includesDest("node -e \"require('fs').writeFileSync('" + mem + "/n.md','x')\"", mem + "/n.md");
+  includesDest("python.exe -c \"open('" + mem + "/n.md','w').write('x')\"", mem + "/n.md");
+  assert.deepEqual(
+    shellWriteDestinations("python3 -c \"from pathlib import Path; print(Path('" + mem + "/MEMORY.md').read_text()); print('x -> y')\""),
+    [],
+  );
+});
+
+test("Get-Content is not a write", () => {
+  assert.deepEqual(shellWriteDestinations("Get-Content -LiteralPath " + mem + "/n.md"), []);
+});
+
+test("abbreviation, alias, and interpreter writes still name the destination", () => {
+  includesDest("Set-Content -LP " + mem + "/n.md -Value x", mem + "/n.md");
+  includesDest("Set-Content -Fo " + mem + "/n.md", mem + "/n.md");
+  includesDest("Out-File -Fi " + mem + "/n.md", mem + "/n.md");
+  includesDest("Set-Content -AsByteStream " + mem + "/n.md", mem + "/n.md");
+  includesDest("Set-Content /Force " + mem + "/n.md", mem + "/n.md");
+  assert.deepEqual(shellWriteDestinations("Copy-Item /w/a.md -Dest " + mem + "/b.md"), [mem + "/b.md"]);
+  includesDest("sc " + mem + "/n.md", mem + "/n.md");
+  includesDest("ni " + mem + "/n.md", mem + "/n.md");
+  includesDest("Add-Content " + mem + "/n.md -Value x", mem + "/n.md");
+  includesDest("py -c \"open(r'" + mem + "/n.md','w').write('x')\"", mem + "/n.md");
+  includesDest("node --eval \"require('fs').writeFileSync('" + mem + "/n.md','x')\"", mem + "/n.md");
+  includesDest("node -erequire('fs').writeFileSync('" + mem + "/n.md','x')", mem + "/n.md");
+  includesDest("[IO.File]::WriteAllText('" + mem + "/n.md','x')", mem + "/n.md");
+  includesDest("[System.IO.File]::AppendAllText('" + mem + "/n.md','x')", mem + "/n.md");
+  assert.deepEqual(shellWriteDestinations("sc query"), []);
+  assert.deepEqual(shellWriteDestinations("cat " + mem + "/n.md"), []);
+  assert.deepEqual(shellWriteDestinations("gc " + mem + "/n.md"), []);
+});


### PR DESCRIPTION
The gate is attached to `Bash` and `apply_patch` as well as the memory tool, but on Windows it recognised almost nothing an agent would type: `absolutize` expanded only `~/`, and the destination parser knew only POSIX verbs. Parsing PowerShell like POSIX was itself the bug — PowerShell accepts any unambiguous prefix of a parameter name, so `-LP`, `-Fo`, `-Fi`, `-Dest` and unlisted switches all steered the parser onto the wrong token. A write cmdlet now over-collects every non-flag operand and the memory-path check narrows; only the copy/move family stays destination-only so copying a file **out** of memories keeps working. Aliases, `Add-Content`, `py`, `node --eval` and the `[IO.File]::WriteAll*` statics are covered.

Measured with a direct probe over the twelve audited bypasses plus four must-allow controls: **parent source 16 misses, this layer 0.**

Closes #135
Closes #136
Closes #141

## Stack (merge bottom-up)

| # | PR | branch | issues |
|---|---|---|---|
| L0 | #154 | `codex/memory-recall-roadmap` | — (roadmap) |
| L1 | #155 | `codex/fix-recall-cwd-normalization` | #138 |
| L2 | #156 | `codex/fix-memory-search-semantics` | #142, #143 |
| L3 | #157 | `codex/fix-recall-cli-arg-hygiene` | #139, #140 |
| L4 | #158 | `codex/fix-chat-index-freshness` | #144 |
| L5 | #159 | `codex/fix-recall-intent-regex` | #137 |
| L6 | #160 | `codex/fix-memory-write-gate` | #135, #136, #141 | **<- you are here**

**You are here: L6.** Base is `codex/fix-recall-intent-regex`. **Review this PR's diff only** — it is already scoped to this layer.

## Review focus

the destination parser. This is the security boundary of the stack.

## Evidence

Every layer was planned to diff level before any code, audited by an independent `xai/grok-4.6` reviewer, and implemented only after the audit's blockers were folded. Each new test was observed **failing on the parent tip** before it was shown passing; the per-layer receipt in `devlog/_plan/260911_memory_recall_sweep/` records the exact red output.

Local gate: `npm run build` exit 0, and `npm test` showing exactly the two pre-existing environmental failures recorded in `002_host_verification_baseline.md` (`hook-bench` hardcodes `cwd: "/tmp"`, and `cxc map --help` needs `py`) and no third.

## Note on the target-branch check

`Enforce PR target branch` requires `dev`. Layers L1-L6 legitimately target the layer below, so that workflow will flag them. **Do not retarget them to `dev`** — that would dissolve the stack. Merge bottom-up; each merge retargets the next child.




