### PR TITLE
release: prepare 0.2.25

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@codexclaw/cli",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
-  "description": "codexclaw CLI \u2014 status, subagent config, provider toggle, GUI launcher.",
+  "description": "codexclaw CLI — status, subagent config, provider toggle, GUI launcher.",
   "bin": {
     "codexclaw": "../bin/codexclaw.mjs"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexclaw",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexclaw",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "license": "MIT",
       "workspaces": [
         "plugins/codexclaw/components/*",
@@ -20,7 +20,7 @@
     },
     "cli": {
       "name": "@codexclaw/cli",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "bin": {
         "codexclaw": "bin/codexclaw.mjs"
       }
@@ -1953,43 +1953,43 @@
     },
     "plugins/codexclaw/components/bg-wake": {
       "name": "@codexclaw/bg-wake",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/components/config-guard": {
       "name": "@codexclaw/config-guard",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/components/cxc-ops": {
       "name": "@codexclaw/cxc-ops",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/components/messenger-bridge": {
       "name": "@codexclaw/messenger-bridge",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/components/pabcd-state": {
       "name": "@codexclaw/pabcd-state",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/components/provider-bridge": {
       "name": "@codexclaw/provider-bridge",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/components/recall": {
       "name": "@codexclaw/recall",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/components/skill-search": {
       "name": "@codexclaw/skill-search",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/components/subagent-config": {
       "name": "@codexclaw/subagent-config",
-      "version": "0.2.24"
+      "version": "0.2.25"
     },
     "plugins/codexclaw/gui": {
       "name": "@codexclaw/gui",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "description": "cli-jaw-style dev discipline + multi-model subagents for the OpenAI Codex runtime.",
   "type": "module",

--- a/plugins/codexclaw/.codex-plugin/plugin.json
+++ b/plugins/codexclaw/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codexclaw",
-  "version": "0.2.24+codex.20260908031619",
+  "version": "0.2.25+codex.20260911171412",
   "description": "cli-jaw-style dev discipline (dev skills + PABCD) and multi-model subagents for the OpenAI Codex runtime, with optional opencodex provider routing.",
   "author": {
     "name": "lidge-jun",

--- a/plugins/codexclaw/components/bg-wake/package.json
+++ b/plugins/codexclaw/components/bg-wake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/bg-wake",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
   "description": "Background task registry + completion wake for Codex. Registers detached commands, then wakes the agent through the Stop hook when they finish.",

--- a/plugins/codexclaw/components/config-guard/package.json
+++ b/plugins/codexclaw/components/config-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/config-guard",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
   "description": "Controlled feature-flag activation: enables only codexclaw's declared [features] flags via the official `codex features` CLI, with a revert manifest and backup.",

--- a/plugins/codexclaw/components/cxc-ops/package.json
+++ b/plugins/codexclaw/components/cxc-ops/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@codexclaw/cxc-ops",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
-  "description": "codexclaw ops CLI \u2014 doctor (plugin health), reset (scoped state cleanup).",
+  "description": "codexclaw ops CLI — doctor (plugin health), reset (scoped state cleanup).",
   "scripts": {
     "test": "node --test"
   }

--- a/plugins/codexclaw/components/messenger-bridge/package.json
+++ b/plugins/codexclaw/components/messenger-bridge/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@codexclaw/messenger-bridge",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
-  "description": "codexclaw messenger bridge \u2014 cxc serve HTTP server + SQLite state substrate (zero third-party deps).",
+  "description": "codexclaw messenger bridge — cxc serve HTTP server + SQLite state substrate (zero third-party deps).",
   "scripts": {
     "test": "node --test"
   }

--- a/plugins/codexclaw/components/pabcd-state/package.json
+++ b/plugins/codexclaw/components/pabcd-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/pabcd-state",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
   "description": "IPABCD finite-state machine backed by per-session .codexclaw/sessions/<sessionId>.json + shared ledger.jsonl.",

--- a/plugins/codexclaw/components/provider-bridge/package.json
+++ b/plugins/codexclaw/components/provider-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/provider-bridge",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
   "description": "Detect-only opencodex (ocx) status probe at session start; graceful native path when absent.",

--- a/plugins/codexclaw/components/recall/package.json
+++ b/plugins/codexclaw/components/recall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/recall",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
   "description": "Read-only chat/memory recall search over the Codex session root (~/.codex): date-pruned rollout scan + thread/memory sqlite enrichment.",

--- a/plugins/codexclaw/components/skill-search/package.json
+++ b/plugins/codexclaw/components/skill-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/skill-search",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
   "description": "Remote dormant-skill search over cli-jaw-skills / Hermes / ClawHub / gh code search. Zero-dep, TTL-cached, adapter-preamble output. No local vendoring.",

--- a/plugins/codexclaw/components/subagent-config/package.json
+++ b/plugins/codexclaw/components/subagent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codexclaw/subagent-config",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
   "description": "Stores subagent model/prompt config; serves it to the GUI and an MCP tool.",

--- a/plugins/codexclaw/gui/package.json
+++ b/plugins/codexclaw/gui/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@codexclaw/gui",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "private": true,
   "type": "module",
-  "description": "codexclaw local dashboard (Vite + React) \u2014 subagent config, prompts, provider link bar.",
+  "description": "codexclaw local dashboard (Vite + React) — subagent config, prompts, provider link bar.",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/plugins/codexclaw/inventory.json
+++ b/plugins/codexclaw/inventory.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "plugin": {
     "name": "codexclaw",
-    "manifestVersion": "0.2.24+codex.20260908031619",
-    "packageVersion": "0.2.24"
+    "manifestVersion": "0.2.25+codex.20260911171412",
+    "packageVersion": "0.2.25"
   },
   "skills": [
     {
@@ -297,55 +297,55 @@
     {
       "folder": "bg-wake",
       "packageName": "@codexclaw/bg-wake",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     },
     {
       "folder": "config-guard",
       "packageName": "@codexclaw/config-guard",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     },
     {
       "folder": "cxc-ops",
       "packageName": "@codexclaw/cxc-ops",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     },
     {
       "folder": "messenger-bridge",
       "packageName": "@codexclaw/messenger-bridge",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     },
     {
       "folder": "pabcd-state",
       "packageName": "@codexclaw/pabcd-state",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     },
     {
       "folder": "provider-bridge",
       "packageName": "@codexclaw/provider-bridge",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     },
     {
       "folder": "recall",
       "packageName": "@codexclaw/recall",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     },
     {
       "folder": "skill-search",
       "packageName": "@codexclaw/skill-search",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     },
     {
       "folder": "subagent-config",
       "packageName": "@codexclaw/subagent-config",
-      "version": "0.2.24",
+      "version": "0.2.25",
       "hasTests": true
     }
   ]


### PR DESCRIPTION
Release preparation for **0.2.25**, following `docs-site/src/content/docs/development/release.md`.

## What this carries

Everything already promoted in #161 — the Windows issue sweep (#109, #131, #132, #133, #134) and the memory/recall sweep (#135–#144) — plus the version surfaces that #161 did not touch.

## Version surfaces

`check-versions.mjs 0.2.25` reports **OK — every surface declares 0.2.25**:

- `package.json`, `package-lock.json`
- `plugins/codexclaw/.codex-plugin/plugin.json` → `0.2.25+codex.20260911171412`
- the nine component packages
- `cli` and `plugins/codexclaw/gui` (bumped in every prior release commit, though `check-versions` does not enumerate them)
- `inventory.plugin.packageVersion` and `inventory.plugin.manifestVersion`

The inventory was regenerated with `inventory.mjs --write --tests 3133`. Per the release doc the count comes from the `tests` line of a real run, not `pass`: the local suite reports `tests 3133`, and `pass` is environment-dependent.

## Evidence on the exact commit

`dff95d19` is green on all three lanes the release gate reads by SHA:

| workflow | conclusion |
|---|---|
| CI | success |
| WSL | success |
| Packed install lifecycle | success |

Next step after this merges: run the Release workflow against `main` with `version=0.2.25` and `expected_sha` set to the merge commit.

